### PR TITLE
feat: add Redis memory monitoring service and health check endpoint with logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/passport": "^11.0.3",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.0.1",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^8.0.0",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/websockets": "^11.0.1",
@@ -2579,6 +2580,19 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -3667,6 +3681,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -6000,6 +6020,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@nestjs/passport": "^11.0.3",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^8.0.0",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/websockets": "^11.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { LoggerModule } from './logger/logger.module';
 import { RequestIdMiddleware } from './logger/request-id.middleware';
 import { UsersModule } from './users/users.module';
 import { TransactionsModule } from './transactions/transactions.module';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -107,6 +108,7 @@ import { TransactionsModule } from './transactions/transactions.module';
     WalletsModule,
     UsersModule,
     TransactionsModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { RedisMemoryService, RedisMemoryStats } from './redis-memory.service';
+
+interface HealthResponse {
+  status: 'ok' | 'degraded';
+  stats: RedisMemoryStats;
+}
+
+@ApiTags('health')
+@Controller('health')
+export class HealthController {
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(private readonly redisMemoryService: RedisMemoryService) {}
+
+  /**
+   * Returns current Redis memory utilisation.
+   * Responds with HTTP 200 when usage is within safe bounds and
+   * HTTP 503 when usage exceeds the 80 % alert threshold.
+   */
+  @Get('redis-memory')
+  @ApiOperation({
+    summary: 'Redis memory health check',
+    description:
+      'Returns Redis memory stats. Status is "degraded" and HTTP 503 is returned when usage exceeds 80%.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Redis memory usage is within normal bounds.',
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Redis memory usage exceeds the 80% alert threshold.',
+  })
+  async checkRedisMemory(): Promise<HealthResponse> {
+    let stats: RedisMemoryStats;
+    try {
+      stats = await this.redisMemoryService.getStats();
+    } catch (err) {
+      this.logger.error(
+        `Redis memory health check failed: ${(err as Error).message}`,
+      );
+      throw new InternalServerErrorException(
+        'Unable to retrieve Redis memory stats',
+      );
+    }
+
+    if (stats.isAboveThreshold) {
+      this.logger.warn('Redis memory health check returned degraded status', {
+        usagePercent: stats.usagePercent,
+        alert: stats.alert,
+      });
+
+      // Return 503 so load balancers / monitoring tools can act on it
+      const response = {
+        status: 'degraded' as const,
+        stats,
+      };
+
+      // Return 503 so load balancers / monitoring tools can act on it.
+      // Throwing HttpException preserves the full JSON body in the response.
+      throw new HttpException(response, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    return { status: 'ok', stats };
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { RedisModule } from '../redis/redis.module';
+import { RedisMemoryService } from './redis-memory.service';
+import { HealthController } from './health.controller';
+
+@Module({
+  imports: [
+    RedisModule,
+    // ScheduleModule powers the @Interval() decorator on RedisMemoryService.
+    // forRoot() is idempotent — safe to call in multiple modules.
+    ScheduleModule.forRoot(),
+  ],
+  controllers: [HealthController],
+  providers: [RedisMemoryService],
+  exports: [RedisMemoryService],
+})
+export class HealthModule {}

--- a/src/health/redis-memory.service.ts
+++ b/src/health/redis-memory.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import { RedisService } from '../redis/redis.service';
+
+export interface RedisMemoryStats {
+  usedMemoryBytes: number;
+  maxMemoryBytes: number;
+  usedMemoryHuman: string;
+  maxMemoryHuman: string;
+  usedMemoryRssBytes: number;
+  memFragmentationRatio: number;
+  /** null when Redis has no memory limit configured */
+  usagePercent: number | null;
+  isAboveThreshold: boolean;
+  alert: string | null;
+  checkedAt: string;
+}
+
+export const MEMORY_ALERT_THRESHOLD_PERCENT = 80;
+
+/** Periodic log interval: every 5 minutes */
+const LOG_INTERVAL_MS = 5 * 60 * 1000;
+
+@Injectable()
+export class RedisMemoryService {
+  private readonly logger = new Logger(RedisMemoryService.name);
+
+  constructor(private readonly redisService: RedisService) {}
+
+  /**
+   * Collects current Redis memory stats, evaluates the alert threshold,
+   * and returns a structured payload.
+   */
+  async getStats(): Promise<RedisMemoryStats> {
+    const info = await this.redisService.getMemoryInfo();
+
+    const isAboveThreshold =
+      info.usagePercent !== null &&
+      info.usagePercent > MEMORY_ALERT_THRESHOLD_PERCENT;
+
+    const alert = isAboveThreshold
+      ? `Redis memory usage is at ${info.usagePercent}%, which exceeds the ${MEMORY_ALERT_THRESHOLD_PERCENT}% threshold. OOM risk is elevated.`
+      : null;
+
+    return {
+      ...info,
+      isAboveThreshold,
+      alert,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Runs on a fixed interval to log Redis memory statistics.
+   * Emits a warning when usage exceeds the configured threshold.
+   */
+  @Interval(LOG_INTERVAL_MS)
+  async logMemoryStats(): Promise<void> {
+    try {
+      const stats = await this.getStats();
+
+      const logPayload = {
+        usedMemory: stats.usedMemoryHuman,
+        maxMemory: stats.maxMemoryHuman,
+        usagePercent: stats.usagePercent,
+        memFragmentationRatio: stats.memFragmentationRatio,
+        alert: stats.alert,
+      };
+
+      if (stats.isAboveThreshold) {
+        this.logger.warn('Redis memory usage above alert threshold', logPayload);
+      } else {
+        this.logger.log('Redis memory stats', logPayload);
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to collect Redis memory stats: ${(err as Error).message}`,
+      );
+    }
+  }
+}

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -64,4 +64,48 @@ export class RedisService {
       return false;
     }
   }
+
+  /**
+   * Retrieves Redis memory statistics via the INFO memory command.
+   * Returns key memory fields in a structured format.
+   */
+  async getMemoryInfo(): Promise<{
+    usedMemoryBytes: number;
+    maxMemoryBytes: number;
+    usedMemoryHuman: string;
+    maxMemoryHuman: string;
+    usedMemoryRssBytes: number;
+    memFragmentationRatio: number;
+    usagePercent: number | null;
+  }> {
+    const raw = await this.redis.info('memory');
+
+    const parse = (key: string): string => {
+      const match = raw.match(new RegExp(`^${key}:(.+)$`, 'm'));
+      return match ? match[1].trim() : '0';
+    };
+
+    const usedMemoryBytes = parseInt(parse('used_memory'), 10);
+    const maxMemoryBytes = parseInt(parse('maxmemory'), 10);
+    const usedMemoryHuman = parse('used_memory_human');
+    const maxMemoryHuman = parse('maxmemory_human');
+    const usedMemoryRssBytes = parseInt(parse('used_memory_rss'), 10);
+    const memFragmentationRatio = parseFloat(parse('mem_fragmentation_ratio'));
+
+    // maxmemory == 0 means "no limit" — usage percentage is indeterminate
+    const usagePercent =
+      maxMemoryBytes > 0
+        ? Math.round((usedMemoryBytes / maxMemoryBytes) * 100 * 100) / 100
+        : null;
+
+    return {
+      usedMemoryBytes,
+      maxMemoryBytes,
+      usedMemoryHuman,
+      maxMemoryHuman,
+      usedMemoryRssBytes,
+      memFragmentationRatio,
+      usagePercent,
+    };
+  }
 }


### PR DESCRIPTION
## What was done 

To monitor Redis memory usage and prevent out-of-memory crashes, three new files were created and two existing ones were updated. A `getMemoryInfo()` method was added to the existing `RedisService` that calls Redis's built-in `INFO memory` command and parses the response into structured fields — used memory, max memory, RSS bytes, fragmentation ratio, and a calculated `usagePercent`. A new `src/health/redis-memory.service.ts` was created to wrap that data, evaluate whether usage exceeds the **80% alert threshold**, and attach a human-readable alert message; it also uses `@nestjs/schedule`'s `@Interval` decorator to automatically log memory stats every **5 minutes** — emitting a `warn` log when above the threshold and a standard `info` log otherwise. A `src/health/health.controller.ts` exposes `GET /health/redis-memory`, returning HTTP **200** with `{ status: "ok", stats }` when usage is safe, or HTTP **503** with `{ status: "degraded", stats }` when the threshold is breached so load balancers and monitoring tools can react. These are wired together in `src/health/health.module.ts`, which imports `RedisModule` and `ScheduleModule`. Finally, `HealthModule` was registered in `AppModule`, and `@nestjs/schedule` was installed as a new dependency.

Close #217