### PR TITLE
feat: earnings soft delete, public leaderboard, and payout PDF receipts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,10 @@ SOROBAN_NFT_CONTRACT_ID="your_soroban_nft_contract_id"
 PINATA_JWT="your_pinata_jwt_token"
 # IPFS_API_URL="https://api.pinata.cloud/pinning/pinJSONToIPFS"  # default
 
+# Leaderboard
+# Set to 'true' to enable the public earnings leaderboard endpoint.
+LEADERBOARD_ENABLED=false
+
 # Webhook Security (required for Stellar payment webhooks)
 # HMAC-SHA256 secret used to verify incoming webhook signatures
 # This must match the secret configured in your Stellar webhook provider

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "helmet": "^8.1.0",
     "ioredis": "^5.4.1",
     "nodemailer": "^8.0.4",
+    "pdfkit": "^0.15.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",

--- a/prisma/migrations/20260530_add_earning_soft_delete/migration.sql
+++ b/prisma/migrations/20260530_add_earning_soft_delete/migration.sql
@@ -1,0 +1,3 @@
+-- Add soft delete support to Earning model
+ALTER TABLE "Earning"
+  ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,14 +105,15 @@ model ClipPost {
 }
 
 model Earning {
-  id        Int      @id @default(autoincrement())
+  id        Int       @id @default(autoincrement())
   clipId    Int
   amount    Float
-  currency  String   @default("USD")
+  currency  String    @default("USD")
   date      DateTime
   source    String?
-  createdAt DateTime @default(now())
-  clip      Clip     @relation(fields: [clipId], references: [id], onDelete: Cascade)
+  createdAt DateTime  @default(now())
+  deletedAt DateTime?
+  clip      Clip      @relation(fields: [clipId], references: [id], onDelete: Cascade)
 }
 
 model UserPlatform {

--- a/src/earnings/earnings.controller.ts
+++ b/src/earnings/earnings.controller.ts
@@ -6,6 +6,7 @@ import {
   Req,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Public } from '../auth/decorators/public.decorator';
 import { EarningsService } from './earnings.service';
 import { Request } from 'express';
 
@@ -32,5 +33,12 @@ export class EarningsController {
       pageNum,
       limitNum,
     );
+  }
+
+  @Public()
+  @Get('leaderboard')
+  async getLeaderboard(@Query('limit') limit = '10') {
+    const limitNum = Math.min(parseInt(limit, 10) || 10, 100);
+    return this.earningsService.getLeaderboard(limitNum);
   }
 }

--- a/src/earnings/earnings.controller.ts
+++ b/src/earnings/earnings.controller.ts
@@ -2,7 +2,9 @@ import {
   Controller,
   UseGuards,
   Get,
+  Delete,
   Query,
+  Param,
   Req,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -31,6 +33,17 @@ export class EarningsController {
       req.user.userId,
       pageNum,
       limitNum,
+    );
+  }
+
+  @Delete(':id')
+  async deleteEarning(
+    @Req() req: RequestWithUser,
+    @Param('id') id: string,
+  ) {
+    return this.earningsService.softDelete(
+      parseInt(id, 10),
+      req.user.userId,
     );
   }
 }

--- a/src/earnings/earnings.service.spec.ts
+++ b/src/earnings/earnings.service.spec.ts
@@ -9,6 +9,8 @@ describe('EarningsService', () => {
   const mockPrismaService = {
     earning: {
       findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
     },
     payout: {
       findMany: jest.fn(),
@@ -95,6 +97,70 @@ describe('EarningsService', () => {
       const result = await service.getEarningsDashboard(1, 2, 10);
 
       expect(result.history).toEqual([]);
+    });
+
+    it('should pass deletedAt: null filter in earnings query', async () => {
+      mockPrismaService.earning.findMany.mockResolvedValue([]);
+      mockPrismaService.payout.findMany.mockResolvedValue([]);
+
+      await service.getEarningsDashboard(1);
+
+      expect(mockPrismaService.earning.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ deletedAt: null }),
+        }),
+      );
+    });
+  });
+
+  describe('softDelete', () => {
+    it('should soft-delete an earning owned by the user', async () => {
+      mockPrismaService.earning.findUnique.mockResolvedValue({
+        id: 1,
+        deletedAt: null,
+        clip: { video: { userId: 1 } },
+      });
+      mockPrismaService.earning.update.mockResolvedValue({});
+
+      const result = await service.softDelete(1, 1);
+
+      expect(result).toEqual({ message: 'Earning deleted successfully' });
+      expect(mockPrismaService.earning.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+
+    it('should throw NotFoundException if earning does not exist', async () => {
+      mockPrismaService.earning.findUnique.mockResolvedValue(null);
+
+      await expect(service.softDelete(999, 1)).rejects.toThrow(
+        'Earning 999 not found',
+      );
+    });
+
+    it('should throw NotFoundException if earning belongs to another user', async () => {
+      mockPrismaService.earning.findUnique.mockResolvedValue({
+        id: 1,
+        deletedAt: null,
+        clip: { video: { userId: 2 } },
+      });
+
+      await expect(service.softDelete(1, 1)).rejects.toThrow(
+        'Earning 1 not found',
+      );
+    });
+
+    it('should throw NotFoundException if earning is already soft-deleted', async () => {
+      mockPrismaService.earning.findUnique.mockResolvedValue({
+        id: 1,
+        deletedAt: new Date(),
+        clip: { video: { userId: 1 } },
+      });
+
+      await expect(service.softDelete(1, 1)).rejects.toThrow(
+        'Earning 1 not found',
+      );
     });
   });
 });

--- a/src/earnings/earnings.service.spec.ts
+++ b/src/earnings/earnings.service.spec.ts
@@ -97,4 +97,66 @@ describe('EarningsService', () => {
       expect(result.history).toEqual([]);
     });
   });
+
+  describe('getLeaderboard', () => {
+    it('should return empty array when LEADERBOARD_ENABLED is not true', async () => {
+      delete process.env.LEADERBOARD_ENABLED;
+
+      const result = await service.getLeaderboard();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when no earnings exist', async () => {
+      process.env.LEADERBOARD_ENABLED = 'true';
+      mockPrismaService.earning.findMany.mockResolvedValue([]);
+
+      const result = await service.getLeaderboard();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return anonymized ranked creators', async () => {
+      process.env.LEADERBOARD_ENABLED = 'true';
+      mockPrismaService.earning.findMany.mockResolvedValue([
+        { amount: 100, clip: { video: { userId: 1 } } },
+        { amount: 200, clip: { video: { userId: 2 } } },
+        { amount: 50, clip: { video: { userId: 1 } } },
+      ]);
+
+      const result = await service.getLeaderboard();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ rank: 1, label: 'Creator #1', totalEarned: 200 });
+      expect(result[1]).toEqual({ rank: 2, label: 'Creator #2', totalEarned: 150 });
+    });
+
+    it('should respect limit parameter', async () => {
+      process.env.LEADERBOARD_ENABLED = 'true';
+      mockPrismaService.earning.findMany.mockResolvedValue([
+        { amount: 100, clip: { video: { userId: 1 } } },
+        { amount: 200, clip: { video: { userId: 2 } } },
+        { amount: 300, clip: { video: { userId: 3 } } },
+      ]);
+
+      const result = await service.getLeaderboard(2);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].totalEarned).toBe(300);
+      expect(result[1].totalEarned).toBe(200);
+    });
+
+    it('should not expose user IDs in results', async () => {
+      process.env.LEADERBOARD_ENABLED = 'true';
+      mockPrismaService.earning.findMany.mockResolvedValue([
+        { amount: 100, clip: { video: { userId: 42 } } },
+      ]);
+
+      const result = await service.getLeaderboard();
+
+      const resultStr = JSON.stringify(result);
+      expect(resultStr).not.toContain('42');
+      expect(resultStr).not.toContain('userId');
+    });
+  });
 });

--- a/src/earnings/earnings.service.ts
+++ b/src/earnings/earnings.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
 export interface EarningsBreakdown {
@@ -32,7 +32,7 @@ export class EarningsService {
     limit = 20,
   ): Promise<EarningsDashboard> {
     const earnings = await this.prisma.earning.findMany({
-      where: { clip: { video: { userId } } },
+      where: { clip: { video: { userId } }, deletedAt: null },
       select: { amount: true, source: true, date: true },
     });
 
@@ -89,5 +89,29 @@ export class EarningsService {
       },
       history: paginatedHistory,
     };
+  }
+
+  async softDelete(earningId: number, userId: number): Promise<{ message: string }> {
+    const earning = await this.prisma.earning.findUnique({
+      where: { id: earningId },
+      include: { clip: { include: { video: { select: { userId: true } } } } },
+    });
+
+    if (!earning || earning.clip.video.userId !== userId) {
+      throw new NotFoundException(`Earning ${earningId} not found`);
+    }
+
+    if (earning.deletedAt !== null) {
+      throw new NotFoundException(`Earning ${earningId} not found`);
+    }
+
+    await this.prisma.earning.update({
+      where: { id: earningId },
+      data: { deletedAt: new Date() },
+    });
+
+    this.logger.log(`Soft-deleted earning ${earningId} for user ${userId}`);
+
+    return { message: 'Earning deleted successfully' };
   }
 }

--- a/src/earnings/earnings.service.ts
+++ b/src/earnings/earnings.service.ts
@@ -20,6 +20,12 @@ export interface EarningsDashboard {
   history: EarningsHistoryItem[];
 }
 
+export interface LeaderboardEntry {
+  rank: number;
+  label: string;
+  totalEarned: number;
+}
+
 @Injectable()
 export class EarningsService {
   private readonly logger = new Logger(EarningsService.name);
@@ -89,5 +95,36 @@ export class EarningsService {
       },
       history: paginatedHistory,
     };
+  }
+
+  async getLeaderboard(limit = 10): Promise<LeaderboardEntry[]> {
+    const enabled = process.env.LEADERBOARD_ENABLED === 'true';
+    if (!enabled) {
+      return [];
+    }
+
+    const earnings = await this.prisma.earning.findMany({
+      where: { deletedAt: null },
+      select: {
+        amount: true,
+        clip: { select: { video: { select: { userId: true } } } },
+      },
+    });
+
+    const totals = new Map<number, number>();
+    for (const e of earnings) {
+      const uid = e.clip.video.userId;
+      totals.set(uid, (totals.get(uid) ?? 0) + e.amount);
+    }
+
+    const sorted = Array.from(totals.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit);
+
+    return sorted.map(([, total], index) => ({
+      rank: index + 1,
+      label: `Creator #${index + 1}`,
+      totalEarned: total,
+    }));
   }
 }

--- a/src/payouts/payout-receipt.service.ts
+++ b/src/payouts/payout-receipt.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+import * as PDFDocument from 'pdfkit';
+
+export interface PayoutReceiptData {
+  payoutId: number;
+  amount: number;
+  currency: string;
+  method: string;
+  transactionId: string;
+  onChainTxHash: string | null;
+  confirmedAt: Date;
+  recipientEmail: string;
+  walletAddress: string;
+}
+
+@Injectable()
+export class PayoutReceiptService {
+  private readonly logger = new Logger(PayoutReceiptService.name);
+  private transporter: nodemailer.Transporter;
+
+  constructor() {
+    this.transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST || 'smtp.ethereal.email',
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+  }
+
+  async generateAndSendReceipt(data: PayoutReceiptData): Promise<void> {
+    try {
+      const pdfBuffer = await this.generatePdf(data);
+
+      await this.transporter.sendMail({
+        from: process.env.SMTP_FROM || '"Clips App" <noreply@clips.app>',
+        to: data.recipientEmail,
+        subject: `Payout Receipt — #${data.payoutId}`,
+        text: this.buildPlainText(data),
+        html: this.buildHtml(data),
+        attachments: [
+          {
+            filename: `payout-receipt-${data.payoutId}.pdf`,
+            content: pdfBuffer,
+            contentType: 'application/pdf',
+          },
+        ],
+      });
+
+      this.logger.log(
+        `Payout receipt sent for payout ${data.payoutId} to ${data.recipientEmail}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to send payout receipt for payout ${data.payoutId}: ${error.message}`,
+      );
+    }
+  }
+
+  private generatePdf(data: PayoutReceiptData): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const doc = new PDFDocument({ margin: 50 });
+      const chunks: Buffer[] = [];
+
+      doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+
+      // Header
+      doc.fontSize(20).text('Payout Receipt', { align: 'center' });
+      doc.moveDown();
+      doc.fontSize(10).text('Clips App', { align: 'center' });
+      doc.moveDown(2);
+
+      // Receipt details
+      doc.fontSize(12);
+
+      const details: [string, string][] = [
+        ['Payout Reference', `#${data.payoutId}`],
+        ['Amount', `${data.amount} ${data.currency}`],
+        ['Method', data.method],
+        ['Status', 'Completed'],
+        ['Date', data.confirmedAt.toISOString()],
+        ['Wallet', this.maskWallet(data.walletAddress)],
+        ['Transaction ID', data.transactionId],
+      ];
+
+      if (data.onChainTxHash) {
+        details.push(['On-Chain Hash', data.onChainTxHash]);
+      }
+
+      for (const [label, value] of details) {
+        doc.font('Helvetica-Bold').text(`${label}: `, { continued: true });
+        doc.font('Helvetica').text(value);
+        doc.moveDown(0.5);
+      }
+
+      doc.moveDown(2);
+      doc
+        .fontSize(9)
+        .fillColor('#888888')
+        .text(
+          'This receipt was automatically generated. Please keep it for your records.',
+          { align: 'center' },
+        );
+
+      doc.end();
+    });
+  }
+
+  private maskWallet(address: string): string {
+    if (address.length <= 10) return address;
+    return `${address.slice(0, 4)}...${address.slice(-6)}`;
+  }
+
+  private buildPlainText(data: PayoutReceiptData): string {
+    return [
+      `Payout Receipt — #${data.payoutId}`,
+      '',
+      `Amount: ${data.amount} ${data.currency}`,
+      `Method: ${data.method}`,
+      `Status: Completed`,
+      `Date: ${data.confirmedAt.toISOString()}`,
+      `Wallet: ${this.maskWallet(data.walletAddress)}`,
+      `Transaction ID: ${data.transactionId}`,
+      data.onChainTxHash ? `On-Chain Hash: ${data.onChainTxHash}` : '',
+      '',
+      'A PDF receipt is attached to this email.',
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private buildHtml(data: PayoutReceiptData): string {
+    return `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;">
+        <h2 style="text-align:center;color:#6366f1;">Payout Receipt</h2>
+        <table style="width:100%;border-collapse:collapse;">
+          <tr><td style="padding:8px;font-weight:bold;">Reference</td><td style="padding:8px;">#${data.payoutId}</td></tr>
+          <tr><td style="padding:8px;font-weight:bold;">Amount</td><td style="padding:8px;">${data.amount} ${data.currency}</td></tr>
+          <tr><td style="padding:8px;font-weight:bold;">Method</td><td style="padding:8px;">${data.method}</td></tr>
+          <tr><td style="padding:8px;font-weight:bold;">Status</td><td style="padding:8px;">Completed</td></tr>
+          <tr><td style="padding:8px;font-weight:bold;">Date</td><td style="padding:8px;">${data.confirmedAt.toISOString()}</td></tr>
+          <tr><td style="padding:8px;font-weight:bold;">Wallet</td><td style="padding:8px;">${this.maskWallet(data.walletAddress)}</td></tr>
+          <tr><td style="padding:8px;font-weight:bold;">Transaction ID</td><td style="padding:8px;">${data.transactionId}</td></tr>
+          ${data.onChainTxHash ? `<tr><td style="padding:8px;font-weight:bold;">On-Chain Hash</td><td style="padding:8px;">${data.onChainTxHash}</td></tr>` : ''}
+        </table>
+        <p style="color:#888;font-size:12px;text-align:center;margin-top:24px;">A PDF receipt is attached to this email.</p>
+      </div>
+    `;
+  }
+}

--- a/src/payouts/payouts.module.ts
+++ b/src/payouts/payouts.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PayoutsService } from './payouts.service';
+import { PayoutReceiptService } from './payout-receipt.service';
 import { PayoutsController } from './payouts.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { StellarModule } from '../stellar/stellar.module';
@@ -7,7 +8,7 @@ import { StellarModule } from '../stellar/stellar.module';
 @Module({
   imports: [PrismaModule, StellarModule],
   controllers: [PayoutsController],
-  providers: [PayoutsService],
+  providers: [PayoutsService, PayoutReceiptService],
   exports: [PayoutsService],
 })
 export class PayoutsModule {}

--- a/src/payouts/payouts.service.spec.ts
+++ b/src/payouts/payouts.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PayoutsService } from './payouts.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
+import { PayoutReceiptService } from './payout-receipt.service';
 import {
   ConflictException,
   BadRequestException,
@@ -34,6 +35,10 @@ describe('PayoutsService', () => {
     networkPassphrase: 'Test SDF Network ; September 2015',
   };
 
+  const mockPayoutReceiptService = {
+    generateAndSendReceipt: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -45,6 +50,10 @@ describe('PayoutsService', () => {
         {
           provide: StellarService,
           useValue: mockStellarService,
+        },
+        {
+          provide: PayoutReceiptService,
+          useValue: mockPayoutReceiptService,
         },
       ],
     }).compile();

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -9,6 +9,7 @@ import {
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
+import { PayoutReceiptService } from './payout-receipt.service';
 
 @Injectable()
 export class PayoutsService {
@@ -18,6 +19,7 @@ export class PayoutsService {
   constructor(
     private prisma: PrismaService,
     private stellarService: StellarService,
+    private payoutReceiptService: PayoutReceiptService,
   ) {
     this.minPayoutAmount = parseFloat(
       process.env.MIN_STELLAR_PAYOUT ?? '5',
@@ -196,6 +198,18 @@ export class PayoutsService {
       this.logger.log(
         `Payout ${payoutId} completed. Transaction hash: ${submitResult.hash}`,
       );
+
+      void this.payoutReceiptService.generateAndSendReceipt({
+        payoutId: payout.id,
+        amount: payout.amount,
+        currency: payout.currency,
+        method: payout.method,
+        transactionId: transaction.hash().toString('hex'),
+        onChainTxHash: submitResult.hash,
+        confirmedAt: new Date(),
+        recipientEmail: payout.user.email,
+        walletAddress: payout.wallet.address,
+      });
 
       return {
         id: payout.id,

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -54,7 +54,7 @@ export class PayoutsService {
 
     // Calculate user's pending balance from earnings
     const totalEarnings = await this.prisma.earning.aggregate({
-      where: { clip: { video: { userId } } },
+      where: { clip: { video: { userId } }, deletedAt: null },
       _sum: { amount: true },
     });
 


### PR DESCRIPTION
Closes #203
Closes #205 

---

## Summary

This PR bundles four independent enhancements for the earnings and payout systems.

---

### 1. Earnings Soft Delete

**Problem:** Earnings records could be permanently deleted, risking accidental data loss.

**Changes:**
- Added `deletedAt DateTime?` to the `Earning` model in Prisma schema
- Created migration `20260530_add_earning_soft_delete`
- Added `softDelete(earningId, userId)` to `EarningsService` with ownership checks
- Added `DELETE /earnings/:id` endpoint (JWT-protected)
- Updated all earnings queries to filter `deletedAt: null`
- Added unit tests for soft delete behavior and query filtering

---

### 2. Public Leaderboard

**Problem:** No way to showcase top creators anonymously.

**Changes:**
- Added `GET /earnings/leaderboard` public endpoint (via `@Public()` decorator)
- Added `getLeaderboard()` to `EarningsService` with:
  - `LEADERBOARD_ENABLED` env flag (opt-in)
  - Anonymized labels (`Creator #1`, `Creator #2`, etc.)
  - No exposure of user IDs or PII
  - Soft-deleted earnings excluded from calculations
- Added `LEADERBOARD_ENABLED` to `.env.example`
- Added unit tests for enabled/disabled states, ranking, and privacy verification

---

### 3. Duplicate Earnings Soft Delete Review

**Finding:** This was a duplicate of Issue #1. The repo contains a single `Earning` model — no second earnings table or path required soft delete support. Issue #1 fully satisfies the requirement.

**Action:** Documented as no-op. No additional code changes.

---

### 4. Payout PDF Receipt

**Problem:** No receipt is sent after a successful payout.

**Changes:**
- Added `pdfkit` dependency for PDF generation
- Created `PayoutReceiptService`:
  - Generates a PDF receipt with payout reference, amount, currency, method, date, wallet (masked), transaction ID, and on-chain hash
  - Sends receipt as email attachment with HTML + plain text body
  - Failures are logged but do not affect payout success state
- Integrated receipt generation into `processPayout()` as fire-and-forget after the payout is confirmed successful
- Added `PayoutReceiptService` to `PayoutsModule`
- Updated `PayoutsService` tests with receipt service mock

---

## Merge Strategy

All four branches were merged sequentially into `main`:
1. `feat/earnings-soft-delete`
2. `feat/earnings-public-leaderboard` (minor conflicts in `src/earnings/*` — resolved by keeping both features)
3. `chore/earnings-soft-delete-duplicate-review`
4. `feat/payout-pdf-receipt`

Closes #202 #203 
Closes #204  #205 


## Files Changed

| Area | Files |
|------|-------|
| Database | `prisma/schema.prisma`, `prisma/migrations/20260530_add_earning_soft_delete/migration.sql` |
| Earnings | `src/earnings/earnings.service.ts`, `src/earnings/earnings.controller.ts`, `src/earnings/earnings.service.spec.ts` |
| Payouts | `src/payouts/payouts.service.ts`, `src/payouts/payouts.module.ts`, `src/payouts/payouts.service.spec.ts`, `src/payouts/payout-receipt.service.ts` |
| Config | `.env.example`, `package.json` |
