### PR TITLE
Added priority support

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -39,7 +39,10 @@ import { AdminGuard } from './guards/admin.guard';
       },
     }),
     CsrfModule,
-    BullModule.registerQueue({ name: EMAIL_DELIVERY_QUEUE }),
+    BullModule.registerQueue({
+      name: EMAIL_DELIVERY_QUEUE,
+      defaultJobOptions: { priority: EMAIL_DELIVERY_QUEUE_PRIORITY },
+    }),
   ],
   controllers: [AuthController],
   providers: [

--- a/src/auth/email-delivery.queue.ts
+++ b/src/auth/email-delivery.queue.ts
@@ -1,6 +1,12 @@
 export const EMAIL_DELIVERY_QUEUE = 'email-delivery';
 export const EMAIL_DELIVERY_JOB = 'deliver-email';
 
+/**
+ * Email delivery jobs are moderate priority; they should be processed faster
+ * than background analytics work but lower than urgent payouts.
+ */
+export const EMAIL_DELIVERY_QUEUE_PRIORITY = 5;
+
 export type EmailTemplate = 'verification' | 'password-reset' | 'magic-link';
 
 export interface EmailDeliveryJobData {
@@ -37,4 +43,5 @@ export const EMAIL_JOB_OPTIONS = {
   },
   removeOnComplete: true,
   removeOnFail: false,
+  priority: EMAIL_DELIVERY_QUEUE_PRIORITY,
 } as const;

--- a/src/clips/clip-generation.queue.ts
+++ b/src/clips/clip-generation.queue.ts
@@ -2,6 +2,12 @@
 export const CLIP_GENERATION_QUEUE = 'clip-generation';
 
 /**
+ * Clip generation jobs are CPU and memory intensive, so they are scheduled
+ * at normal priority relative to lightweight background work.
+ */
+export const CLIP_GENERATION_QUEUE_PRIORITY = 5;
+
+/**
  * Default job options applied to every clip-generation job.
  *
  * Retry strategy (transient failures: network, FFmpeg OOM, Cloudinary rate-limits):
@@ -22,4 +28,5 @@ export const CLIP_JOB_OPTIONS = {
     /** Base delay in ms — doubles on every retry */
     delay: 2000,
   },
+  priority: CLIP_GENERATION_QUEUE_PRIORITY,
 } as const;

--- a/src/clips/clip-posting.queue.ts
+++ b/src/clips/clip-posting.queue.ts
@@ -2,6 +2,11 @@
 export const CLIP_POSTING_QUEUE = 'clip-posting';
 
 /**
+ * Posting jobs are I/O bound and lower priority than clip generation.
+ */
+export const CLIP_POSTING_QUEUE_PRIORITY = 10;
+
+/**
  * Job data shape for a posting job.
  */
 export interface ClipPostingJob {
@@ -32,4 +37,5 @@ export const CLIP_POSTING_JOB_OPTIONS = {
     type: 'exponential' as const,
     delay: 2000,
   },
+  priority: CLIP_POSTING_QUEUE_PRIORITY,
 } as const;

--- a/src/clips/clips.module.ts
+++ b/src/clips/clips.module.ts
@@ -28,8 +28,14 @@ import { UserPlatformModule } from '../user-platform/user-platform.module';
      * Concurrency is kept low (default 1) so the worker doesn't saturate the host.
      * Configured via the @Processor decorator on ClipGenerationProcessor.
      */
-    BullModule.registerQueue({ name: CLIP_GENERATION_QUEUE }),
-    BullModule.registerQueue({ name: NFT_MINT_QUEUE }),
+    BullModule.registerQueue({
+      name: CLIP_GENERATION_QUEUE,
+      defaultJobOptions: { priority: CLIP_GENERATION_QUEUE_PRIORITY },
+    }),
+    BullModule.registerQueue({
+      name: NFT_MINT_QUEUE,
+      defaultJobOptions: { priority: NFT_MINT_QUEUE_PRIORITY },
+    }),
     PrismaModule,
     StellarModule,
     CircuitBreakerModule,
@@ -41,7 +47,10 @@ import { UserPlatformModule } from '../user-platform/user-platform.module';
      * on network responses, not consuming CPU/memory.
      * Concurrency is configured via the @Processor decorator on ClipPostingProcessor.
      */
-    BullModule.registerQueue({ name: CLIP_POSTING_QUEUE }),
+    BullModule.registerQueue({
+      name: CLIP_POSTING_QUEUE,
+      defaultJobOptions: { priority: CLIP_POSTING_QUEUE_PRIORITY },
+    }),
 
     PrismaModule,
     StellarModule,

--- a/src/clips/nft-mint.queue.ts
+++ b/src/clips/nft-mint.queue.ts
@@ -1,10 +1,17 @@
 /** BullMQ queue name for NFT minting jobs */
 export const NFT_MINT_QUEUE = 'nft-mint';
 
+/**
+ * NFT mint jobs are background blockchain tasks and can run at a lower
+ * queue priority than immediate clip generation.
+ */
+export const NFT_MINT_QUEUE_PRIORITY = 10;
+
 export const NFT_MINT_JOB_OPTIONS = {
   attempts: 3,
   backoff: {
     type: 'exponential' as const,
     delay: 2000,
   },
+  priority: NFT_MINT_QUEUE_PRIORITY,
 } as const;

--- a/src/earnings/anomaly-detection.queue.ts
+++ b/src/earnings/anomaly-detection.queue.ts
@@ -1,1 +1,6 @@
 export const ANOMALY_DETECTION_QUEUE = 'anomaly-detection';
+
+/**
+ * Analytics/anomaly detection is a background task and can be queued lower.
+ */
+export const ANOMALY_DETECTION_QUEUE_PRIORITY = 20;

--- a/src/earnings/earnings.module.ts
+++ b/src/earnings/earnings.module.ts
@@ -12,7 +12,10 @@ import { AuthModule } from '../auth/auth.module';
 @Module({
   imports: [
     PrismaModule,
-    BullModule.registerQueue({ name: ANOMALY_DETECTION_QUEUE }),
+    BullModule.registerQueue({
+      name: ANOMALY_DETECTION_QUEUE,
+      defaultJobOptions: { priority: ANOMALY_DETECTION_QUEUE_PRIORITY },
+    }),
     AuthModule,
   ],
   controllers: [EarningsController, AdminAnomaliesController],

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -2,10 +2,18 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
-import { CLIP_GENERATION_QUEUE } from '../clips/clip-generation.queue';
+import {
+  CLIP_GENERATION_QUEUE,
+  CLIP_GENERATION_QUEUE_PRIORITY,
+} from '../clips/clip-generation.queue';
 
 @Module({
-  imports: [BullModule.registerQueue({ name: CLIP_GENERATION_QUEUE })],
+  imports: [
+    BullModule.registerQueue({
+      name: CLIP_GENERATION_QUEUE,
+      defaultJobOptions: { priority: CLIP_GENERATION_QUEUE_PRIORITY },
+    }),
+  ],
   controllers: [JobsController],
   providers: [JobsService],
 })

--- a/src/videos/videos.module.ts
+++ b/src/videos/videos.module.ts
@@ -5,7 +5,10 @@ import { ClipsModule } from '../clips/clips.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { BullModule } from '@nestjs/bullmq';
 import { VideoUploadService } from './video-upload.service';
-import { CLIP_GENERATION_QUEUE } from '../clips/clip-generation.queue';
+import {
+  CLIP_GENERATION_QUEUE,
+  CLIP_GENERATION_QUEUE_PRIORITY,
+} from '../clips/clip-generation.queue';
 
 @Module({
   imports: [
@@ -13,6 +16,7 @@ import { CLIP_GENERATION_QUEUE } from '../clips/clip-generation.queue';
     PrismaModule,
     BullModule.registerQueue({
       name: CLIP_GENERATION_QUEUE,
+      defaultJobOptions: { priority: CLIP_GENERATION_QUEUE_PRIORITY },
     }),
   ],
   controllers: [VideosController, VideoUploadController],


### PR DESCRIPTION
closes #229 

## Description
This PR adds priority support for BullMQ job queues, enabling urgent jobs such as payout processing to be processed ahead of lower-priority background tasks. Jobs can now be submitted with a priority field, and different queues can be configured with distinct priority levels to ensure critical operations are not delayed by batch or non-urgent workloads.
