### PR TITLE
test: fix unit tests for ClipGenerationProcessor and shared stellar-sdk mocks

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -12,14 +12,7 @@ import { DeviceFingerprintService } from './device-fingerprint.service';
 import { BruteForceProtectionService } from './brute-force-protection.service';
 import { EncryptionService } from '../encryption/encryption.service';
 
-jest.mock('@stellar/stellar-sdk', () => ({
-  Keypair: {
-    random: jest.fn(() => ({
-      publicKey: () => 'GPUBLICKEY',
-      secret: () => 'SSECRETKEY',
-    })),
-  },
-}));
+jest.mock('@stellar/stellar-sdk', () => require('../../test/mocks/stellar-sdk.mock'));
 
 const mockPrisma = {
   user: {

--- a/src/clips/clip-generation.processor.spec.ts
+++ b/src/clips/clip-generation.processor.spec.ts
@@ -65,7 +65,12 @@ function makeJob(
 function makeProcessor() {
   const emitter = new EventEmitter2();
   const cloudinaryService = new MockCloudinaryService();
-  const clipsGateway = { emitProgressToUser: jest.fn() };
+  const clipsGateway = {
+    emitProgressToUser: jest.fn(),
+    emitProgress: jest.fn(),
+    emitCompleted: jest.fn(),
+    emitFailed: jest.fn(),
+  };
   const clipsService = {
     _registerJobController: jest.fn(),
     _clearJobController: jest.fn(),
@@ -77,6 +82,11 @@ function makeProcessor() {
   const metricsService = {
     incrementClipsGenerated: jest.fn(),
   };
+  const prisma = {
+    video: {
+      findUnique: jest.fn().mockResolvedValue({ userId: 1 }),
+    },
+  };
   jest.spyOn(emitter, 'emit');
   jest.spyOn(cloudinaryService, 'uploadVideoFromBuffer');
   jest.spyOn(cloudinaryService, 'deleteLocalFile');
@@ -86,8 +96,9 @@ function makeProcessor() {
     clipsGateway as any,
     clipsService as any,
     metricsService as any,
+    prisma as any,
   );
-  return { processor, emitter, cloudinaryService, clipsService };
+  return { processor, emitter, cloudinaryService, clipsService, prisma };
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/subscriptions/stellar-payment.service.spec.ts
+++ b/src/subscriptions/stellar-payment.service.spec.ts
@@ -9,17 +9,7 @@ jest.mock('../prisma/prisma.service', () => ({
   PrismaService: class PrismaService {},
 }));
 
-jest.mock('@stellar/stellar-sdk', () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation(() => ({
-    transactionsTransaction: jest.fn(),
-  })),
-  TransactionBuilder: jest.fn(),
-  Networks: {},
-  Operation: {},
-  Asset: {},
-  Horizon: { Server: jest.fn() },
-}));
+jest.mock('@stellar/stellar-sdk', () => require('../../test/mocks/stellar-sdk.mock'));
 
 describe('StellarPaymentService', () => {
   let service: StellarPaymentService;


### PR DESCRIPTION
## Summary

Fixes 4 open testing issues in one commit.

### Changes

**#258 / #259 — ClipGenerationProcessor unit tests**
- Added missing `PrismaService` argument to `ClipGenerationProcessor` constructor in spec (was causing TS2554 compile error)
- Added `emitFailed`, `emitCompleted`, `emitProgress` to the `clipsGateway` mock (were missing, causing runtime errors in `onFailed`/`onCompleted` tests)

**#257 — Shared stellar-sdk mock**
- Replaced inline `jest.mock('@stellar/stellar-sdk', ...)` in `stellar-payment.service.spec.ts` with the shared `test/mocks/stellar-sdk.mock.ts`
- Replaced inline `jest.mock('@stellar/stellar-sdk', ...)` in `auth.service.spec.ts` with the shared mock

**#256 — Prisma + BullMQ integration tests**
- Already passing — no changes needed.

Closes #256
Closes #257
Closes #258
Closes #259