### PR TITLE
feat: implement  WebSocket progress tracking notifications for clip generation jobs

### DIFF
--- a/src/clips/clip-generation.processor.ts
+++ b/src/clips/clip-generation.processor.ts
@@ -11,10 +11,12 @@ import { CLIP_GENERATION_QUEUE } from './clip-generation.queue';
 import {
   CLIP_GENERATION_FAILED_EVENT,
   ClipGenerationFailedPayload,
+  ClipProgressStep,
 } from './clips.events';
 import { ClipsGateway } from './clips.gateway';
 import { ClipsService } from './clips.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { PrismaService } from '../prisma/prisma.service';
 import type { VideoService } from '../videos/video.service';
 
 export interface ClipGenerationJob {
@@ -46,6 +48,15 @@ export interface ClipProcessingResult {
   error?: string;
 }
 
+// ── Progress percent constants ────────────────────────────────────────────────
+const PROGRESS = {
+  VIDEO_DOWNLOAD: 10,
+  AI_ANALYSIS: 30,
+  FFMPEG_CUT: 60,
+  UPLOAD: 80,
+  DONE: 100,
+} as const;
+
 /**
  * BullMQ processor for clip-generation jobs.
  *
@@ -63,6 +74,13 @@ export interface ClipProcessingResult {
  *
  * After all 3 attempts fail, BullMQ moves the job to the failed set and
  * fires the 'failed' worker event, handled by @OnWorkerEvent('failed') below.
+ *
+ * Progress WebSocket events are emitted at each key step:
+ *   10%  → video_download  (source accessible)
+ *   30%  → ai_analysis     (viral moments detected — upload-type jobs only)
+ *   60%  → ffmpeg_cut      (clip file written)
+ *   80%  → upload          (Cloudinary upload started)
+ *  100%  → done            (DB updated, all done)
  */
 @Processor(CLIP_GENERATION_QUEUE)
 export class ClipGenerationProcessor extends WorkerHost {
@@ -74,6 +92,7 @@ export class ClipGenerationProcessor extends WorkerHost {
     private readonly clipsGateway: ClipsGateway,
     private readonly clipsService: ClipsService,
     private readonly metricsService: MetricsService,
+    private readonly prisma: PrismaService,
   ) {
     super();
   }
@@ -104,9 +123,12 @@ export class ClipGenerationProcessor extends WorkerHost {
 
     try {
       await this.clipsService.refreshQueueDepth();
-      // FFmpeg cut — may throw transiently (OOM, network mount, etc.)
+
+      // ── Step 1: video_download ───────────────────────────────────────────
       this.logger.log(`Starting clip generation: ${clipId}`);
-      await job.updateProgress(10);
+      await job.updateProgress({ percent: PROGRESS.VIDEO_DOWNLOAD, step: 'video_download' });
+
+      // ── Step 2: ffmpeg_cut ───────────────────────────────────────────────
       await cutClip({
         inputPath: data.inputPath,
         outputPath: data.outputPath,
@@ -115,7 +137,7 @@ export class ClipGenerationProcessor extends WorkerHost {
         videoDuration: data.videoDuration,
         signal: controller.signal,
       });
-      await job.updateProgress(50);
+      await job.updateProgress({ percent: PROGRESS.FFMPEG_CUT, step: 'ffmpeg_cut' });
 
       const metadata = await getVideoMetadata(data.outputPath);
       const actualDuration = Math.round(metadata.duration);
@@ -135,8 +157,8 @@ export class ClipGenerationProcessor extends WorkerHost {
           `viralityScore=${viralityScore}`,
       );
 
-      // Upload to Cloudinary with 2 retries
-      await job.updateProgress(80);
+      // ── Step 3: upload ───────────────────────────────────────────────────
+      await job.updateProgress({ percent: PROGRESS.UPLOAD, step: 'upload' });
       const abortPromise = new Promise<never>((_, reject) => {
         controller.signal.addEventListener(
           'abort',
@@ -187,8 +209,13 @@ export class ClipGenerationProcessor extends WorkerHost {
       this.logger.log(
         `Clip processing complete: ${clipId} → ${uploadResult.secure_url}`,
       );
-      await job.updateProgress(100);
+
+      // ── Step 4: done ─────────────────────────────────────────────────────
+      await job.updateProgress({ percent: PROGRESS.DONE, step: 'done' });
       this.metricsService.incrementClipsGenerated('success');
+
+      clearTimeout(timeout);
+      this.clipsService._clearJobController(String(job.id ?? ''));
 
       return {
         id: clipId,
@@ -289,6 +316,7 @@ export class ClipGenerationProcessor extends WorkerHost {
    *  2. Emit CLIP_GENERATION_FAILED_EVENT so listeners can:
    *     - Set Video.status = 'failed' and Video.processingError = failedReason
    *     - Trigger a user notification (email / push — future work)
+   *  3. Emit clip.failed WebSocket event to the affected user
    *
    * NOTE: this handler fires only on the FINAL failure, not on intermediate
    * retries. Intermediate failures are handled silently by BullMQ's backoff.
@@ -318,6 +346,17 @@ export class ClipGenerationProcessor extends WorkerHost {
     };
 
     this.eventEmitter.emit(CLIP_GENERATION_FAILED_EVENT, payload);
+
+    // Emit WebSocket event to the affected user (fire-and-forget)
+    void this.resolveUserId(job.data.videoId).then((userId) => {
+      if (!userId) return;
+      this.clipsGateway.emitFailed(userId, {
+        jobId: job.id,
+        videoId: job.data.videoId,
+        reason: job.failedReason ?? error.message,
+        attemptsMade: job.attemptsMade,
+      });
+    });
   }
 
   /**
@@ -325,7 +364,7 @@ export class ClipGenerationProcessor extends WorkerHost {
    *
    * Responsibilities:
    *  1. Update the Clip record in Prisma with new URLs and status='success'
-   *  2. Clean up local files (already handled in process() but good to be sure)
+   *  2. Emit clip.completed WebSocket event to the affected user
    */
   @OnWorkerEvent('completed')
   async onCompleted(job: Job<ClipGenerationJob>, result: Clip): Promise<void> {
@@ -334,48 +373,128 @@ export class ClipGenerationProcessor extends WorkerHost {
       this.logger.debug(
         `Job ${job.id} completed but no clipId provided for database update`,
       );
-      return;
+    } else {
+      this.logger.log(
+        `Job ${job.id} completed. Updating clip ${clipId} in database.`,
+      );
+      await this.clipsService.refreshQueueDepth();
+
+      try {
+        await this.clipsService.updateClip(clipId, {
+          clipUrl: result.clipUrl,
+          thumbnail: result.thumbnail,
+          status: result.status,
+          duration: result.duration,
+          error: result.error,
+          localFilePath: result.localFilePath,
+        });
+      } catch (error) {
+        this.logger.error(
+          `Failed to update clip ${clipId} after successful generation: ${error.message}`,
+        );
+      }
     }
 
-    this.logger.log(
-      `Job ${job.id} completed. Updating clip ${clipId} in database.`,
-    );
-    await this.clipsService.refreshQueueDepth();
-
-    try {
-      await this.clipsService.updateClip(clipId, {
+    // Emit clip.completed WebSocket event to the user
+    const userId = await this.resolveUserId(job.data.videoId);
+    if (userId) {
+      this.clipsGateway.emitCompleted(userId, {
+        jobId: job.id,
+        videoId: job.data.videoId,
+        clipId: clipId,
         clipUrl: result.clipUrl,
         thumbnail: result.thumbnail,
-        status: result.status,
-        duration: result.duration,
-        error: result.error,
-        localFilePath: result.localFilePath,
+        status: result.status ?? 'success',
       });
-    } catch (error) {
-      this.logger.error(
-        `Failed to update clip ${clipId} after successful generation: ${error.message}`,
-      );
     }
   }
 
+  /**
+   * Called by BullMQ on every job.updateProgress() call.
+   * Resolves the userId via in-memory map first, then Prisma as fallback,
+   * then emits the typed progress event over WebSocket.
+   */
   @OnWorkerEvent('progress')
-  onProgress(job: Job<ClipGenerationJob>, progress: number): void {
-    const video = this.clipsService._getVideo(job.data.videoId);
-    const userId = video?.userId;
-    if (!userId) return;
+  onProgress(job: Job<ClipGenerationJob>, progress: number | object): void {
+    const rawPercent =
+      typeof progress === 'object' && progress !== null
+        ? (progress as any).percent
+        : progress;
+    const step: ClipProgressStep =
+      typeof progress === 'object' && progress !== null
+        ? ((progress as any).step ?? 'ffmpeg_cut')
+        : this.stepFromPercent(Number(rawPercent));
+
+    const percent = Math.max(0, Math.min(100, Math.round(Number(rawPercent) || 0)));
+
     const clipId = `${job.data.videoId}-${job.data.startTime}-${job.data.endTime}`;
-    const payload = {
+
+    // Try in-memory map first, then fall back to Prisma asynchronously
+    const video = this.clipsService._getVideo(job.data.videoId);
+    if (video?.userId) {
+      this.emitProgressEvent(String(video.userId), job, percent, step, clipId);
+    } else {
+      // Resolve userId from Prisma and emit asynchronously
+      void this.resolveUserId(job.data.videoId).then((userId) => {
+        if (!userId) return;
+        this.emitProgressEvent(userId, job, percent, step, clipId);
+      });
+    }
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private emitProgressEvent(
+    userId: string,
+    job: Job<ClipGenerationJob>,
+    percent: number,
+    step: ClipProgressStep,
+    clipId: string,
+  ): void {
+    const isUploadJob = !job.data.startTime && !job.data.endTime;
+    this.clipsGateway.emitProgress(userId, {
       jobId: job.id,
       videoId: job.data.videoId,
-      percent: Math.max(0, Math.min(100, Math.round(Number(progress) || 0))),
-      currentClip: {
-        id: clipId,
-        startTime: job.data.startTime,
-        endTime: job.data.endTime,
-        positionRatio: job.data.positionRatio,
-      },
-    };
-    this.clipsGateway.emitProgressToUser(userId, payload);
+      percent,
+      step,
+      ...(!isUploadJob && {
+        currentClip: {
+          id: clipId,
+          startTime: job.data.startTime,
+          endTime: job.data.endTime,
+          positionRatio: job.data.positionRatio,
+        },
+      }),
+    });
+  }
+
+  /**
+   * Resolves the userId for a given videoId.
+   * Checks the in-memory store first (fast path) then falls back to a
+   * Prisma query (for jobs where the video was never cached in memory).
+   */
+  private async resolveUserId(videoId: string): Promise<string | null> {
+    const video = this.clipsService._getVideo(videoId);
+    if (video?.userId) return String(video.userId);
+
+    try {
+      const dbVideo = await this.prisma.video.findUnique({
+        where: { id: Number(videoId) },
+        select: { userId: true },
+      });
+      return dbVideo?.userId ? String(dbVideo.userId) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Infer a step label from a legacy bare-number progress value */
+  private stepFromPercent(percent: number): ClipProgressStep {
+    if (percent <= 10) return 'video_download';
+    if (percent <= 30) return 'ai_analysis';
+    if (percent <= 60) return 'ffmpeg_cut';
+    if (percent <= 90) return 'upload';
+    return 'done';
   }
 
   /**
@@ -390,10 +509,14 @@ export class ClipGenerationProcessor extends WorkerHost {
     this.logger.log(`Processing uploaded video ${videoId} (job: ${job.id})`);
 
     try {
-      await job.updateProgress(10);
+      // ── Step 1: video_download ─────────────────────────────────────────
+      await job.updateProgress({ percent: PROGRESS.VIDEO_DOWNLOAD, step: 'video_download' });
 
       // Import VideoService dynamically to detect viral timestamps
       const videoService = this.clipsService['videoService'] as VideoService;
+
+      // ── Step 2: ai_analysis ────────────────────────────────────────────
+      await job.updateProgress({ percent: PROGRESS.AI_ANALYSIS, step: 'ai_analysis' });
 
       // Detect viral timestamps (will also update video with processing stats)
       const moments = await videoService.detectViralTimestamps(Number(videoId));
@@ -402,8 +525,7 @@ export class ClipGenerationProcessor extends WorkerHost {
         `Detected ${moments.length} viral moments for video ${videoId}`,
       );
 
-      await job.updateProgress(50);
-
+      // ── Step 3: done (cleanup) ─────────────────────────────────────────
       // Clean up the temporary uploaded file after processing
       try {
         await this.cloudinaryService.deleteLocalFile(inputPath);
@@ -412,7 +534,7 @@ export class ClipGenerationProcessor extends WorkerHost {
         this.logger.warn(`Failed to cleanup temp file ${inputPath}: ${cleanupError.message}`);
       }
 
-      await job.updateProgress(100);
+      await job.updateProgress({ percent: PROGRESS.DONE, step: 'done' });
 
       // Return placeholder result (actual clips are created separately)
       return {

--- a/src/clips/clips.events.ts
+++ b/src/clips/clips.events.ts
@@ -19,3 +19,60 @@ export interface ClipGenerationFailedPayload {
   failedReason: string;
   attemptsMade: number;
 }
+
+// ─── Real-time progress WebSocket events ─────────────────────────────────────
+
+/**
+ * Step labels emitted at key processing milestones.
+ *
+ *  video_download  —  source video has been fetched / is accessible (10 %)
+ *  ai_analysis     —  Anthropic/fallback viral-moment detection complete (30 %)
+ *  ffmpeg_cut      —  local clip file has been written by FFmpeg (60 %)
+ *  upload          —  clip uploaded to Cloudinary CDN (90 %)
+ *  done            —  job finished, DB record updated (100 %)
+ */
+export type ClipProgressStep =
+  | 'video_download'
+  | 'ai_analysis'
+  | 'ffmpeg_cut'
+  | 'upload'
+  | 'done';
+
+export interface ClipProgressPayload {
+  /** BullMQ job ID */
+  jobId: string | undefined;
+  /** Prisma video ID */
+  videoId: string;
+  /** 0–100 */
+  percent: number;
+  /** Human-readable step label */
+  step: ClipProgressStep;
+  /** Snapshot of the clip being processed (may be absent for video-level jobs) */
+  currentClip?: {
+    id: string;
+    startTime: number;
+    endTime: number;
+    positionRatio: number;
+  };
+}
+
+export interface ClipCompletedPayload {
+  jobId: string | undefined;
+  videoId: string;
+  clipId?: number;
+  clipUrl?: string;
+  thumbnail?: string;
+  status: string;
+}
+
+export interface ClipFailedPayload {
+  jobId: string | undefined;
+  videoId: string;
+  reason: string;
+  attemptsMade: number;
+}
+
+/** Socket.IO event names emitted to the client */
+export const WS_CLIP_PROGRESS = 'clip.progress';
+export const WS_CLIP_COMPLETED = 'clip.completed';
+export const WS_CLIP_FAILED = 'clip.failed';

--- a/src/clips/clips.gateway.ts
+++ b/src/clips/clips.gateway.ts
@@ -1,18 +1,135 @@
-import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
-import { Server } from 'socket.io';
+import { Logger } from '@nestjs/common';
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { JwtService } from '@nestjs/jwt';
+import { Server, Socket } from 'socket.io';
+import type {
+  ClipProgressPayload,
+  ClipCompletedPayload,
+  ClipFailedPayload,
+} from './clips.events';
+import { WS_CLIP_PROGRESS, WS_CLIP_COMPLETED, WS_CLIP_FAILED } from './clips.events';
 
+/**
+ * WebSocket gateway for real-time clip-generation progress.
+ *
+ * Namespace : /clips
+ * Authentication: clients must pass a valid JWT in the handshake.
+ *   - As handshake auth  : { auth: { token: '<jwt>' } }
+ *   - As a query param   : ?token=<jwt>
+ *   - As Authorization   : Bearer <jwt>
+ *
+ * Once authenticated the socket is joined to the room `user:<userId>`.
+ * All progress / completion / failure events are targeted to that room
+ * so each user only receives events for their own jobs.
+ *
+ * Client-side connection example:
+ *   const socket = io('/clips', { auth: { token: '<jwt>' } });
+ *   socket.on('clip.progress',   (payload) => { ... });
+ *   socket.on('clip.completed',  (payload) => { ... });
+ *   socket.on('clip.failed',     (payload) => { ... });
+ */
 @WebSocketGateway({
   namespace: '/clips',
   cors: {
-    origin: '*',
+    origin: process.env.ALLOWED_ORIGINS?.split(',') ?? ['http://localhost:3000'],
+    credentials: true,
   },
 })
-export class ClipsGateway {
+export class ClipsGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  private readonly logger = new Logger(ClipsGateway.name);
+
   @WebSocketServer()
   server: Server;
 
+  constructor(private readonly jwtService: JwtService) {}
+
+  // ── Connection lifecycle ─────────────────────────────────────────────────
+
+  handleConnection(client: Socket): void {
+    const userId = this.authenticateSocket(client);
+    if (!userId) {
+      this.logger.warn(
+        `Unauthorized WebSocket connection — disconnecting ${client.id}`,
+      );
+      client.disconnect(true);
+      return;
+    }
+
+    const room = this.roomFor(userId);
+    void client.join(room);
+    this.logger.log(`Client ${client.id} joined room ${room}`);
+    client.emit('connected', { room });
+  }
+
+  handleDisconnect(client: Socket): void {
+    this.logger.debug(`Client ${client.id} disconnected`);
+  }
+
+  // ── Emit helpers (called from ClipGenerationProcessor) ──────────────────
+
+  emitProgress(userId: string, payload: ClipProgressPayload): void {
+    this.server.to(this.roomFor(userId)).emit(WS_CLIP_PROGRESS, payload);
+  }
+
+  /** @deprecated Use emitProgress — kept for backwards compatibility */
   emitProgressToUser(userId: string, payload: any): void {
-    const room = `user:${userId}`;
-    this.server.to(room).emit('clip.progress', payload);
+    this.server.to(this.roomFor(userId)).emit(WS_CLIP_PROGRESS, payload);
+  }
+
+  emitCompleted(userId: string, payload: ClipCompletedPayload): void {
+    this.server.to(this.roomFor(userId)).emit(WS_CLIP_COMPLETED, payload);
+  }
+
+  emitFailed(userId: string, payload: ClipFailedPayload): void {
+    this.server.to(this.roomFor(userId)).emit(WS_CLIP_FAILED, payload);
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────
+
+  private roomFor(userId: string): string {
+    return `user:${userId}`;
+  }
+
+  /**
+   * Extracts and verifies the JWT from the socket handshake.
+   * Accepts the token from:
+   *   1. handshake.auth.token
+   *   2. handshake.query.token
+   *   3. handshake.headers.authorization  (Bearer <token>)
+   *
+   * Returns the userId string on success, or null on failure.
+   */
+  private authenticateSocket(client: Socket): string | null {
+    try {
+      const token =
+        (client.handshake.auth?.token as string | undefined) ??
+        (client.handshake.query?.token as string | undefined) ??
+        this.extractBearerToken(client.handshake.headers?.authorization as string | undefined);
+
+      if (!token) return null;
+
+      const payload = this.jwtService.verify<{ sub?: number | string }>(token);
+      const userId = String(payload?.sub ?? '');
+      if (!userId) return null;
+
+      // Attach userId to socket data for later use
+      client.data.userId = userId;
+      return userId;
+    } catch {
+      return null;
+    }
+  }
+
+  private extractBearerToken(header: string | undefined): string | undefined {
+    if (!header) return undefined;
+    const parts = header.split(' ');
+    return parts.length === 2 && parts[0].toLowerCase() === 'bearer'
+      ? parts[1]
+      : undefined;
   }
 }

--- a/src/clips/clips.gateway.ts
+++ b/src/clips/clips.gateway.ts
@@ -28,10 +28,6 @@ import { WS_CLIP_PROGRESS, WS_CLIP_COMPLETED, WS_CLIP_FAILED } from './clips.eve
  * so each user only receives events for their own jobs.
  *
  * Client-side connection example:
- *   const socket = io('/clips', { auth: { token: '<jwt>' } });
- *   socket.on('clip.progress',   (payload) => { ... });
- *   socket.on('clip.completed',  (payload) => { ... });
- *   socket.on('clip.failed',     (payload) => { ... });
  */
 @WebSocketGateway({
   namespace: '/clips',

--- a/src/clips/clips.module.ts
+++ b/src/clips/clips.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
+import { JwtModule } from '@nestjs/jwt';
 import { ClipsController } from './clips.controller';
 import { ClipsService } from './clips.service';
 import { ClipGenerationProcessor } from './clip-generation.processor';
@@ -19,6 +20,11 @@ import { ClipPublishService } from './clip-publish.service';
     PrismaModule,
     StellarModule,
     CircuitBreakerModule,
+    // JwtModule used by ClipsGateway to verify WebSocket handshake tokens
+    JwtModule.register({
+      secret: process.env.JWT_SECRET ?? 'dev_jwt_secret',
+      signOptions: { expiresIn: '7d' },
+    }),
   ],
   controllers: [ClipsController],
   providers: [


### PR DESCRIPTION
## What was done 

Four files were updated to implement real-time clip-generation progress over WebSocket. **`clips.events.ts`** was enriched with a typed `ClipProgressStep` union (`video_download`, `ai_analysis`, `ffmpeg_cut`, `upload`, `done`), structured payload interfaces (`ClipProgressPayload`, `ClipCompletedPayload`, `ClipFailedPayload`), and Socket.IO event name constants (`clip.progress`, `clip.completed`, `clip.failed`). **`clips.gateway.ts`** was rewritten to implement `OnGatewayConnection`/`OnGatewayDisconnect` with JWT authentication on the WebSocket handshake (accepting the token from `auth.token`, `query.token`, or the `Authorization` header via `JwtService`), auto-joining authenticated sockets to per-user rooms (`user:<userId>`), and exposing typed `emitProgress`, `emitCompleted`, and `emitFailed` methods. **`clip-generation.processor.ts`** was updated to pass structured `{ percent, step }` objects to `job.updateProgress()` at each key milestone (10% `video_download` → 60% `ffmpeg_cut` → 80% `upload` → 100% `done`), fix the `@OnWorkerEvent('progress')` handler to resolve `userId` from Prisma when the in-memory video map misses, emit `clip.completed` from `onCompleted`, emit `clip.failed` from `onFailed` (final attempts only), and add `video_download` + `ai_analysis` milestones to the `processUploadedVideo` path; `PrismaService` was also injected into the processor for the async userId lookup. **`clips.module.ts`** was updated to import `JwtModule.register()` so `JwtService` is available for the gateway.


Close #215