### PR TITLE
feat(nft): implement Soulbound NFT contract on Soroban

### DIFF
--- a/contracts/nft-contract/Cargo.toml
+++ b/contracts/nft-contract/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "clips-nft-contract"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.74"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { version = "22.0.0" }
+soroban-token-sdk = { version = "22.0.0" }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/nft-contract/src/admin.rs
+++ b/contracts/nft-contract/src/admin.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::{Address, Env, Symbol};
+use soroban_sdk::contracttype;
+
+#[contracttype]
+pub struct Admin;
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&Symbol::new(env, "admin"))
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&Symbol::new(env, "admin"), admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&Symbol::new(env, "admin"))
+}

--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -1,0 +1,229 @@
+#![no_std]
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contractmeta, contracttype,
+    Address, Env, String, Symbol, Val, Vec,
+};
+use soroban_token_sdk::metadata::TokenMetadata;
+
+mod admin;
+mod metadata;
+mod storage;
+
+#[cfg(test)]
+mod test;
+
+pub use admin::Admin;
+pub use metadata::ClipMetadata;
+pub use storage::{get_token_metadata, set_token_metadata, TokenStorage};
+
+const CLIP_NAME: &[u8] = b"ClipCash NFT";
+const CLIP_SYMBOL: &[u8] = b"CLIP";
+
+#[contractmeta(key = "name", val = "ClipCash NFT Contract")]
+#[contractmeta(key = "version", val = "1.0.0")]
+
+pub struct ClipsNftContract;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenData {
+    pub owner: Address,
+    pub is_soulbound: bool,
+    pub creator: Address,
+    pub clip_id: String,
+    pub content_uri: String,
+    pub created_at: u64,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    Unauthorized = 1,
+    TokenNotFound = 2,
+    AlreadyInitialized = 3,
+    NotInitialized = 4,
+    SoulboundTokenNotTransferable = 5,
+    InvalidTokenId = 6,
+}
+
+#[contractimpl]
+impl ClipsNftContract {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if storage::has_admin(&env) {
+            return Err(Error::AlreadyInitialized);
+        }
+        storage::set_admin(&env, &admin);
+        Ok(())
+    }
+
+    pub fn mint(
+        env: Env,
+        to: Address,
+        token_id: u64,
+        clip_id: String,
+        content_uri: String,
+        is_soulbound: bool,
+    ) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if storage::has_token(&env, token_id) {
+            return Err(Error::InvalidTokenId);
+        }
+
+        let creator = to.clone();
+        let created_at = env.ledger().timestamp();
+
+        let token_data = TokenData {
+            owner: to.clone(),
+            is_soulbound,
+            creator,
+            clip_id,
+            content_uri,
+            created_at,
+        };
+
+        storage::set_token(&env, token_id, &token_data);
+        storage::set_owner_token(&env, &to, token_id);
+        storage::increment_total_supply(&env);
+
+        events::emit_mint(&env, &to, token_id, is_soulbound);
+        Ok(())
+    }
+
+    pub fn transfer(
+        env: Env,
+        from: Address,
+        to: Address,
+        token_id: u64,
+    ) -> Result<(), Error> {
+        from.require_auth();
+
+        let token_data = storage::get_token(&env, token_id).ok_or(Error::TokenNotFound)?;
+
+        if token_data.owner != from {
+            return Err(Error::Unauthorized);
+        }
+
+        if token_data.is_soulbound {
+            return Err(Error::SoulboundTokenNotTransferable);
+        }
+
+        storage::remove_owner_token(&env, &from, token_id);
+        storage::set_owner_token(&env, &to, token_id);
+
+        let mut updated_token = token_data;
+        updated_token.owner = to.clone();
+        storage::set_token(&env, token_id, &updated_token);
+
+        events::emit_transfer(&env, &from, &to, token_id);
+        Ok(())
+    }
+
+    pub fn transfer_from(
+        env: Env,
+        spender: Address,
+        from: Address,
+        to: Address,
+        token_id: u64,
+    ) -> Result<(), Error> {
+        spender.require_auth();
+
+        let token_data = storage::get_token(&env, token_id).ok_or(Error::TokenNotFound)?;
+
+        if token_data.owner != from {
+            return Err(Error::Unauthorized);
+        }
+
+        if !storage::is_approved(&env, token_id, &spender) && token_data.owner != spender {
+            return Err(Error::Unauthorized);
+        }
+
+        if token_data.is_soulbound {
+            return Err(Error::SoulboundTokenNotTransferable);
+        }
+
+        storage::remove_owner_token(&env, &from, token_id);
+        storage::set_owner_token(&env, &to, token_id);
+
+        let mut updated_token = token_data;
+        updated_token.owner = to.clone();
+        storage::set_token(&env, token_id, &updated_token);
+
+        storage::remove_approval(&env, token_id);
+
+        events::emit_transfer(&env, &from, &to, token_id);
+        Ok(())
+    }
+
+    pub fn approve(env: Env, owner: Address, spender: Address, token_id: u64) -> Result<(), Error> {
+        owner.require_auth();
+
+        let token_data = storage::get_token(&env, token_id).ok_or(Error::TokenNotFound)?;
+
+        if token_data.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+
+        if token_data.is_soulbound {
+            return Err(Error::SoulboundTokenNotTransferable);
+        }
+
+        storage::set_approval(&env, token_id, &spender);
+        events::emit_approve(&env, &owner, &spender, token_id);
+        Ok(())
+    }
+
+    pub fn owner_of(env: Env, token_id: u64) -> Option<Address> {
+        storage::get_token(&env, token_id).map(|t| t.owner)
+    }
+
+    pub fn get_token_data(env: Env, token_id: u64) -> Option<TokenData> {
+        storage::get_token(&env, token_id)
+    }
+
+    pub fn is_soulbound(env: Env, token_id: u64) -> bool {
+        storage::get_token(&env, token_id)
+            .map(|t| t.is_soulbound)
+            .unwrap_or(false)
+    }
+
+    pub fn get_creator(env: Env, token_id: u64) -> Option<Address> {
+        storage::get_token(&env, token_id).map(|t| t.creator)
+    }
+
+    pub fn balance_of(env: Env, owner: Address) -> u64 {
+        storage::get_owner_tokens(&env, &owner).len() as u64
+    }
+
+    pub fn total_supply(env: Env) -> u64 {
+        storage::get_total_supply(&env)
+    }
+
+    pub fn get_approved(env: Env, token_id: u64) -> Option<Address> {
+        storage::get_approval(&env, token_id)
+    }
+}
+
+mod events {
+    use super::*;
+
+    pub fn emit_mint(env: &Env, to: &Address, token_id: u64, is_soulbound: bool) {
+        let topics = (Symbol::new(env, "mint"), to.clone());
+        env.events().publish(
+            topics,
+            (token_id, is_soulbound),
+        );
+    }
+
+    pub fn emit_transfer(env: &Env, from: &Address, to: &Address, token_id: u64) {
+        let topics = (Symbol::new(env, "transfer"), from.clone(), to.clone());
+        env.events().publish(topics, token_id);
+    }
+
+    pub fn emit_approve(env: &Env, owner: &Address, spender: &Address, token_id: u64) {
+        let topics = (Symbol::new(env, "approve"), owner.clone(), spender.clone());
+        env.events().publish(topics, token_id);
+    }
+}

--- a/contracts/nft-contract/src/metadata.rs
+++ b/contracts/nft-contract/src/metadata.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::{contracttype, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClipMetadata {
+    pub name: String,
+    pub description: String,
+    pub content_uri: String,
+    pub creator: String,
+    pub royalty_percent: u32,
+    pub is_soulbound: bool,
+    pub created_at: u64,
+}

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -1,0 +1,91 @@
+use soroban_sdk::{Address, Env, Map, Vec};
+use soroban_sdk::contracttype;
+use soroban_sdk::Symbol;
+
+use crate::TokenData;
+
+#[contracttype]
+pub struct TokenStorage;
+
+const TOTAL_SUPPLY_KEY: &str = "total_supply";
+const ADMIN_KEY: &str = "admin";
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&Symbol::new(env, ADMIN_KEY))
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&Symbol::new(env, ADMIN_KEY), admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&Symbol::new(env, ADMIN_KEY))
+}
+
+pub fn set_token(env: &Env, token_id: u64, token_data: &TokenData) {
+    env.storage().persistent().set(&token_id, token_data);
+}
+
+pub fn get_token(env: &Env, token_id: u64) -> Option<TokenData> {
+    env.storage().persistent().get(&token_id)
+}
+
+pub fn has_token(env: &Env, token_id: u64) -> bool {
+    env.storage().persistent().has(&token_id)
+}
+
+pub fn set_owner_token(env: &Env, owner: &Address, token_id: u64) {
+    let mut tokens: Vec<u64> = env.storage().persistent().get(&owner).unwrap_or(Vec::new(env));
+    if !tokens.contains(token_id) {
+        tokens.push_back(token_id);
+        env.storage().persistent().set(&owner, &tokens);
+    }
+}
+
+pub fn remove_owner_token(env: &Env, owner: &Address, token_id: u64) {
+    let tokens: Vec<u64> = env.storage().persistent().get(&owner).unwrap_or(Vec::new(env));
+    let mut new_tokens = Vec::new(env);
+    for id in tokens.iter() {
+        if id != token_id {
+            new_tokens.push_back(id);
+        }
+    }
+    env.storage().persistent().set(&owner, &new_tokens);
+}
+
+pub fn get_owner_tokens(env: &Env, owner: &Address) -> Vec<u64> {
+    env.storage().persistent().get(&owner).unwrap_or(Vec::new(env))
+}
+
+pub fn increment_total_supply(env: &Env) {
+    let current = get_total_supply(env);
+    env.storage().instance().set(&Symbol::new(env, TOTAL_SUPPLY_KEY), &(current + 1));
+}
+
+pub fn get_total_supply(env: &Env) -> u64 {
+    env.storage().instance().get(&Symbol::new(env, TOTAL_SUPPLY_KEY)).unwrap_or(0)
+}
+
+pub fn set_approval(env: &Env, token_id: u64, spender: &Address) {
+    env.storage().persistent().set(&(token_id, Symbol::new(env, "approval")), spender);
+}
+
+pub fn get_approval(env: &Env, token_id: u64) -> Option<Address> {
+    env.storage().persistent().get(&(token_id, Symbol::new(env, "approval")))
+}
+
+pub fn is_approved(env: &Env, token_id: u64, spender: &Address) -> bool {
+    get_approval(env, token_id).map(|a| a == *spender).unwrap_or(false)
+}
+
+pub fn remove_approval(env: &Env, token_id: u64) {
+    env.storage().persistent().remove(&(token_id, Symbol::new(env, "approval")));
+}
+
+pub fn set_token_metadata(env: &Env, token_id: u64, metadata: &crate::ClipMetadata) {
+    env.storage().persistent().set(&(token_id, Symbol::new(env, "metadata")), metadata);
+}
+
+pub fn get_token_metadata(env: &Env, token_id: u64) -> Option<crate::ClipMetadata> {
+    env.storage().persistent().get(&(token_id, Symbol::new(env, "metadata")))
+}

--- a/contracts/nft-contract/src/test.rs
+++ b/contracts/nft-contract/src/test.rs
@@ -1,0 +1,232 @@
+#![cfg(test)]
+
+use crate::{ClipsNftContract, ClipsNftContractClient, Error, TokenData};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup_env() -> (Env, Address, ClipsNftContractClient<'static>) {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, ClipsNftContract);
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    (env, contract_id, client)
+}
+
+#[test]
+fn test_initialize() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    // Verify double initialization fails
+    let result = client.try_initialize(&admin);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_mint_regular_token() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    let clip_id = String::from_str(&env, "clip_001");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_001");
+    let is_soulbound = false;
+    
+    client.mint(&owner, &1, &clip_id, &content_uri, &is_soulbound);
+    
+    assert_eq!(client.owner_of(&1), Some(owner.clone()));
+    assert_eq!(client.is_soulbound(&1), false);
+    assert_eq!(client.balance_of(&owner), 1);
+    assert_eq!(client.total_supply(), 1);
+}
+
+#[test]
+fn test_mint_soulbound_token() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    let clip_id = String::from_str(&env, "clip_002");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_002");
+    let is_soulbound = true;
+    
+    client.mint(&owner, &2, &clip_id, &content_uri, &is_soulbound);
+    
+    assert_eq!(client.owner_of(&2), Some(owner.clone()));
+    assert_eq!(client.is_soulbound(&2), true);
+    assert_eq!(client.balance_of(&owner), 1);
+    
+    // Verify token data
+    let token_data = client.get_token_data(&2).unwrap();
+    assert_eq!(token_data.is_soulbound, true);
+    assert_eq!(token_data.creator, owner);
+}
+
+#[test]
+fn test_transfer_regular_token() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    // Mint regular (non-soulbound) token
+    let clip_id = String::from_str(&env, "clip_003");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_003");
+    client.mint(&owner, &3, &clip_id, &content_uri, &false);
+    
+    assert_eq!(client.balance_of(&owner), 1);
+    
+    // Transfer should succeed
+    client.transfer(&owner, &recipient, &3);
+    
+    assert_eq!(client.owner_of(&3), Some(recipient.clone()));
+    assert_eq!(client.balance_of(&owner), 0);
+    assert_eq!(client.balance_of(&recipient), 1);
+}
+
+#[test]
+fn test_transfer_soulbound_token_fails() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    // Mint soulbound token
+    let clip_id = String::from_str(&env, "clip_004");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_004");
+    client.mint(&owner, &4, &clip_id, &content_uri, &true);
+    
+    // Attempt to transfer should fail with SoulboundTokenNotTransferable error
+    let result = client.try_transfer(&owner, &recipient, &4);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_approve_regular_token() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    // Mint regular token
+    let clip_id = String::from_str(&env, "clip_005");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_005");
+    client.mint(&owner, &5, &clip_id, &content_uri, &false);
+    
+    // Approve should succeed
+    client.approve(&owner, &spender, &5);
+    assert_eq!(client.get_approved(&5), Some(spender));
+}
+
+#[test]
+fn test_approve_soulbound_token_fails() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    // Mint soulbound token
+    let clip_id = String::from_str(&env, "clip_006");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_006");
+    client.mint(&owner, &6, &clip_id, &content_uri, &true);
+    
+    // Attempt to approve should fail
+    let result = client.try_approve(&owner, &spender, &6);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_transfer_from_soulbound_token_fails() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    // Mint a regular token and approve spender first
+    let clip_id = String::from_str(&env, "clip_007");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_007");
+    client.mint(&owner, &7, &clip_id, &content_uri, &false);
+    client.approve(&owner, &spender, &7);
+    
+    // Regular token transfer_from should succeed
+    client.transfer_from(&spender, &owner, &recipient, &7);
+    assert_eq!(client.owner_of(&7), Some(recipient.clone()));
+    
+    // Now test soulbound token
+    let clip_id_2 = String::from_str(&env, "clip_008");
+    let content_uri_2 = String::from_str(&env, "https://clips.cash/clip_008");
+    client.mint(&owner, &8, &clip_id_2, &content_uri_2, &true);
+    
+    // Even with approval, soulbound token cannot be transferred
+    let result = client.try_transfer_from(&owner, &owner, &recipient, &8);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_token_data() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    let clip_id = String::from_str(&env, "clip_009");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_009");
+    client.mint(&owner, &9, &clip_id, &content_uri, &true);
+    
+    let token_data = client.get_token_data(&9).unwrap();
+    assert_eq!(token_data.owner, owner);
+    assert_eq!(token_data.creator, owner);
+    assert_eq!(token_data.is_soulbound, true);
+    assert_eq!(token_data.clip_id, clip_id);
+    assert_eq!(token_data.content_uri, content_uri);
+    assert!(token_data.created_at > 0);
+}
+
+#[test]
+fn test_get_creator() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    env.mock_all_auths();
+    
+    let clip_id = String::from_str(&env, "clip_010");
+    let content_uri = String::from_str(&env, "https://clips.cash/clip_010");
+    client.mint(&creator, &10, &clip_id, &content_uri, &false);
+    
+    assert_eq!(client.get_creator(&10), Some(creator));
+}


### PR DESCRIPTION
## Description
This PR introduces a specialized NFT contract for the Soroban platform, featuring native support for **Soulbound Tokens (SBT)**. This implementation allows for the issuance of non-transferable digital assets, ideal for identity verification, certificates, and non-tradable achievements within the Ajo-Circle ecosystem.

## Key Components

### **1. Core Soulbound Logic (`lib.rs`)**
* **Token Metadata**: The `TokenData` struct now includes an `is_soulbound` boolean flag. This allows the contract to host both standard (transferable) and Soulbound (permanent) assets in a single deployment.
* **Transfer Blocking**: Implemented strict enforcement at the contract level. If a token is flagged as `is_soulbound`, the following operations are programmatically blocked and will return a `SoulboundTokenNotTransferable` (Code: 5) error:
    * `transfer`
    * `transfer_from`
    * `approve`

### **2. Public Query Interface**
* **`is_soulbound(token_id)`**: Added a public query function to allow off-chain indexers and other smart contracts to verify the transferability of a specific token before attempting an operation.

### **3. Module Architecture**
* **`admin.rs`**: Centralized management for contract administration and minting permissions.
* **`storage.rs`**: Optimized storage helpers for efficient Soroban ledger access.
* **`metadata.rs`**: Structured definitions for NFT attributes and content URIs.

## Code Snippet: Transfer Restriction
```rust
if token_data.is_soulbound {
    return Err(Error::SoulboundTokenNotTransferable);
}

