### PR TITLE
feat(payouts): add status filtering and payout detail endpoint

### DIFF
--- a/src/payouts/payouts.constants.ts
+++ b/src/payouts/payouts.constants.ts
@@ -1,0 +1,7 @@
+export const PAYOUT_FILTER_STATUSES = [
+  'pending',
+  'completed',
+  'failed',
+] as const;
+
+export type PayoutFilterStatus = (typeof PAYOUT_FILTER_STATUSES)[number];

--- a/src/payouts/payouts.controller.ts
+++ b/src/payouts/payouts.controller.ts
@@ -3,9 +3,10 @@ import {
   Post,
   Get,
   Param,
+  Query,
   UseGuards,
   Req,
-  Body,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { PayoutsService } from './payouts.service';
@@ -26,8 +27,19 @@ export class PayoutsController {
   }
 
   @Get()
-  async getPayoutHistory(@Req() req: RequestWithUser) {
-    return this.payoutsService.getPayoutHistory(req.user.userId);
+  async listPayouts(
+    @Req() req: RequestWithUser,
+    @Query('status') status?: string,
+  ) {
+    return this.payoutsService.getPayouts(req.user.userId, status);
+  }
+
+  @Get(':id')
+  async getPayout(
+    @Req() req: RequestWithUser,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return this.payoutsService.getPayoutById(req.user.userId, id);
   }
 
   @Post(':id/process')

--- a/src/payouts/payouts.service.spec.ts
+++ b/src/payouts/payouts.service.spec.ts
@@ -1,3 +1,10 @@
+jest.mock('../stellar/stellar.service', () => ({
+  StellarService: jest.fn().mockImplementation(() => ({
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  })),
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { PayoutsService } from './payouts.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -6,6 +13,7 @@ import {
   ConflictException,
   BadRequestException,
   InternalServerErrorException,
+  NotFoundException,
 } from '@nestjs/common';
 
 describe('PayoutsService', () => {
@@ -102,16 +110,70 @@ describe('PayoutsService', () => {
     });
   });
 
-  describe('getPayoutHistory', () => {
-    it('should return payout history for user', async () => {
+  describe('getPayouts', () => {
+    it('should return all payouts for user', async () => {
       const payouts = [
         { id: 1, amount: 100, status: 'completed' },
         { id: 2, amount: 50, status: 'pending' },
       ];
       mockPrismaService.payout.findMany.mockResolvedValue(payouts);
 
-      const result = await service.getPayoutHistory(1);
+      const result = await service.getPayouts(1);
       expect(result).toHaveLength(2);
+      expect(mockPrismaService.payout.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 1 },
+        }),
+      );
+    });
+
+    it('should filter payouts by status', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([]);
+
+      await service.getPayouts(1, 'pending');
+
+      expect(mockPrismaService.payout.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 1, status: 'pending' },
+        }),
+      );
+    });
+
+    it('should throw BadRequestException for invalid status', async () => {
+      await expect(service.getPayouts(1, 'processing')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('getPayoutById', () => {
+    it('should return payout when owned by user', async () => {
+      const payout = { id: 5, userId: 1, amount: 100, status: 'completed' };
+      mockPrismaService.payout.findFirst.mockResolvedValue(payout);
+
+      const result = await service.getPayoutById(1, 5);
+      expect(result).toEqual(payout);
+      expect(mockPrismaService.payout.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 5, userId: 1 },
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when payout does not exist', async () => {
+      mockPrismaService.payout.findFirst.mockResolvedValue(null);
+
+      await expect(service.getPayoutById(1, 999)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException when payout belongs to another user', async () => {
+      mockPrismaService.payout.findFirst.mockResolvedValue(null);
+
+      await expect(service.getPayoutById(2, 5)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -9,6 +9,47 @@ import {
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
+import {
+  PAYOUT_FILTER_STATUSES,
+  PayoutFilterStatus,
+} from './payouts.constants';
+
+const payoutListSelect = {
+  id: true,
+  amount: true,
+  currency: true,
+  method: true,
+  status: true,
+  transactionId: true,
+  onChainTxHash: true,
+  createdAt: true,
+  confirmedAt: true,
+} as const;
+
+const payoutDetailSelect = {
+  ...payoutListSelect,
+  walletId: true,
+  paidAt: true,
+  updatedAt: true,
+} as const;
+
+export type PayoutListItem = {
+  id: number;
+  amount: number;
+  currency: string;
+  method: string;
+  status: string;
+  transactionId: string | null;
+  onChainTxHash: string | null;
+  createdAt: Date;
+  confirmedAt: Date | null;
+};
+
+export type PayoutDetail = PayoutListItem & {
+  walletId: number | null;
+  paidAt: Date | null;
+  updatedAt: Date;
+};
 
 @Injectable()
 export class PayoutsService {
@@ -93,34 +134,52 @@ export class PayoutsService {
     };
   }
 
-  async getPayoutHistory(userId: number): Promise<
-    Array<{
-      id: number;
-      amount: number;
-      currency: string;
-      method: string;
-      status: string;
-      transactionId: string | null;
-      onChainTxHash: string | null;
-      createdAt: Date;
-      confirmedAt: Date | null;
-    }>
-  > {
+  async getPayouts(
+    userId: number,
+    status?: string,
+  ): Promise<PayoutListItem[]> {
+    const filterStatus = this.parseStatusFilter(status);
+
     return this.prisma.payout.findMany({
-      where: { userId },
-      orderBy: { createdAt: 'desc' },
-      select: {
-        id: true,
-        amount: true,
-        currency: true,
-        method: true,
-        status: true,
-        transactionId: true,
-        onChainTxHash: true,
-        createdAt: true,
-        confirmedAt: true,
+      where: {
+        userId,
+        ...(filterStatus ? { status: filterStatus } : {}),
       },
+      orderBy: { createdAt: 'desc' },
+      select: payoutListSelect,
     });
+  }
+
+  async getPayoutById(
+    userId: number,
+    payoutId: number,
+  ): Promise<PayoutDetail> {
+    const payout = await this.prisma.payout.findFirst({
+      where: { id: payoutId, userId },
+      select: payoutDetailSelect,
+    });
+
+    if (!payout) {
+      throw new NotFoundException('Payout record not found');
+    }
+
+    return payout;
+  }
+
+  private parseStatusFilter(status?: string): PayoutFilterStatus | undefined {
+    if (!status) {
+      return undefined;
+    }
+
+    if (
+      !PAYOUT_FILTER_STATUSES.includes(status as PayoutFilterStatus)
+    ) {
+      throw new BadRequestException(
+        `status must be one of: ${PAYOUT_FILTER_STATUSES.join(', ')}`,
+      );
+    }
+
+    return status as PayoutFilterStatus;
   }
 
   async processPayout(payoutId: number): Promise<{


### PR DESCRIPTION
Closes #186

## Summary

- Extends `GET /payouts` to list the authenticated user's payouts with optional `?status=` filter (`pending`, `completed`, `failed`).
- Adds `GET /payouts/:id` for single-payout details (wallet id, paid/confirmed timestamps, transaction hashes).
- Enforces user-scoped access: users only see their own payouts; missing or other users' payouts return `404`.
- Invalid `status` values return `400` with allowed values in the message.

## API

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/payouts` | List payouts (newest first) |
| GET | `/payouts?status=pending` | Filter by status |
| GET | `/payouts/:id` | Single payout details |

Both routes require JWT (existing `JwtAuthGuard`).

## Test plan

- [ ] `GET /payouts` returns only the current user's payouts
- [ ] `GET /payouts?status=completed` returns only completed payouts
- [ ] `GET /payouts?status=invalid` returns `400`
- [ ] `GET /payouts/:id` returns payout details for own payout
- [ ] `GET /payouts/:id` for another user's payout returns `404`
- [ ] `GET /payouts/not-a-number` returns `400` (ParseIntPipe)
- [ ] `npx jest --testPathPatterns=payouts` passes (12 tests)