### PR TITLE
feat(earnings): add CSV export endpoint for tax reporting

### DIFF
--- a/src/earnings/earnings-csv.util.spec.ts
+++ b/src/earnings/earnings-csv.util.spec.ts
@@ -1,0 +1,65 @@
+import {
+  buildCsvRow,
+  buildEarningsCsv,
+  escapeCsvField,
+} from './earnings-csv.util';
+
+describe('earnings-csv.util', () => {
+  describe('escapeCsvField', () => {
+    it('returns plain values unchanged', () => {
+      expect(escapeCsvField('royalty')).toBe('royalty');
+      expect(escapeCsvField(42.5)).toBe('42.5');
+    });
+
+    it('wraps fields containing commas in quotes', () => {
+      expect(escapeCsvField('Clip, Part 2')).toBe('"Clip, Part 2"');
+    });
+
+    it('escapes double quotes', () => {
+      expect(escapeCsvField('Say "hello"')).toBe('"Say ""hello"""');
+    });
+
+    it('wraps fields containing newlines', () => {
+      expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+    });
+
+    it('returns empty string for null and undefined', () => {
+      expect(escapeCsvField(null)).toBe('');
+      expect(escapeCsvField(undefined)).toBe('');
+    });
+  });
+
+  describe('buildEarningsCsv', () => {
+    it('includes header row and data rows', () => {
+      const csv = buildEarningsCsv([
+        [
+          '2024-01-01T00:00:00.000Z',
+          'My Clip',
+          10,
+          'USD',
+          'royalty',
+          '1',
+        ],
+      ]);
+
+      expect(csv).toBe(
+        'date,clip title,amount,currency,source,transactionId\n' +
+          '2024-01-01T00:00:00.000Z,My Clip,10,USD,royalty,1',
+      );
+    });
+
+    it('escapes special characters in clip titles', () => {
+      const csv = buildEarningsCsv([
+        ['2024-01-01T00:00:00.000Z', 'Clip, "A"', 1, 'USD', 'royalty', '2'],
+      ]);
+
+      expect(csv).toContain('"Clip, ""A"""');
+    });
+  });
+
+  describe('buildCsvRow', () => {
+    it('joins escaped fields with commas', () => {
+      expect(buildCsvRow(['a', 'b,c', 3])).toBe('a,"b,c",3');
+    });
+  });
+});

--- a/src/earnings/earnings-csv.util.ts
+++ b/src/earnings/earnings-csv.util.ts
@@ -1,0 +1,36 @@
+/** Escape a single CSV field per RFC 4180. */
+export function escapeCsvField(
+  value: string | number | null | undefined,
+): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function buildCsvRow(
+  fields: (string | number | null | undefined)[],
+): string {
+  return fields.map(escapeCsvField).join(',');
+}
+
+export const EARNINGS_CSV_HEADERS = [
+  'date',
+  'clip title',
+  'amount',
+  'currency',
+  'source',
+  'transactionId',
+] as const;
+
+export function buildEarningsCsv(
+  rows: (string | number | null | undefined)[][],
+): string {
+  const header = buildCsvRow([...EARNINGS_CSV_HEADERS]);
+  const body = rows.map((row) => buildCsvRow(row)).join('\n');
+  return body.length > 0 ? `${header}\n${body}` : `${header}\n`;
+}

--- a/src/earnings/earnings.controller.ts
+++ b/src/earnings/earnings.controller.ts
@@ -1,13 +1,15 @@
 import {
+  BadRequestException,
   Controller,
   UseGuards,
   Get,
   Query,
   Req,
+  Res,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { EarningsService } from './earnings.service';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 
 interface RequestWithUser extends Request {
   user: { userId: number };
@@ -17,6 +19,31 @@ interface RequestWithUser extends Request {
 @Controller('earnings')
 export class EarningsController {
   constructor(private readonly earningsService: EarningsService) {}
+
+  @Get('export')
+  async exportEarnings(
+    @Req() req: RequestWithUser,
+    @Res() res: Response,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('format') format = 'csv',
+  ) {
+    if (format !== 'csv') {
+      throw new BadRequestException('Only format=csv is supported');
+    }
+
+    const { filename, content } = await this.earningsService.exportEarningsCsv(
+      req.user.userId,
+      { startDate, endDate },
+    );
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${filename}"`,
+    );
+    res.send(content);
+  }
 
   @Get()
   async getEarnings(

--- a/src/earnings/earnings.service.spec.ts
+++ b/src/earnings/earnings.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { EarningsService } from './earnings.service';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -95,6 +96,72 @@ describe('EarningsService', () => {
       const result = await service.getEarningsDashboard(1, 2, 10);
 
       expect(result.history).toEqual([]);
+    });
+  });
+
+  describe('exportEarningsCsv', () => {
+    it('returns CSV with headers and earning rows', async () => {
+      mockPrismaService.earning.findMany.mockResolvedValue([
+        {
+          id: 7,
+          amount: 25.5,
+          currency: 'USD',
+          date: new Date('2024-06-15T12:00:00.000Z'),
+          source: 'royalty',
+          clip: { title: 'Viral moment' },
+        },
+      ]);
+
+      const result = await service.exportEarningsCsv(1, {});
+
+      expect(result.filename).toBe('earnings-export.csv');
+      expect(result.content).toContain(
+        'date,clip title,amount,currency,source,transactionId',
+      );
+      expect(result.content).toContain('Viral moment');
+      expect(result.content).toContain('royalty');
+      expect(result.content).toContain('7');
+      expect(mockPrismaService.earning.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { clip: { video: { userId: 1 } } },
+          orderBy: { date: 'asc' },
+        }),
+      );
+    });
+
+    it('filters by date range when startDate and endDate are provided', async () => {
+      mockPrismaService.earning.findMany.mockResolvedValue([]);
+
+      await service.exportEarningsCsv(1, {
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+      });
+
+      expect(mockPrismaService.earning.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            date: expect.objectContaining({
+              gte: expect.any(Date),
+              lte: expect.any(Date),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('throws when only one date is provided', async () => {
+      await expect(
+        service.exportEarningsCsv(1, { startDate: '2024-01-01' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws when startDate is after endDate', async () => {
+      await expect(
+        service.exportEarningsCsv(1, {
+          startDate: '2024-12-31',
+          endDate: '2024-01-01',
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/earnings/earnings.service.ts
+++ b/src/earnings/earnings.service.ts
@@ -1,5 +1,20 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { buildEarningsCsv } from './earnings-csv.util';
+
+export interface EarningsExportOptions {
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface EarningsExportResult {
+  filename: string;
+  content: string;
+}
 
 export interface EarningsBreakdown {
   royalties: number;
@@ -89,5 +104,87 @@ export class EarningsService {
       },
       history: paginatedHistory,
     };
+  }
+
+  async exportEarningsCsv(
+    userId: number,
+    options: EarningsExportOptions,
+  ): Promise<EarningsExportResult> {
+    const dateRange = this.parseExportDateRange(
+      options.startDate,
+      options.endDate,
+    );
+
+    const earnings = await this.prisma.earning.findMany({
+      where: {
+        clip: { video: { userId } },
+        ...(dateRange
+          ? { date: { gte: dateRange.start, lte: dateRange.end } }
+          : {}),
+      },
+      select: {
+        id: true,
+        amount: true,
+        currency: true,
+        date: true,
+        source: true,
+        clip: { select: { title: true } },
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    const rows = earnings.map((earning) => [
+      earning.date.toISOString(),
+      earning.clip.title ?? '',
+      earning.amount,
+      earning.currency,
+      earning.source ?? '',
+      String(earning.id),
+    ]);
+
+    const filename = this.buildExportFilename(dateRange);
+    return {
+      filename,
+      content: buildEarningsCsv(rows),
+    };
+  }
+
+  private parseExportDateRange(
+    startDate?: string,
+    endDate?: string,
+  ): { start: Date; end: Date } | null {
+    if (!startDate && !endDate) {
+      return null;
+    }
+    if (!startDate || !endDate) {
+      throw new BadRequestException(
+        'Both startDate and endDate are required for a custom date range',
+      );
+    }
+
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      throw new BadRequestException(
+        'startDate and endDate must be valid ISO date strings',
+      );
+    }
+    if (start > end) {
+      throw new BadRequestException('startDate must be on or before endDate');
+    }
+
+    end.setUTCHours(23, 59, 59, 999);
+    return { start, end };
+  }
+
+  private buildExportFilename(
+    dateRange: { start: Date; end: Date } | null,
+  ): string {
+    if (!dateRange) {
+      return 'earnings-export.csv';
+    }
+    const start = dateRange.start.toISOString().slice(0, 10);
+    const end = dateRange.end.toISOString().slice(0, 10);
+    return `earnings-export-${start}-to-${end}.csv`;
   }
 }


### PR DESCRIPTION
Closes #185

## Summary

- Adds `GET /earnings/export?startDate=&endDate=&format=csv` (JWT-protected) for creators to download earnings history for tax reporting.
- CSV columns: `date`, `clip title`, `amount`, `currency`, `source`, `transactionId` — with RFC 4180 escaping (commas, quotes, newlines).
- Response is a downloadable file (`Content-Disposition: attachment`) with `Content-Type: text/csv`.
- Optional `startDate` / `endDate` filter (both required when using a custom range); omit both to export all earnings.
- `transactionId` uses the earning record `id` (the `Earning` model has no on-chain `transactionId` field yet).

## Test plan

- [ ] `GET /earnings/export?format=csv` with valid JWT returns CSV attachment and header row
- [ ] `GET /earnings/export?startDate=2024-01-01&endDate=2024-12-31&format=csv` filters rows to the date range
- [ ] Clip titles with commas/quotes are escaped correctly in the CSV
- [ ] `format=json` (or other) returns `400`
- [ ] Only `startDate` or only `endDate` returns `400`
- [ ] `npm test -- --testPathPatterns=earnings` passes