### PR TITLE
feat: implement automated Stellar Friendbot testnet wallet funding on user signup

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(cockatiel)/)"
+    ],
     "moduleNameMapper": {
       "^@prisma/client$": "<rootDir>/__mocks__/@prisma/client.ts"
     },

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -18,12 +18,14 @@ import { EMAIL_DELIVERY_QUEUE } from './email-delivery.queue';
 import { EmailDeliveryService } from './email-delivery.service';
 import { EmailDeliveryProcessor } from './email-delivery.processor';
 import { EncryptionModule } from '../encryption/encryption.module';
+import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [
     ConfigModule,
     PrismaModule,
     EncryptionModule,
+    StellarModule,
     PassportModule.register({ session: false }),
     JwtModule.registerAsync({
       useFactory: () => {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   NotFoundException,
   UnauthorizedException,
+  Logger,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
@@ -20,6 +21,7 @@ import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
 import * as speakeasy from 'speakeasy';
 import * as QRCode from 'qrcode';
+import { StellarService } from '../stellar/stellar.service';
 
 type JwtUser = {
   id: number;
@@ -34,6 +36,8 @@ const REFRESH_TOKEN_EXPIRES_DAYS =
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     private readonly jwtService: JwtService,
     private readonly prisma: PrismaService,
@@ -41,19 +45,31 @@ export class AuthService {
     private readonly deviceFingerprintService: DeviceFingerprintService,
     private readonly bruteForceService: BruteForceProtectionService,
     private readonly encryption: EncryptionService,
+    private readonly stellarService: StellarService,
   ) {}
 
   /** Generate a custodial Stellar keypair and persist it on the user record. */
   private async assignStellarWallet(userId: number): Promise<void> {
     const keypair = Keypair.random();
+    const publicKey = keypair.publicKey();
     await this.prisma.user.update({
       where: { id: userId },
       data: {
-        stellarPublicKey: keypair.publicKey(),
+        stellarPublicKey: publicKey,
         walletType: 'custodial',
         encryptedStellarSecret: this.encryption.encrypt(keypair.secret()),
       },
     });
+
+    if (this.stellarService.isTestnet()) {
+      try {
+        await this.stellarService.fundWithFriendbot(publicKey);
+      } catch (error) {
+        this.logger.error(
+          `Friendbot automated funding failed for user ${userId} and wallet ${publicKey}: ${error.message}`,
+        );
+      }
+    }
   }
 
   async findOrCreateGoogleUser(params: {

--- a/src/auth/auth.signup.spec.ts
+++ b/src/auth/auth.signup.spec.ts
@@ -7,11 +7,15 @@ import { JwtService } from '@nestjs/jwt';
 import { MailService } from './mail.service';
 import { DeviceFingerprintService } from './device-fingerprint.service';
 import { BruteForceProtectionService } from './brute-force-protection.service';
+import { EmailDeliveryService } from './email-delivery.service';
+import { EncryptionService } from '../encryption/encryption.service';
+import { StellarService } from '../stellar/stellar.service';
 import * as bcrypt from 'bcrypt';
 
 describe('Auth - Password Strength Validation', () => {
   let service: AuthService;
   let prismaService: PrismaService;
+  let stellarService: StellarService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,6 +27,7 @@ describe('Auth - Password Strength Validation', () => {
             user: {
               findUnique: jest.fn(),
               create: jest.fn(),
+              update: jest.fn(),
             },
             refreshToken: {
               create: jest.fn(),
@@ -54,11 +59,32 @@ describe('Auth - Password Strength Validation', () => {
           provide: BruteForceProtectionService,
           useValue: { check: jest.fn(), record: jest.fn() },
         },
+        {
+          provide: EmailDeliveryService,
+          useValue: {
+            enqueue: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: EncryptionService,
+          useValue: {
+            encrypt: jest.fn().mockReturnValue('encrypted_secret'),
+            decrypt: jest.fn().mockReturnValue('decrypted_secret'),
+          },
+        },
+        {
+          provide: StellarService,
+          useValue: {
+            isTestnet: jest.fn().mockReturnValue(true),
+            fundWithFriendbot: jest.fn().mockResolvedValue(undefined),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
     prismaService = module.get<PrismaService>(PrismaService);
+    stellarService = module.get<StellarService>(StellarService);
   });
 
   describe('POST /auth/signup', () => {
@@ -131,6 +157,61 @@ describe('Auth - Password Strength Validation', () => {
       await expect(service.signup(signupDto)).rejects.toThrow(
         BadRequestException,
       );
+    });
+
+    it('should automatically fund the custodial wallet with Friendbot on testnet', async () => {
+      const email = 'test-friendbot@example.com';
+      const password = 'MyStr0ng!P@ssw0rd';
+      const mockUser = {
+        id: 1,
+        email,
+        password: 'hashed_password',
+        name: null,
+        picture: null,
+      };
+
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+      (prismaService.user.create as jest.Mock).mockResolvedValue(mockUser);
+      (stellarService.isTestnet as jest.Mock).mockReturnValue(true);
+
+      const signupDto: SignupDto = {
+        name: 'Test Friendbot User',
+        email,
+        password,
+      };
+
+      await service.signup(signupDto);
+
+      expect(stellarService.isTestnet).toHaveBeenCalled();
+      expect(stellarService.fundWithFriendbot).toHaveBeenCalled();
+    });
+
+    it('should not fund the custodial wallet if not on testnet', async () => {
+      const email = 'test-no-friendbot@example.com';
+      const password = 'MyStr0ng!P@ssw0rd';
+      const mockUser = {
+        id: 1,
+        email,
+        password: 'hashed_password',
+        name: null,
+        picture: null,
+      };
+
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+      (prismaService.user.create as jest.Mock).mockResolvedValue(mockUser);
+      (stellarService.isTestnet as jest.Mock).mockReturnValue(false);
+      (stellarService.fundWithFriendbot as jest.Mock).mockClear();
+
+      const signupDto: SignupDto = {
+        name: 'Test No Friendbot User',
+        email,
+        password,
+      };
+
+      await service.signup(signupDto);
+
+      expect(stellarService.isTestnet).toHaveBeenCalled();
+      expect(stellarService.fundWithFriendbot).not.toHaveBeenCalled();
     });
   });
 

--- a/src/stellar/stellar.service.spec.ts
+++ b/src/stellar/stellar.service.spec.ts
@@ -13,6 +13,7 @@ describe('StellarService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -210,4 +211,48 @@ describe('StellarService', () => {
       ).rejects.toThrow(ServiceUnavailableException);
     });
   });
+
+  describe('fundWithFriendbot', () => {
+    it('should fund testnet address when fetch is successful', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      const address = 'GC7OHFPWPSWXL4HMN6TXAG54MTZSMJIASWHO6KVRQNHNCXEAHWDSGGC3';
+      await expect(service.fundWithFriendbot(address)).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://friendbot.stellar.org/?addr=${encodeURIComponent(address)}`,
+      );
+    });
+
+    it('should throw an error when Friendbot responds with non-ok status', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: jest.fn().mockResolvedValue('Bad Request'),
+      });
+
+      const address = 'GC7OHFPWPSWXL4HMN6TXAG54MTZSMJIASWHO6KVRQNHNCXEAHWDSGGC3';
+      await expect(service.fundWithFriendbot(address)).rejects.toThrow(
+        'Friendbot funding failed (400): Bad Request',
+      );
+    });
+
+    it('should throw an error when fetch fails', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network failure'));
+
+      const address = 'GC7OHFPWPSWXL4HMN6TXAG54MTZSMJIASWHO6KVRQNHNCXEAHWDSGGC3';
+      await expect(service.fundWithFriendbot(address)).rejects.toThrow('Network failure');
+    });
+
+    it('should do nothing if not on testnet', async () => {
+      jest.spyOn(service, 'isTestnet').mockReturnValueOnce(false);
+
+      const address = 'GC7OHFPWPSWXL4HMN6TXAG54MTZSMJIASWHO6KVRQNHNCXEAHWDSGGC3';
+      await service.fundWithFriendbot(address);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
 });
+

--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -127,4 +127,32 @@ export class StellarService {
       };
     }
   }
+
+  async fundWithFriendbot(address: string): Promise<void> {
+    if (!this.isTestnet()) {
+      this.logger.warn(`Not funding address ${address}: not on testnet.`);
+      return;
+    }
+
+    try {
+      this.logger.log(`Requesting Friendbot funding for address ${address}...`);
+      const response = await fetch(
+        `https://friendbot.stellar.org/?addr=${encodeURIComponent(address)}`,
+      );
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(
+          `Friendbot funding failed (${response.status}): ${body.slice(0, 300)}`,
+        );
+      }
+
+      this.logger.log(`Successfully funded ${address} using Friendbot.`);
+    } catch (error) {
+      this.logger.error(
+        `Failed to fund address ${address} with Friendbot: ${error.message}`,
+      );
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
closes #174 

### Description
Automates the Testnet initialization step for new signups by seamlessly integrating Stellar's Friendbot funding mechanism into the wallet creation lifecycle. This ensures newly provisioned user addresses are immediately pre-funded and operational upon signup.

### Changes Implemented
- **Faucet Integration Engine (`stellar.service.ts`):** Provisioned `fundWithFriendbot(address)` using the native fetch interface to request standard Testnet network asset balances for target keypairs.
- **Signup Hook Orchestration (`auth.service.ts` & `auth.module.ts`):** Injected `StellarService` inside the core `AuthService` framework. Intercepted the `assignStellarWallet` flow to selectively issue Friendbot requests if the execution runtime targets Testnet.
- **Fail-Safe Processing Architecture:** Wrapped the external funding call in an isolated try/catch block with explicit logging. This ensures transient faucet limits or API downtime never compromise or block core user creation pathways.
- **Jest & Dependency Hotfix (`package.json`):** Patched `transformIgnorePatterns` configurations to appropriately parse downstream ESM-specific package imports (such as `cockatiel`) during standalone testing bounds.

### Verification Plan
- **Stellar Service Tests:** Appended targeted test assertions inside `stellar.service.spec.ts` validating API dispatch mechanics and standard mock isolations.
- **Auth Signup Flow Isolation:** Expanded `auth.signup.spec.ts` with assertions verifying that automated testnet funding fires as intended during account creations, and remains skipped during non-testnet deployments.
- **Execution Pass Verification:** Verified flawless unit execution pass rates and zero structural anomalies during code compilation:
  ```bash
  npm run test -- src/stellar/stellar.service.spec.ts
  npm run test -- src/auth/auth.signup.spec.ts
  npx tsc --noEmit