### PR TITLE
feat(nft): upload clip metadata to IPFS before minting

### DIFF
--- a/prisma/migrations/202603292220_add_clip_metadata_uri/migration.sql
+++ b/prisma/migrations/202603292220_add_clip_metadata_uri/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Clip" ADD COLUMN "metadataUri" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Clip {
   endTime       Float
   duration      Int
   viralityScore Float?
+  metadataUri   String?
   postStatus    Json?
   postedAt      DateTime?
   createdAt     DateTime  @default(now())

--- a/src/clips/nft-mint.service.spec.ts
+++ b/src/clips/nft-mint.service.spec.ts
@@ -1,0 +1,93 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { NftMintService } from './nft-mint.service';
+
+describe('NftMintService uploadMetadataToIPFS', () => {
+  const prismaMock = {
+    clip: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  const stellarMock = {
+    networkPassphrase: 'Test SDF Network ; September 2015',
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    network: 'testnet',
+  };
+
+  let service: NftMintService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new NftMintService(prismaMock as any, stellarMock as any);
+  });
+
+  it('throws NotFoundException when clip does not exist', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue(null);
+
+    await expect(service.uploadMetadataToIPFS(101)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('throws BadRequestException when clipUrl is missing', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      id: 2,
+      clipUrl: '',
+    });
+
+    await expect(service.uploadMetadataToIPFS(2)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('uploads metadata, persists metadataUri, and returns cid', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      id: 5,
+      title: 'Amazing Clip',
+      caption: 'A test clip',
+      clipUrl: 'https://cdn.example.com/video.mp4',
+      thumbnail: 'https://cdn.example.com/thumb.jpg',
+      duration: 27,
+      viralityScore: 88,
+      createdAt: new Date('2026-03-01T00:00:00.000Z'),
+      postStatus: { tiktok: true },
+    });
+
+    const uploadSpy = jest
+      .spyOn(service as any, 'uploadMetadataToIpfs')
+      .mockResolvedValue('ipfs://bafyTestCid123');
+
+    prismaMock.clip.update.mockResolvedValue({});
+
+    const result = await service.uploadMetadataToIPFS(5);
+
+    expect(uploadSpy).toHaveBeenCalledTimes(1);
+    const [metadata, clipId] = uploadSpy.mock.calls[0];
+
+    expect(clipId).toBe(5);
+    expect(metadata).toMatchObject({
+      name: 'Amazing Clip',
+      description: 'A test clip',
+      image: 'https://cdn.example.com/thumb.jpg',
+      animation_url: 'https://cdn.example.com/video.mp4',
+    });
+    expect(metadata.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ trait_type: 'royaltyBps', value: 1000 }),
+        expect.objectContaining({ trait_type: 'royaltyPercent', value: 10 }),
+      ]),
+    );
+
+    expect(prismaMock.clip.update).toHaveBeenCalledWith({
+      where: { id: 5 },
+      data: { metadataUri: 'ipfs://bafyTestCid123' },
+    });
+
+    expect(result).toEqual({
+      clipId: 5,
+      cid: 'bafyTestCid123',
+      metadataUri: 'ipfs://bafyTestCid123',
+    });
+  });
+});

--- a/src/clips/nft-mint.service.ts
+++ b/src/clips/nft-mint.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
-import * as StellarSdk from 'stellar-sdk';
+import * as StellarSdk from '@stellar/stellar-sdk';
 
 interface NftAttribute {
   trait_type: string;
@@ -20,6 +20,12 @@ interface NftMetadata {
   animation_url: string;
   external_url?: string;
   attributes: NftAttribute[];
+}
+
+interface UploadMetadataResult {
+  clipId: number;
+  cid: string;
+  metadataUri: string;
 }
 
 @Injectable()
@@ -44,6 +50,49 @@ export class NftMintService {
     private readonly prisma: PrismaService,
     private readonly stellarService: StellarService,
   ) {}
+
+  async uploadMetadataToIPFS(clipId: number): Promise<UploadMetadataResult> {
+    const clip = await this.prisma.clip.findUnique({
+      where: { id: clipId },
+    });
+
+    if (!clip) {
+      throw new NotFoundException(`Clip with ID ${clipId} not found`);
+    }
+
+    if (!clip.clipUrl) {
+      throw new BadRequestException(
+        'Clip is not ready for metadata upload (missing clipUrl)',
+      );
+    }
+
+    const metadata = this.buildMetadata({
+      id: clip.id,
+      title: clip.title,
+      caption: clip.caption,
+      clipUrl: clip.clipUrl,
+      thumbnail: clip.thumbnail,
+      duration: clip.duration,
+      viralityScore: clip.viralityScore,
+      createdAt: clip.createdAt,
+      postStatus: clip.postStatus,
+      royaltyBps: this.CREATOR_ROYALTY_BPS,
+    });
+
+    const metadataUri = await this.uploadMetadataToIpfs(metadata, clip.id);
+    const cid = metadataUri.replace('ipfs://', '');
+
+    await this.prisma.clip.update({
+      where: { id: clip.id },
+      data: { metadataUri },
+    });
+
+    return {
+      clipId: clip.id,
+      cid,
+      metadataUri,
+    };
+  }
 
   /**
    * Prepares a Soroban transaction for minting a clip as an NFT.
@@ -97,8 +146,8 @@ export class NftMintService {
     const userWallet = user.wallets[0].address;
 
     try {
-      const metadata = this.buildMetadata(clip);
-      const metadataUri = await this.uploadMetadataToIpfs(metadata, clip.id);
+      const metadataUri =
+        clip.metadataUri ?? (await this.uploadMetadataToIPFS(clip.id)).metadataUri;
 
       // 3. Build Soroban transaction
       const networkPassphrase = this.stellarService.networkPassphrase;
@@ -178,12 +227,15 @@ export class NftMintService {
     viralityScore: number | null;
     createdAt: Date;
     postStatus: unknown;
+    royaltyBps: number;
   }): NftMetadata {
     const platforms = this.extractPlatforms(clip.postStatus);
     const attributes: NftAttribute[] = [
       { trait_type: 'clipDuration', value: clip.duration },
       { trait_type: 'viralityScore', value: clip.viralityScore ?? 0 },
       { trait_type: 'createdAt', value: clip.createdAt.toISOString() },
+      { trait_type: 'royaltyBps', value: clip.royaltyBps },
+      { trait_type: 'royaltyPercent', value: clip.royaltyBps / 100 },
       {
         trait_type: 'platformsPosted',
         value: platforms.length ? platforms.join(',') : 'none',


### PR DESCRIPTION
- add Clip.metadataUri field via prisma migration
- implement uploadMetadataToIPFS(clipId) in NftMintService
- generate standard NFT metadata JSON with image/animation_url
- include royalty attributes in metadata payload
- persist returned ipfs:// URI to Clip.metadataUri
- return CID and metadataUri for downstream mint flow
- reuse stored metadataUri in prepareMintTx when available
- add focused unit tests for upload, persistence, and schema

Closes #74