### PR TITLE
refactor: enhance retry logic and logging for email and job configurations

### DIFF
--- a/src/auth/email-delivery.processor.ts
+++ b/src/auth/email-delivery.processor.ts
@@ -16,19 +16,42 @@ export class EmailDeliveryProcessor extends WorkerHost {
   }
 
   async process(job: Job<EmailDeliveryJobData>): Promise<void> {
+    this.logger.log(
+      `Processing email job ${job.id} — attempt ${job.attemptsMade + 1}/${job.opts.attempts ?? 1} ` +
+        `to=${job.data.to} template=${job.data.template}`,
+    );
     await this.mailService.sendTemplatedEmail(job.data);
   }
 
   @OnWorkerEvent('failed')
   onFailed(job: Job<EmailDeliveryJobData>, error: Error): void {
-    const attempts = job.opts.attempts ?? 1;
-    const isTerminalFailure = job.attemptsMade >= attempts;
-    if (!isTerminalFailure) {
+    const maxAttempts = job.opts.attempts ?? 1;
+    const isFinalAttempt = job.attemptsMade >= maxAttempts;
+
+    if (!isFinalAttempt) {
+      // Intermediate failure — compute the next backoff delay for the log message
+      const backoffDelay = job.opts.backoff
+        ? typeof job.opts.backoff === 'number'
+          ? job.opts.backoff
+          : // exponential: delay * 2^(attemptsMade - 1)
+            (job.opts.backoff.delay ?? 500) *
+            Math.pow(2, job.attemptsMade - 1)
+        : 0;
+
+      this.logger.warn(
+        `[RETRY] Email job ${job.id} failed on attempt ${job.attemptsMade}/${maxAttempts} — ` +
+          `to=${job.data.to} template=${job.data.template} — ` +
+          `reason: ${error.message} — ` +
+          `retrying in ~${Math.round(backoffDelay / 1000)}s`,
+      );
       return;
     }
 
     this.logger.error(
-      `Email job moved to DLQ after ${attempts} attempts for ${job.data.to}: ${error.message}`,
+      `[FINAL FAILURE] Email job ${job.id} moved to DLQ after ${maxAttempts} attempts — ` +
+        `to=${job.data.to} template=${job.data.template} — ` +
+        `reason: ${error.message}`,
+      error.stack,
     );
   }
 }

--- a/src/auth/email-delivery.queue.ts
+++ b/src/auth/email-delivery.queue.ts
@@ -11,3 +11,30 @@ export interface EmailDeliveryJobData {
     token: string;
   };
 }
+
+/**
+ * Job options for the email-delivery queue.
+ *
+ * Retry strategy (transient failures: SMTP connection drops, rate limits):
+ *   - 5 attempts total (1 initial + 4 automatic retries)
+ *   - Exponential backoff starting at 500 ms
+ *     attempt 1 → immediate
+ *     attempt 2 → ~500 ms delay
+ *     attempt 3 → ~1 000 ms delay
+ *     attempt 4 → ~2 000 ms delay
+ *     attempt 5 → ~4 000 ms delay
+ *   - Shorter base delay than clip-generation — SMTP transients
+ *     resolve faster than FFmpeg / Cloudinary failures.
+ *   - removeOnComplete: true — completed email jobs don't need auditing here
+ *   - removeOnFail: false  — keep failed jobs for post-mortem inspection
+ */
+export const EMAIL_JOB_OPTIONS = {
+  attempts: 5,
+  backoff: {
+    type: 'exponential' as const,
+    /** Base delay in ms — doubles on every retry */
+    delay: 500,
+  },
+  removeOnComplete: true,
+  removeOnFail: false,
+} as const;

--- a/src/auth/email-delivery.service.ts
+++ b/src/auth/email-delivery.service.ts
@@ -4,6 +4,7 @@ import { Queue } from 'bullmq';
 import {
   EMAIL_DELIVERY_JOB,
   EMAIL_DELIVERY_QUEUE,
+  EMAIL_JOB_OPTIONS,
   EmailDeliveryJobData,
 } from './email-delivery.queue';
 
@@ -17,15 +18,7 @@ export class EmailDeliveryService {
   ) {}
 
   async enqueue(data: EmailDeliveryJobData): Promise<void> {
-    await this.queue.add(EMAIL_DELIVERY_JOB, data, {
-      attempts: 5,
-      backoff: {
-        type: 'exponential',
-        delay: 1000,
-      },
-      removeOnComplete: true,
-      removeOnFail: false,
-    });
+    await this.queue.add(EMAIL_DELIVERY_JOB, data, EMAIL_JOB_OPTIONS);
     this.logger.log(`Queued email delivery for ${data.to} (${data.template})`);
   }
 }

--- a/src/clips/clip-generation.processor.ts
+++ b/src/clips/clip-generation.processor.ts
@@ -50,10 +50,12 @@ export interface ClipProcessingResult {
  * BullMQ processor for clip-generation jobs.
  *
  * Retry configuration (set per-job in ClipsService.enqueueClip via CLIP_JOB_OPTIONS):
- *   attempts : 3   — 1 initial attempt + 2 automatic retries
- *   backoff  : exponential, starting at 1 000 ms
- *              attempt 2 → ~1 000 ms wait
- *              attempt 3 → ~2 000 ms wait
+ *   attempts : 5   — 1 initial attempt + 4 automatic retries
+ *   backoff  : exponential, starting at 2 000 ms
+ *              attempt 2 → ~2 000 ms wait
+ *              attempt 3 → ~4 000 ms wait
+ *              attempt 4 → ~8 000 ms wait
+ *              attempt 5 → ~16 000 ms wait
  *
  * After FFmpeg cuts a clip, uploads to Cloudinary for reliable CDN delivery:
  *   1. Uploads video buffer using upload_stream
@@ -61,7 +63,7 @@ export interface ClipProcessingResult {
  *   3. Deletes local temporary file after success
  *   4. Handles errors with BullMQ retries (exponential backoff)
  *
- * After all 3 attempts fail, BullMQ moves the job to the failed set and
+ * After all 5 attempts fail, BullMQ moves the job to the failed set and
  * fires the 'failed' worker event, handled by @OnWorkerEvent('failed') below.
  */
 @Processor(CLIP_GENERATION_QUEUE)
@@ -295,21 +297,38 @@ export class ClipGenerationProcessor extends WorkerHost {
    */
   @OnWorkerEvent('failed')
   onFailed(job: Job<ClipGenerationJob>, error: Error): void {
-    const isFinalAttempt = job.attemptsMade >= (job.opts.attempts ?? 1);
-
-    this.logger.error(
-      `Clip job ${job.id} failed — ` +
-        `attempt ${job.attemptsMade}/${job.opts.attempts ?? 1} — ` +
-        `reason: ${error.message}`,
-    );
+    const maxAttempts = job.opts.attempts ?? 1;
+    const isFinalAttempt = job.attemptsMade >= maxAttempts;
 
     if (!isFinalAttempt) {
-      // Intermediate failure — BullMQ will retry with backoff; nothing else to do
+      // Intermediate failure — compute the next backoff delay for the log message
+      const backoffDelay = job.opts.backoff
+        ? typeof job.opts.backoff === 'number'
+          ? job.opts.backoff
+          : // exponential: delay * 2^(attemptsMade - 1)
+            (job.opts.backoff.delay ?? 2000) *
+            Math.pow(2, job.attemptsMade - 1)
+        : 0;
+
+      this.logger.warn(
+        `[RETRY] Clip job ${job.id} failed on attempt ${job.attemptsMade}/${maxAttempts} — ` +
+          `videoId=${job.data.videoId} — ` +
+          `reason: ${error.message} — ` +
+          `retrying in ~${Math.round(backoffDelay / 1000)}s`,
+      );
       return;
     }
+
+    // Final failure — log and notify the rest of the system
+    this.logger.error(
+      `[FINAL FAILURE] Clip job ${job.id} exhausted all ${maxAttempts} attempts — ` +
+        `videoId=${job.data.videoId} — ` +
+        `reason: ${error.message}`,
+      error.stack,
+    );
+
     void this.clipsService.refreshQueueDepth();
 
-    // Final failure — notify the rest of the system
     const payload: ClipGenerationFailedPayload = {
       jobId: job.id,
       videoId: job.data.videoId,

--- a/src/clips/clip-generation.queue.ts
+++ b/src/clips/clip-generation.queue.ts
@@ -4,19 +4,22 @@ export const CLIP_GENERATION_QUEUE = 'clip-generation';
 /**
  * Default job options applied to every clip-generation job.
  *
- * Retry strategy:
- *   - Up to 3 attempts total (1 initial + 2 retries)
- *   - Exponential backoff starting at 1 000 ms
+ * Retry strategy (transient failures: network, FFmpeg OOM, Cloudinary rate-limits):
+ *   - 5 attempts total (1 initial + 4 automatic retries)
+ *   - Exponential backoff starting at 2 000 ms
  *     attempt 1 → immediate
- *     attempt 2 → ~1 000 ms delay
- *     attempt 3 → ~2 000 ms delay
+ *     attempt 2 → ~2 000 ms delay
+ *     attempt 3 → ~4 000 ms delay
+ *     attempt 4 → ~8 000 ms delay
+ *     attempt 5 → ~16 000 ms delay
  *   - After all attempts are exhausted BullMQ moves the job to the
  *     failed set, which triggers the @OnWorkerEvent('failed') handler.
  */
 export const CLIP_JOB_OPTIONS = {
-  attempts: 3,
+  attempts: 5,
   backoff: {
     type: 'exponential' as const,
-    delay: 1000,
+    /** Base delay in ms — doubles on every retry */
+    delay: 2000,
   },
 } as const;


### PR DESCRIPTION
## What was done 

The retry strategy was improved across both BullMQ queues in the project. In `clip-generation.queue.ts`, `CLIP_JOB_OPTIONS` was updated from 3 attempts (1 + 2 retries) to **5 attempts** (1 + 4 retries) with the exponential backoff base delay raised from 1 000 ms to **2 000 ms**, producing a retry ladder of ~2 s → ~4 s → ~8 s → ~16 s — appropriate for heavy transient failures like FFmpeg OOM, network mounts, or Cloudinary rate limits. A new `EMAIL_JOB_OPTIONS` constant was added to `email-delivery.queue.ts` with the same 5-attempt policy but a faster **500 ms** base delay (~0.5 s → ~1 s → ~2 s → ~4 s), reflecting that SMTP transients resolve faster than media-processing ones; `email-delivery.service.ts` was updated to use this centralised constant instead of duplicating inline options. Finally, both `clip-generation.processor.ts` and `email-delivery.processor.ts` were updated so that every **intermediate retry** emits a structured `WARN` log with the attempt number, failure reason, and computed next-backoff delay, while terminal failures emit a distinct `ERROR` log tagged `[FINAL FAILURE]` — making every retry visible in the application logs without changing the underlying BullMQ event flow.

Close #216