### PR TITLE
test: add fixtures, Cloudinary mock, AuthService unit tests, wallet E2E

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
+        "pdfkit": "^0.15.0",
         "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "reflect-metadata": "^0.2.2",
@@ -3382,6 +3383,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -4848,6 +4858,22 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
@@ -5244,6 +5270,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -6065,6 +6109,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6104,6 +6154,38 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-is": {
@@ -6155,6 +6237,23 @@
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6234,6 +6333,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -6524,6 +6629,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-module-lexer": {
@@ -7271,6 +7396,32 @@
         }
       }
     },
+    "node_modules/fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7452,6 +7603,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7703,6 +7863,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7938,6 +8110,20 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ioredis": {
       "version": "5.10.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
@@ -7971,6 +8157,39 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -7978,11 +8197,58 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8042,6 +8308,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8050,6 +8328,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-promise": {
@@ -8065,6 +8359,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
@@ -8075,6 +8387,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -8088,6 +8427,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typed-array": {
@@ -8116,6 +8488,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -9047,6 +9447,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9223,6 +9630,25 @@
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
       "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
       "license": "MIT"
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -9973,6 +10399,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -10106,6 +10577,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10304,6 +10781,19 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
+    "node_modules/pdfkit": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.2.tgz",
+      "integrity": "sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -10430,6 +10920,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/pngjs": {
@@ -10914,6 +11412,26 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/remeda": {
       "version": "2.33.4",
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
@@ -11016,6 +11534,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -11070,6 +11594,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -11176,6 +11717,21 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
       },
       "engines": {
@@ -11537,6 +12093,19 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/streamifier": {
       "version": "0.1.1",
@@ -12002,6 +12571,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.4",
@@ -12519,6 +13094,32 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -12942,6 +13543,43 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {

--- a/src/__mocks__/cloudinary.ts
+++ b/src/__mocks__/cloudinary.ts
@@ -1,0 +1,41 @@
+/**
+ * Reusable Jest manual mock for the `cloudinary` package.
+ * Place this file at src/__mocks__/cloudinary.ts so Jest auto-resolves it
+ * whenever a module does `import { v2 as cloudinary } from 'cloudinary'`.
+ *
+ * Usage in tests:
+ *   jest.mock('cloudinary');
+ *   import { v2 as cloudinary } from 'cloudinary';
+ *   (cloudinary.uploader.upload_stream as jest.Mock).mockImplementation(...)
+ */
+
+export const FAKE_SECURE_URL = 'https://res.cloudinary.com/demo/video/upload/clips/test-clip.mp4';
+export const FAKE_PUBLIC_ID = 'clips/test-clip';
+
+/** Default successful upload result returned by upload_stream mock. */
+export const defaultUploadResult = {
+  secure_url: FAKE_SECURE_URL,
+  public_id: FAKE_PUBLIC_ID,
+  resource_type: 'video',
+};
+
+const v2 = {
+  config: jest.fn(),
+  uploader: {
+    /**
+     * Simulates a successful upload by default.
+     * Override per-test:
+     *   (cloudinary.uploader.upload_stream as jest.Mock).mockImplementation(
+     *     (opts, cb) => { cb(new Error('fail'), null); return { on: jest.fn() }; }
+     *   );
+     */
+    upload_stream: jest.fn().mockImplementation((_options, callback) => {
+      callback(null, defaultUploadResult);
+      return { on: jest.fn() };
+    }),
+    destroy: jest.fn().mockResolvedValue({ result: 'ok' }),
+  },
+};
+
+export { v2 };
+export default { v2 };

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,287 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { JwtService } from '@nestjs/jwt';
+import { EmailDeliveryService } from './email-delivery.service';
+import { DeviceFingerprintService } from './device-fingerprint.service';
+import { BruteForceProtectionService } from './brute-force-protection.service';
+import { EncryptionService } from '../encryption/encryption.service';
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Keypair: {
+    random: jest.fn(() => ({
+      publicKey: () => 'GPUBLICKEY',
+      secret: () => 'SSECRETKEY',
+    })),
+  },
+}));
+
+const mockPrisma = {
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  refreshToken: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+  },
+  emailVerificationToken: {
+    create: jest.fn(),
+  },
+};
+
+const mockJwt = { sign: jest.fn().mockReturnValue('mock.jwt.token') };
+
+const mockEmailDelivery = { enqueue: jest.fn() };
+
+const mockDeviceFingerprint = {
+  compareFingerprints: jest.fn().mockReturnValue(true),
+};
+
+const mockBruteForce = {
+  recordFailedAttempt: jest.fn().mockResolvedValue({
+    isLocked: false,
+    remainingAttempts: 4,
+    lockoutTimeLeft: 0,
+  }),
+  clearFailedAttempts: jest.fn(),
+};
+
+const mockEncryption = { encrypt: jest.fn().mockReturnValue('encrypted-secret') };
+
+async function buildService(): Promise<AuthService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      AuthService,
+      { provide: PrismaService, useValue: mockPrisma },
+      { provide: JwtService, useValue: mockJwt },
+      { provide: EmailDeliveryService, useValue: mockEmailDelivery },
+      { provide: DeviceFingerprintService, useValue: mockDeviceFingerprint },
+      { provide: BruteForceProtectionService, useValue: mockBruteForce },
+      { provide: EncryptionService, useValue: mockEncryption },
+    ],
+  }).compile();
+  return module.get<AuthService>(AuthService);
+}
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    service = await buildService();
+  });
+
+  // ─── signup ────────────────────────────────────────────────────────────────
+
+  describe('signup', () => {
+    const dto = { name: 'Alice', email: 'alice@example.com', password: 'Str0ng!Pass' };
+
+    it('throws BadRequestException when email is already registered', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, email: dto.email });
+      await expect(service.signup(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('creates user, hashes password, and returns tokens', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({
+        id: 1,
+        email: dto.email,
+        name: dto.name,
+        picture: null,
+        emailVerified: null,
+      });
+      mockPrisma.user.update.mockResolvedValue({});
+      mockPrisma.emailVerificationToken.create.mockResolvedValue({});
+      mockPrisma.refreshToken.create.mockResolvedValue({});
+
+      const result = await service.signup(dto);
+
+      expect(result.user.email).toBe(dto.email);
+      expect(result.tokens.accessToken).toBe('mock.jwt.token');
+      expect(result.tokens.refreshToken).toBeDefined();
+
+      // Password must be hashed before persisting
+      const createCall = mockPrisma.user.create.mock.calls[0][0];
+      expect(createCall.data.password).not.toBe(dto.password);
+      const isHashed = await bcrypt.compare(dto.password, createCall.data.password);
+      expect(isHashed).toBe(true);
+    });
+
+    it('enqueues a verification email after signup', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({
+        id: 2,
+        email: dto.email,
+        name: dto.name,
+        picture: null,
+        emailVerified: null,
+      });
+      mockPrisma.user.update.mockResolvedValue({});
+      mockPrisma.emailVerificationToken.create.mockResolvedValue({});
+      mockPrisma.refreshToken.create.mockResolvedValue({});
+
+      await service.signup(dto);
+
+      expect(mockEmailDelivery.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ to: dto.email, template: 'verification' }),
+      );
+    });
+  });
+
+  // ─── login ─────────────────────────────────────────────────────────────────
+
+  describe('login', () => {
+    const password = 'Str0ng!Pass';
+    let hashedPassword: string;
+
+    beforeAll(async () => {
+      hashedPassword = await bcrypt.hash(password, 10);
+    });
+
+    const baseUser = () => ({
+      id: 1,
+      email: 'alice@example.com',
+      password: hashedPassword,
+      name: 'Alice',
+      picture: null,
+      emailVerified: new Date(),
+      mfaEnabled: false,
+      mfaSecret: null,
+    });
+
+    it('throws UnauthorizedException for unknown email', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      await expect(
+        service.login({ email: 'nobody@example.com', password }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException for wrong password', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(baseUser());
+      await expect(
+        service.login({ email: 'alice@example.com', password: 'WrongPass1!' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('returns user and tokens on valid credentials', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(baseUser());
+      mockPrisma.refreshToken.create.mockResolvedValue({});
+      mockBruteForce.clearFailedAttempts.mockResolvedValue(undefined);
+
+      const result = await service.login({ email: 'alice@example.com', password });
+
+      expect(result.user.email).toBe('alice@example.com');
+      expect(result.tokens.accessToken).toBe('mock.jwt.token');
+      expect(result.tokens.refreshToken).toBeDefined();
+    });
+
+    it('clears brute-force counter on successful login', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(baseUser());
+      mockPrisma.refreshToken.create.mockResolvedValue({});
+      mockBruteForce.clearFailedAttempts.mockResolvedValue(undefined);
+
+      await service.login({ email: 'alice@example.com', password });
+
+      expect(mockBruteForce.clearFailedAttempts).toHaveBeenCalledWith('alice@example.com');
+    });
+
+    it('records failed attempt on wrong password', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(baseUser());
+
+      await expect(
+        service.login({ email: 'alice@example.com', password: 'BadPass1!' }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(mockBruteForce.recordFailedAttempt).toHaveBeenCalledWith('alice@example.com');
+    });
+
+    it('throws UnauthorizedException with lockout message when account is locked', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(baseUser());
+      mockBruteForce.recordFailedAttempt.mockResolvedValue({
+        isLocked: true,
+        lockoutTimeLeft: 120,
+        remainingAttempts: 0,
+      });
+
+      await expect(
+        service.login({ email: 'alice@example.com', password: 'BadPass1!' }),
+      ).rejects.toThrow(/locked/i);
+    });
+  });
+
+  // ─── refreshTokens ─────────────────────────────────────────────────────────
+
+  describe('refreshTokens', () => {
+    const rawToken = 'some-raw-refresh-token';
+    const storedToken = {
+      id: 10,
+      userId: 1,
+      tokenHash: 'will-be-overridden',
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      userAgentHash: null,
+      ipAddress: null,
+      acceptLanguage: null,
+      user: {
+        id: 1,
+        email: 'alice@example.com',
+        emailVerified: new Date(),
+      },
+    };
+
+    it('throws UnauthorizedException for unknown token', async () => {
+      mockPrisma.refreshToken.findUnique.mockResolvedValue(null);
+      await expect(service.refreshTokens(rawToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException for revoked token', async () => {
+      mockPrisma.refreshToken.findUnique.mockResolvedValue({
+        ...storedToken,
+        revokedAt: new Date(),
+      });
+      await expect(service.refreshTokens(rawToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException for expired token', async () => {
+      mockPrisma.refreshToken.findUnique.mockResolvedValue({
+        ...storedToken,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      await expect(service.refreshTokens(rawToken)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('rotates token and returns new tokens on valid input', async () => {
+      mockPrisma.refreshToken.findUnique.mockResolvedValue(storedToken);
+      mockPrisma.refreshToken.update.mockResolvedValue({});
+      mockPrisma.refreshToken.create.mockResolvedValue({});
+
+      const result = await service.refreshTokens(rawToken);
+
+      expect(result.accessToken).toBe('mock.jwt.token');
+      expect(result.refreshToken).toBeDefined();
+      // Old token must be revoked
+      expect(mockPrisma.refreshToken.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: storedToken.id },
+          data: expect.objectContaining({ revokedAt: expect.any(Date) }),
+        }),
+      );
+    });
+  });
+});

--- a/test/__mocks__/cockatiel.js
+++ b/test/__mocks__/cockatiel.js
@@ -1,0 +1,16 @@
+// Minimal stub for the cockatiel ESM package used by CircuitBreakerService.
+// This allows e2e tests to run without needing ESM support in Jest.
+const noop = () => {};
+const passthrough = (fn) => fn();
+
+module.exports = {
+  circuitBreaker: () => ({ execute: passthrough, onBreak: noop, onReset: noop }),
+  SamplingBreaker: class SamplingBreaker {},
+  CircuitBreakerPolicy: class CircuitBreakerPolicy {
+    execute(fn) { return fn(); }
+    onBreak() {}
+    onReset() {}
+  },
+  ConsecutiveBreaker: class ConsecutiveBreaker {},
+  handleAll: { orWhenResult: () => ({}) },
+};

--- a/test/fixtures/clip.fixture.ts
+++ b/test/fixtures/clip.fixture.ts
@@ -1,0 +1,44 @@
+import { Clip } from '../../src/clips/clip.entity';
+
+export function buildClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: 'clip-fixture-001',
+    videoId: 'video-fixture-001',
+    userId: 'user-fixture-001',
+    startTime: 30,
+    endTime: 75,
+    duration: 45,
+    positionRatio: 0.25,
+    transcript: 'This is a sample transcript for the clip fixture.',
+    viralityScore: 72,
+    clipUrl: 'https://res.cloudinary.com/demo/video/upload/clips/clip-fixture-001.mp4',
+    thumbnail: 'https://res.cloudinary.com/demo/video/upload/so_50p/clips/clip-fixture-001.jpg',
+    status: 'success',
+    error: undefined,
+    localFilePath: undefined,
+    selected: false,
+    postStatus: null,
+    caption: '🔥 Check out this viral moment! #shorts #viral',
+    royaltyBps: 1000,
+    createdAt: new Date('2026-01-15T10:05:00.000Z'),
+    updatedAt: new Date('2026-01-15T10:06:00.000Z'),
+    ...overrides,
+  };
+}
+
+export function buildClipList(
+  count: number,
+  overrides: Partial<Clip> = {},
+): Clip[] {
+  return Array.from({ length: count }, (_, i) =>
+    buildClip({
+      id: `clip-fixture-${String(i + 1).padStart(3, '0')}`,
+      startTime: i * 60,
+      endTime: i * 60 + 45,
+      positionRatio: i / Math.max(count, 1),
+      viralityScore: Math.round(40 + Math.random() * 55),
+      createdAt: new Date(Date.now() - i * 30_000),
+      ...overrides,
+    }),
+  );
+}

--- a/test/fixtures/video.fixture.ts
+++ b/test/fixtures/video.fixture.ts
@@ -1,0 +1,26 @@
+import { Video, VideoStatus } from '../../src/videos/video.entity';
+
+export function buildVideo(overrides: Partial<Video> = {}): Video {
+  return {
+    id: 'video-fixture-001',
+    userId: 'user-fixture-001',
+    status: 'done' as VideoStatus,
+    processingError: null,
+    createdAt: new Date('2026-01-15T10:00:00.000Z'),
+    updatedAt: new Date('2026-01-15T10:05:00.000Z'),
+    ...overrides,
+  };
+}
+
+export function buildVideoList(
+  count: number,
+  overrides: Partial<Video> = {},
+): Video[] {
+  return Array.from({ length: count }, (_, i) =>
+    buildVideo({
+      id: `video-fixture-${String(i + 1).padStart(3, '0')}`,
+      createdAt: new Date(Date.now() - i * 60_000),
+      ...overrides,
+    }),
+  );
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^cockatiel$": "<rootDir>/__mocks__/cockatiel.js"
   }
 }

--- a/test/wallet-connection.e2e-spec.ts
+++ b/test/wallet-connection.e2e-spec.ts
@@ -1,0 +1,226 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe, ExecutionContext } from '@nestjs/common';
+import request from 'supertest';
+import { WalletsService } from '../src/wallets/wallets.service';
+import { WalletsController } from '../src/wallets/wallets.controller';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { StellarService } from '../src/stellar/stellar.service';
+import { JwtAuthGuard } from '../src/auth/guards/jwt-auth.guard';
+import { WalletOwnershipGuard } from '../src/wallets/guards/wallet-ownership.guard';
+
+/**
+ * E2E / integration tests for the wallet connection flow.
+ *
+ * Guards are overridden so we can control authentication state without
+ * needing a real JWT or database. This lets us test the full HTTP layer
+ * (routing, validation, service logic) in isolation.
+ */
+
+const VALID_STELLAR_ADDRESS = 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3';
+const USER_ID = 42;
+
+const mockPrisma = {
+  wallet: {
+    findUnique: jest.fn(),
+    upsert: jest.fn(),
+    update: jest.fn(),
+  },
+  payout: {
+    findFirst: jest.fn(),
+  },
+};
+
+const mockStellarService = {
+  validateAddress: jest.fn(),
+};
+
+/** Guard that simulates an authenticated user. */
+class AuthenticatedGuard {
+  canActivate(ctx: ExecutionContext) {
+    const req = ctx.switchToHttp().getRequest();
+    req.user = { userId: USER_ID, email: 'user@example.com' };
+    return true;
+  }
+}
+
+/** Guard that simulates an unauthenticated request (returns 401). */
+class UnauthenticatedGuard {
+  canActivate() {
+    return false; // NestJS returns 403 by default; we'll use AuthGuard behaviour
+  }
+}
+
+describe('Wallet connection flow (E2E)', () => {
+  let app: INestApplication;
+  let authedApp: INestApplication;
+
+  /** Build an app with the given JwtAuthGuard override. */
+  async function buildApp(jwtGuardOverride: any): Promise<INestApplication> {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [WalletsController],
+      providers: [
+        WalletsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: StellarService, useValue: mockStellarService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useClass(jwtGuardOverride)
+      .overrideGuard(WalletOwnershipGuard)
+      .useClass(AuthenticatedGuard) // ownership guard always passes in authed context
+      .compile();
+
+    const a = moduleFixture.createNestApplication();
+    a.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await a.init();
+    return a;
+  }
+
+  beforeAll(async () => {
+    authedApp = await buildApp(AuthenticatedGuard);
+  });
+
+  afterAll(async () => {
+    await authedApp.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ─── POST /wallets/connect ─────────────────────────────────────────────────
+
+  describe('POST /wallets/connect', () => {
+    it('returns 401 when JWT guard rejects the request', async () => {
+      const unauthApp = await buildApp(UnauthenticatedGuard);
+      try {
+        await request(unauthApp.getHttpServer())
+          .post('/wallets/connect')
+          .send({ address: VALID_STELLAR_ADDRESS, chain: 'stellar', type: 'freighter' })
+          .expect(403); // NestJS returns 403 when canActivate returns false
+      } finally {
+        await unauthApp.close();
+      }
+    });
+
+    it('returns 400 for invalid Stellar address', async () => {
+      mockStellarService.validateAddress.mockReturnValue({ valid: false });
+
+      await request(authedApp.getHttpServer())
+        .post('/wallets/connect')
+        .send({ address: 'not-a-valid-address', chain: 'stellar', type: 'freighter' })
+        .expect(400);
+    });
+
+    it('returns 400 for unsupported chain', async () => {
+      await request(authedApp.getHttpServer())
+        .post('/wallets/connect')
+        .send({ address: VALID_STELLAR_ADDRESS, chain: 'ethereum', type: 'freighter' })
+        .expect(400);
+    });
+
+    it('returns 400 for unsupported wallet type', async () => {
+      await request(authedApp.getHttpServer())
+        .post('/wallets/connect')
+        .send({ address: VALID_STELLAR_ADDRESS, chain: 'stellar', type: 'metamask' })
+        .expect(400);
+    });
+
+    it('creates a DB record and returns the wallet on valid input', async () => {
+      mockStellarService.validateAddress.mockReturnValue({ valid: true });
+      const createdWallet = {
+        id: 1,
+        userId: USER_ID,
+        address: VALID_STELLAR_ADDRESS,
+        chain: 'stellar',
+        type: 'freighter',
+        deletedAt: null,
+      };
+      mockPrisma.wallet.upsert.mockResolvedValue(createdWallet);
+
+      const res = await request(authedApp.getHttpServer())
+        .post('/wallets/connect')
+        .send({ address: VALID_STELLAR_ADDRESS, chain: 'stellar', type: 'freighter' })
+        .expect(200);
+
+      expect(res.body.id).toBe(1);
+      expect(res.body.address).toBe(VALID_STELLAR_ADDRESS);
+
+      // Verify the DB upsert was called with the correct userId
+      expect(mockPrisma.wallet.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ userId: USER_ID }),
+        }),
+      );
+    });
+
+    it('reactivates a previously disconnected wallet (duplicate prevention via upsert)', async () => {
+      mockStellarService.validateAddress.mockReturnValue({ valid: true });
+      const reactivatedWallet = {
+        id: 2,
+        userId: USER_ID,
+        address: VALID_STELLAR_ADDRESS,
+        chain: 'stellar',
+        type: 'freighter',
+        deletedAt: null,
+      };
+      mockPrisma.wallet.upsert.mockResolvedValue(reactivatedWallet);
+
+      const res = await request(authedApp.getHttpServer())
+        .post('/wallets/connect')
+        .send({ address: VALID_STELLAR_ADDRESS, chain: 'stellar', type: 'freighter' })
+        .expect(200);
+
+      // The upsert update payload must clear deletedAt to reactivate
+      expect(mockPrisma.wallet.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({ deletedAt: null }),
+        }),
+      );
+      expect(res.body.deletedAt).toBeNull();
+    });
+  });
+
+  // ─── DELETE /wallets/:id ───────────────────────────────────────────────────
+
+  describe('DELETE /wallets/:id', () => {
+    it('returns 403 when JWT guard rejects the request', async () => {
+      const unauthApp = await buildApp(UnauthenticatedGuard);
+      try {
+        await request(unauthApp.getHttpServer()).delete('/wallets/1').expect(403);
+      } finally {
+        await unauthApp.close();
+      }
+    });
+
+    it('returns 404 when wallet does not belong to the user', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue({
+        id: 1,
+        userId: 999, // different user
+        deletedAt: null,
+      });
+      mockPrisma.payout.findFirst.mockResolvedValue(null);
+
+      await request(authedApp.getHttpServer())
+        .delete('/wallets/1')
+        .expect(404);
+    });
+
+    it('soft-deletes the wallet and returns success', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue({
+        id: 1,
+        userId: USER_ID,
+        deletedAt: null,
+      });
+      mockPrisma.payout.findFirst.mockResolvedValue(null);
+      mockPrisma.wallet.update.mockResolvedValue({ id: 1, deletedAt: new Date() });
+
+      const res = await request(authedApp.getHttpServer())
+        .delete('/wallets/1')
+        .expect(200);
+
+      expect(res.body.message).toMatch(/disconnected/i);
+      expect(res.body.walletId).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves all four open testing issues in one commit.

### Changes

| File | Issue |
|------|-------|
| `test/fixtures/video.fixture.ts` | #241 |
| `test/fixtures/clip.fixture.ts` | #241 |
| `src/__mocks__/cloudinary.ts` | #243 |
| `src/auth/auth.service.spec.ts` | #244 |
| `test/wallet-connection.e2e-spec.ts` | #242 |
| `test/__mocks__/cockatiel.js` | #242 (e2e infra) |
| `test/jest-e2e.json` | #242 (e2e infra) |

### Details

**#241 – Test fixtures for Video and Clip models**
- `buildVideo` / `buildVideoList` factory with realistic defaults
- `buildClip` / `buildClipList` factory with virality scores, timestamps, royaltyBps

**#243 – Reusable Cloudinary mock**
- `src/__mocks__/cloudinary.ts` auto-resolved by Jest when any module does `import { v2 as cloudinary } from 'cloudinary'`
- Mocks `upload_stream` (default success) and `destroy`; exports `defaultUploadResult` and URL helpers

**#244 – AuthService unit tests (13 tests)**
- `signup`: duplicate email rejection, bcrypt hashing, verification email enqueue
- `login`: unknown user, wrong password, success, brute-force tracking, lockout message
- `refreshTokens`: invalid/revoked/expired token, token rotation

**#242 – Wallet connection E2E tests (9 tests)**
- `POST /wallets/connect`: unauthenticated (403), invalid address (400), unsupported chain/type (400), successful upsert, reactivation of soft-deleted wallet
- `DELETE /wallets/:id`: unauthenticated (403), wrong owner (404), successful soft-delete
- Fixed `test/jest-e2e.json` to stub the ESM-only `cockatiel` package via `moduleNameMapper`

### Test results
- Unit tests: **13/13 passing**
- E2E tests: **9/9 passing**

Closes #241
Closes #242
Closes #243
Closes #244