### PR TITLE
feat(payouts): enforce configurable min and max payout limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,9 +48,11 @@ COOKIE_SAME_SITE=lax
 # Defaults to 'testnet' if not set.
 STELLAR_NETWORK=testnet
 
-# Minimum Stellar payout amount in USD equivalent.
-# Payouts below this value are rejected to avoid wasting fees on micro-transactions.
-# Defaults to 5 if not set.
+# Payout limits (per currency). Use either PAYOUT_LIMITS JSON or MIN/MAX_PAYOUT_{CURRENCY}.
+# PAYOUT_LIMITS={"USD":{"min":5,"max":10000},"EUR":{"min":8,"max":5000}}
+MIN_PAYOUT_USD=5
+MAX_PAYOUT_USD=10000
+# Legacy alias for MIN_PAYOUT_USD
 MIN_STELLAR_PAYOUT=5
 
 # Stellar NFT Royalties

--- a/src/payouts/payout-limits.service.spec.ts
+++ b/src/payouts/payout-limits.service.spec.ts
@@ -1,0 +1,83 @@
+import { BadRequestException } from '@nestjs/common';
+import { PayoutLimitsService } from './payout-limits.service';
+
+describe('PayoutLimitsService', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.PAYOUT_LIMITS;
+    delete process.env.MIN_PAYOUT_USD;
+    delete process.env.MAX_PAYOUT_USD;
+    delete process.env.MIN_STELLAR_PAYOUT;
+    delete process.env.MAX_PAYOUT;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('loads default USD limits when no config is set', () => {
+    const service = new PayoutLimitsService();
+
+    expect(service.getLimits('USD')).toEqual({ min: 5, max: 10000 });
+  });
+
+  it('loads limits from PAYOUT_LIMITS JSON', () => {
+    process.env.PAYOUT_LIMITS = JSON.stringify({
+      USD: { min: 10, max: 5000 },
+      EUR: { min: 8, max: 3000 },
+    });
+
+    const service = new PayoutLimitsService();
+
+    expect(service.getLimits('usd')).toEqual({ min: 10, max: 5000 });
+    expect(service.getLimits('EUR')).toEqual({ min: 8, max: 3000 });
+  });
+
+  it('loads limits from MIN_PAYOUT_* and MAX_PAYOUT_* env vars', () => {
+    process.env.MIN_PAYOUT_USD = '15';
+    process.env.MAX_PAYOUT_USD = '8000';
+
+    const service = new PayoutLimitsService();
+
+    expect(service.getLimits('USD')).toEqual({ min: 15, max: 8000 });
+  });
+
+  describe('resolvePayoutAmount', () => {
+    it('throws when balance is below minimum', () => {
+      const service = new PayoutLimitsService();
+
+      expect(() => service.resolvePayoutAmount(3, 'USD')).toThrow(
+        BadRequestException,
+      );
+      expect(() => service.resolvePayoutAmount(3, 'USD')).toThrow(
+        /Minimum payout for USD is 5/,
+      );
+    });
+
+    it('returns full balance when within limits', () => {
+      const service = new PayoutLimitsService();
+
+      expect(service.resolvePayoutAmount(100, 'USD')).toBe(100);
+    });
+
+    it('caps amount at maximum when balance exceeds it', () => {
+      process.env.PAYOUT_LIMITS = JSON.stringify({
+        USD: { min: 5, max: 1000 },
+      });
+      const service = new PayoutLimitsService();
+
+      expect(service.resolvePayoutAmount(5000, 'USD')).toBe(1000);
+    });
+
+    it('throws for unconfigured currency', () => {
+      const service = new PayoutLimitsService();
+
+      expect(() => service.resolvePayoutAmount(100, 'GBP')).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/payouts/payout-limits.service.ts
+++ b/src/payouts/payout-limits.service.ts
@@ -1,0 +1,166 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+
+export interface PayoutLimits {
+  min: number;
+  max: number;
+}
+
+@Injectable()
+export class PayoutLimitsService {
+  private readonly logger = new Logger(PayoutLimitsService.name);
+  private readonly limitsByCurrency: Map<string, PayoutLimits>;
+
+  constructor() {
+    this.limitsByCurrency = this.loadLimits();
+    this.logger.log(
+      `Payout limits loaded for currencies: ${[...this.limitsByCurrency.keys()].join(', ')}`,
+    );
+  }
+
+  getLimits(currency: string): PayoutLimits {
+    const normalized = currency.toUpperCase();
+    const limits = this.limitsByCurrency.get(normalized);
+
+    if (!limits) {
+      throw new BadRequestException(
+        `Payout limits are not configured for currency ${normalized}.`,
+      );
+    }
+
+    return limits;
+  }
+
+  /**
+   * Validates available balance against limits and returns the payout amount
+   * (capped at the per-currency maximum when balance exceeds it).
+   */
+  resolvePayoutAmount(availableBalance: number, currency: string): number {
+    const { min, max } = this.getLimits(currency);
+
+    if (availableBalance < min) {
+      throw new BadRequestException(
+        `Minimum payout for ${currency} is ${min}. Your available balance is ${availableBalance.toFixed(2)} ${currency}.`,
+      );
+    }
+
+    if (availableBalance > max) {
+      return max;
+    }
+
+    return availableBalance;
+  }
+
+  private loadLimits(): Map<string, PayoutLimits> {
+    if (process.env.PAYOUT_LIMITS) {
+      return this.parseJsonLimits(process.env.PAYOUT_LIMITS);
+    }
+
+    const limits = this.parseEnvPrefixLimits();
+    this.applyUsdDefaults(limits);
+    this.assertValidLimits(limits);
+    return limits;
+  }
+
+  private parseJsonLimits(raw: string): Map<string, PayoutLimits> {
+    let parsed: Record<string, { min: number; max: number }>;
+
+    try {
+      parsed = JSON.parse(raw) as Record<string, { min: number; max: number }>;
+    } catch {
+      throw new Error('PAYOUT_LIMITS must be valid JSON');
+    }
+
+    const limits = new Map<string, PayoutLimits>();
+
+    for (const [currency, value] of Object.entries(parsed)) {
+      limits.set(currency.toUpperCase(), {
+        min: Number(value.min),
+        max: Number(value.max),
+      });
+    }
+
+    this.assertValidLimits(limits);
+    return limits;
+  }
+
+  private parseEnvPrefixLimits(): Map<string, PayoutLimits> {
+    const limits = new Map<string, PayoutLimits>();
+
+    for (const [key, value] of Object.entries(process.env)) {
+      if (!value) {
+        continue;
+      }
+
+      const minMatch = /^MIN_PAYOUT_(.+)$/.exec(key);
+      if (minMatch) {
+        const currency = minMatch[1].toUpperCase();
+        const existing = limits.get(currency) ?? { min: 0, max: Number.POSITIVE_INFINITY };
+        limits.set(currency, {
+          ...existing,
+          min: parseFloat(value),
+        });
+        continue;
+      }
+
+      const maxMatch = /^MAX_PAYOUT_(.+)$/.exec(key);
+      if (maxMatch) {
+        const currency = maxMatch[1].toUpperCase();
+        const existing = limits.get(currency) ?? { min: 0, max: Number.POSITIVE_INFINITY };
+        limits.set(currency, {
+          ...existing,
+          max: parseFloat(value),
+        });
+      }
+    }
+
+    return limits;
+  }
+
+  private applyUsdDefaults(limits: Map<string, PayoutLimits>): void {
+    const defaults = this.defaultUsdLimits();
+
+    if (!limits.has('USD')) {
+      limits.set('USD', defaults);
+      return;
+    }
+
+    const usd = limits.get('USD')!;
+    limits.set('USD', {
+      min: usd.min > 0 ? usd.min : defaults.min,
+      max: Number.isFinite(usd.max) ? usd.max : defaults.max,
+    });
+  }
+
+  private defaultUsdLimits(): PayoutLimits {
+    return {
+      min: parseFloat(
+        process.env.MIN_PAYOUT_USD ??
+          process.env.MIN_STELLAR_PAYOUT ??
+          '5',
+      ),
+      max: parseFloat(
+        process.env.MAX_PAYOUT_USD ?? process.env.MAX_PAYOUT ?? '10000',
+      ),
+    };
+  }
+
+  private assertValidLimits(limits: Map<string, PayoutLimits>): void {
+    for (const [currency, { min, max }] of limits) {
+      if (
+        Number.isNaN(min) ||
+        Number.isNaN(max) ||
+        min < 0 ||
+        max < 0 ||
+        min > max
+      ) {
+        throw new Error(
+          `Invalid payout limits for ${currency}: min=${min}, max=${max}`,
+        );
+      }
+    }
+  }
+}

--- a/src/payouts/payouts.module.ts
+++ b/src/payouts/payouts.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { PayoutsService } from './payouts.service';
 import { PayoutsController } from './payouts.controller';
+import { PayoutLimitsService } from './payout-limits.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [PrismaModule, StellarModule],
   controllers: [PayoutsController],
-  providers: [PayoutsService],
+  providers: [PayoutsService, PayoutLimitsService],
   exports: [PayoutsService],
 })
 export class PayoutsModule {}

--- a/src/payouts/payouts.service.spec.ts
+++ b/src/payouts/payouts.service.spec.ts
@@ -1,7 +1,15 @@
+jest.mock('../stellar/stellar.service', () => ({
+  StellarService: jest.fn().mockImplementation(() => ({
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  })),
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { PayoutsService } from './payouts.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
+import { PayoutLimitsService } from './payout-limits.service';
 import {
   ConflictException,
   BadRequestException,
@@ -10,7 +18,6 @@ import {
 
 describe('PayoutsService', () => {
   let service: PayoutsService;
-  let prisma: jest.Mocked<PrismaService>;
 
   const mockPrismaService = {
     payout: {
@@ -34,6 +41,10 @@ describe('PayoutsService', () => {
     networkPassphrase: 'Test SDF Network ; September 2015',
   };
 
+  const mockPayoutLimitsService = {
+    resolvePayoutAmount: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -46,11 +57,14 @@ describe('PayoutsService', () => {
           provide: StellarService,
           useValue: mockStellarService,
         },
+        {
+          provide: PayoutLimitsService,
+          useValue: mockPayoutLimitsService,
+        },
       ],
     }).compile();
 
     service = module.get<PayoutsService>(PayoutsService);
-    prisma = module.get(PrismaService);
   });
 
   afterEach(() => {
@@ -83,7 +97,7 @@ describe('PayoutsService', () => {
       );
     });
 
-    it('should throw BadRequestException if balance below minimum', async () => {
+    it('should throw BadRequestException when balance is below minimum', async () => {
       mockPrismaService.payout.findFirst.mockResolvedValue(null);
       mockPrismaService.wallet.findFirst.mockResolvedValue({
         id: 1,
@@ -95,10 +109,49 @@ describe('PayoutsService', () => {
       mockPrismaService.payout.aggregate.mockResolvedValue({
         _sum: { amount: 0 },
       });
+      mockPayoutLimitsService.resolvePayoutAmount.mockImplementation(() => {
+        throw new BadRequestException(
+          'Minimum payout for USD is 5. Your available balance is 3.00 USD.',
+        );
+      });
 
       await expect(service.requestPayout(1)).rejects.toThrow(
         BadRequestException,
       );
+    });
+
+    it('should create payout capped at maximum limit', async () => {
+      mockPrismaService.payout.findFirst.mockResolvedValue(null);
+      mockPrismaService.wallet.findFirst.mockResolvedValue({
+        id: 1,
+        address: 'GTEST...',
+      });
+      mockPrismaService.earning.aggregate.mockResolvedValue({
+        _sum: { amount: 20000 },
+      });
+      mockPrismaService.payout.aggregate.mockResolvedValue({
+        _sum: { amount: 0 },
+      });
+      mockPayoutLimitsService.resolvePayoutAmount.mockReturnValue(10000);
+      mockPrismaService.payout.create.mockResolvedValue({
+        id: 9,
+        amount: 10000,
+        status: 'pending',
+        createdAt: new Date(),
+      });
+
+      const result = await service.requestPayout(1);
+
+      expect(mockPayoutLimitsService.resolvePayoutAmount).toHaveBeenCalledWith(
+        20000,
+        'USD',
+      );
+      expect(mockPrismaService.payout.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ amount: 10000, currency: 'USD' }),
+        }),
+      );
+      expect(result.amount).toBe(10000);
     });
   });
 

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -9,20 +9,19 @@ import {
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
+import { PayoutLimitsService } from './payout-limits.service';
 
 @Injectable()
 export class PayoutsService {
   private readonly logger = new Logger(PayoutsService.name);
-  private readonly minPayoutAmount: number;
+  private readonly defaultPayoutCurrency =
+    process.env.DEFAULT_PAYOUT_CURRENCY ?? 'USD';
 
   constructor(
     private prisma: PrismaService,
     private stellarService: StellarService,
-  ) {
-    this.minPayoutAmount = parseFloat(
-      process.env.MIN_STELLAR_PAYOUT ?? '5',
-    );
-  }
+    private payoutLimitsService: PayoutLimitsService,
+  ) {}
 
   async requestPayout(userId: number): Promise<{
     id: number;
@@ -63,23 +62,23 @@ export class PayoutsService {
       _sum: { amount: true },
     });
 
-    const pendingBalance =
+    const availableBalance =
       (totalEarnings._sum.amount ?? 0) -
       (totalPaidOut._sum.amount ?? 0);
 
-    if (pendingBalance < this.minPayoutAmount) {
-      throw new BadRequestException(
-        `Minimum payout amount is $${this.minPayoutAmount}. Your pending balance is $${pendingBalance.toFixed(2)}.`,
-      );
-    }
+    const currency = this.defaultPayoutCurrency;
+    const payoutAmount = this.payoutLimitsService.resolvePayoutAmount(
+      availableBalance,
+      currency,
+    );
 
     // Create payout record
     const payout = await this.prisma.payout.create({
       data: {
         userId,
         walletId: wallet.id,
-        amount: pendingBalance,
-        currency: 'USD',
+        amount: payoutAmount,
+        currency,
         method: 'stellar',
         status: 'pending',
       },


### PR DESCRIPTION
Closes #188

## Summary

- Adds `PayoutLimitsService` for per-currency min/max payout limits.
- Validates payout amounts in `POST /payouts/request` with clear error messages.
- Caps payout amount at the configured maximum when available balance exceeds it.
- Supports configuration via `PAYOUT_LIMITS` JSON, `MIN_PAYOUT_{CURRENCY}` / `MAX_PAYOUT_{CURRENCY}`, or legacy `MIN_STELLAR_PAYOUT` / `MAX_PAYOUT_USD`.

## Configuration

**JSON (recommended for multiple currencies):**
```env
PAYOUT_LIMITS={"USD":{"min":5,"max":10000},"EUR":{"min":8,"max":5000}}