### PR TITLE
refactor: break ClipGenerationProcessor into smaller private methods

### DIFF
--- a/src/clips/clip-generation.processor.ts
+++ b/src/clips/clip-generation.processor.ts
@@ -19,6 +19,7 @@ import { ClipsService } from './clips.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { PrismaService } from '../prisma/prisma.service';
 import type { VideoService } from '../videos/video.service';
+import { getBullMQWorkerConfig } from '../config/bullmq.config';
 
 export interface ClipGenerationJob {
   videoId: string;
@@ -58,6 +59,9 @@ const PROGRESS = {
   DONE: 100,
 } as const;
 
+/** Job timeout: 30 minutes */
+const JOB_TIMEOUT_MS = 30 * 60 * 1000;
+
 /**
  * BullMQ processor for clip-generation jobs.
  *
@@ -67,19 +71,6 @@ const PROGRESS = {
  * Retry configuration (set per-job in ClipsService.enqueueClip via CLIP_JOB_OPTIONS):
  *   attempts : 5   — 1 initial attempt + 4 automatic retries
  *   backoff  : exponential, starting at 2 000 ms
- *              attempt 2 → ~2 000 ms wait
- *              attempt 3 → ~4 000 ms wait
- *              attempt 4 → ~8 000 ms wait
- *              attempt 5 → ~16 000 ms wait
- *
- * After FFmpeg cuts a clip, uploads to Cloudinary for reliable CDN delivery:
- *   1. Uploads video buffer using upload_stream
- *   2. Generates auto-thumbnail at 50% video position
- *   3. Deletes local temporary file after success
- *   4. Handles errors with BullMQ retries (exponential backoff)
- *
- * After all 5 attempts fail, BullMQ moves the job to the failed set and
- * fires the 'failed' worker event, handled by @OnWorkerEvent('failed') below.
  *
  * Progress WebSocket events are emitted at each key step:
  *   10%  → video_download  (source accessible)
@@ -103,242 +94,128 @@ export class ClipGenerationProcessor extends WorkerHost {
     private readonly prisma: PrismaService,
   ) {
     super();
-    const config = getBullMQWorkerConfig(configService);
+    const config = getBullMQWorkerConfig(new ConfigService());
     this.logger.log(
       `Clip generation worker initialized with concurrency: ${config.clipGenerationConcurrency}`,
     );
   }
 
+  // ── Main entry point ───────────────────────────────────────────────────────
+
   /** Main job handler — called by BullMQ on each attempt */
   async process(job: Job<ClipGenerationJob | any>): Promise<Clip> {
-    // Handle uploaded video processing job
+    // Uploaded-video jobs have inputPath but no startTime/endTime
     if (job.data.inputPath && !job.data.startTime && !job.data.endTime) {
       return this.processUploadedVideo(job);
     }
+    return this.processClipJob(job as Job<ClipGenerationJob>);
+  }
 
-    const data = job.data as ClipGenerationJob;
-    const durationSeconds = data.endTime - data.startTime;
+  // ── Clip generation job ────────────────────────────────────────────────────
+
+  /**
+   * Process a standard clip-generation job:
+   * 1. Set up timeout + abort controller
+   * 2. Cut the clip with FFmpeg
+   * 3. Upload to Cloudinary
+   * 4. Return the completed Clip object
+   */
+  private async processClipJob(job: Job<ClipGenerationJob>): Promise<Clip> {
+    const data = job.data;
     const clipId = `${data.videoId}-${data.startTime}-${data.endTime}`;
-    const JOB_TIMEOUT_MS = 30 * 60 * 1000;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), JOB_TIMEOUT_MS);
-    this.clipsService._registerJobController(
-      data.videoId,
-      String(job.id ?? ''),
-      controller,
-    );
+    const jobMetricId = `${CLIP_GENERATION_QUEUE}:${job.id}`;
+
+    const { controller, timeout } = this.setupJobTimeout(data.videoId, String(job.id ?? ''));
 
     this.logger.log(
       `Processing clip job ${job.id} — attempt ${job.attemptsMade + 1}/${job.opts.attempts ?? 1} ` +
         `videoId=${data.videoId}`,
     );
-
-    // Record job start for metrics tracking
-    const jobMetricId = `${CLIP_GENERATION_QUEUE}:${job.id}`;
     this.metricsService.recordJobStart(jobMetricId);
 
     try {
       await this.clipsService.refreshQueueDepth();
 
-      // ── Step 1: video_download ───────────────────────────────────────────
-      this.logger.log(`Starting clip generation: ${clipId}`);
+      // ── Step 1: video_download ─────────────────────────────────────────
       await job.updateProgress({ percent: PROGRESS.VIDEO_DOWNLOAD, step: 'video_download' });
 
-      // ── Step 2: ffmpeg_cut ───────────────────────────────────────────────
-      await cutClip({
-        inputPath: data.inputPath,
-        outputPath: data.outputPath,
-        startTime: data.startTime,
-        endTime: data.endTime,
-        videoDuration: data.videoDuration,
-        signal: controller.signal,
-      });
-      await job.updateProgress({ percent: PROGRESS.FFMPEG_CUT, step: 'ffmpeg_cut' });
+      // ── Step 2: ffmpeg_cut ─────────────────────────────────────────────
+      const { actualDuration, viralityScore } = await this.cutAndAnalyze(job, data, controller);
 
-      const metadata = await getVideoMetadata(data.outputPath);
-      const actualDuration = Math.round(metadata.duration);
-
-      const viralityScore =
-        data.existingViralityScore ??
-        calculateViralityScore({
-          durationSeconds: actualDuration,
-          positionRatio: data.positionRatio,
-          transcript: data.transcript,
-        });
-
-      this.logger.log(
-        `Clip cut successfully — videoId=${data.videoId} ` +
-          `duration=${durationSeconds}s ` +
-          `position=${(data.positionRatio * 100).toFixed(0)}% ` +
-          `viralityScore=${viralityScore}`,
-      );
-
-      // ── Step 3: upload ───────────────────────────────────────────────────
+      // ── Step 3: upload ─────────────────────────────────────────────────
       await job.updateProgress({ percent: PROGRESS.UPLOAD, step: 'upload' });
-      const abortPromise = new Promise<never>((_, reject) => {
-        controller.signal.addEventListener(
-          'abort',
-          () => reject(new Error('Aborted')),
-          { once: true },
-        );
-      });
-      const uploadResult = await Promise.race([
-        this.uploadToCloudinary(data.outputPath, clipId),
-        abortPromise,
-      ]);
+      const uploadResult = await this.uploadWithAbort(data.outputPath, clipId, controller);
 
       if (uploadResult.error) {
-        // Upload failed after all retries - keep local file as fallback
-        this.logger.error(
-          `Cloudinary upload failed after retries for ${clipId}: ${uploadResult.error}. ` +
-            `Keeping local file as fallback: ${data.outputPath}`,
-        );
-
-        this.metricsService.incrementClipsGenerated('failure');
-        // Return clip with upload_failed status and local file path
-        return {
-          id: clipId,
-          videoId: data.videoId,
-          userId: '', // populated by ClipsService after dequeue
-          startTime: data.startTime,
-          endTime: data.endTime,
-          duration: actualDuration,
-          positionRatio: data.positionRatio,
-          transcript: data.transcript,
-          viralityScore,
-          clipUrl: '', // No Cloudinary URL available
-          thumbnail: undefined,
-          status: 'upload_failed',
-          localFilePath: data.outputPath, // Keep local file as fallback
-          error: `Cloudinary upload failed: ${uploadResult.error}`,
-          selected: false,
-          postStatus: null,
-          caption: generateCaption(data.title, clipId, data.transcript),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        };
+        return this.buildUploadFailedClip(data, clipId, actualDuration, viralityScore, uploadResult.error);
       }
 
-      // Delete local temporary file after successful upload
+      // ── Step 4: done ───────────────────────────────────────────────────
       await this.cloudinaryService.deleteLocalFile(data.outputPath);
-
-      this.logger.log(
-        `Clip processing complete: ${clipId} → ${uploadResult.secure_url}`,
-      );
-
-      // ── Step 4: done ─────────────────────────────────────────────────────
       await job.updateProgress({ percent: PROGRESS.DONE, step: 'done' });
+
       this.metricsService.incrementClipsGenerated('success');
       this.metricsService.recordJobCompletion(jobMetricId, CLIP_GENERATION_QUEUE, 'success');
+      this.clearJobResources(data.videoId, String(job.id ?? ''), timeout);
 
-      clearTimeout(timeout);
-      this.clipsService._clearJobController(String(job.id ?? ''));
+      this.logger.log(`Clip processing complete: ${clipId} → ${uploadResult.secure_url}`);
 
-      return {
-        id: clipId,
-        videoId: data.videoId,
-        userId: '', // populated by ClipsService after dequeue
-        startTime: data.startTime,
-        endTime: data.endTime,
-        duration: actualDuration,
-        positionRatio: data.positionRatio,
-        transcript: data.transcript,
-        viralityScore,
-        clipUrl: uploadResult.secure_url,
-        thumbnail: uploadResult.thumbnail_url,
-        status: 'success',
-        selected: false,
-        postStatus: null,
-        caption: generateCaption(data.title, clipId, data.transcript),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
+      return this.buildSuccessClip(data, clipId, actualDuration, viralityScore, uploadResult);
     } catch (error) {
-      this.metricsService.incrementClipsGenerated('failure');
-      this.metricsService.recordJobCompletion(jobMetricId, CLIP_GENERATION_QUEUE, 'failure');
-      this.metricsService.recordJobFailure(CLIP_GENERATION_QUEUE, error.message);
-      this.logger.error(
-        `Clip generation failed for ${clipId}: ${error.message}`,
-        error.stack,
-      );
-
-      // Only attempt cleanup if the error occurred before/during FFmpeg cut
-      // If upload failed, the file is already preserved in the success path
-      const errorMessage = error.message || '';
-      const isUploadError =
-        errorMessage.includes('Cloudinary') || errorMessage.includes('upload');
-
-      if (!isUploadError) {
-        // Attempt cleanup of local file for non-upload errors
-        try {
-          await this.cloudinaryService.deleteLocalFile(data.outputPath);
-        } catch (cleanupError) {
-          this.logger.warn(
-            `Cleanup failed for ${data.outputPath}: ${cleanupError.message}`,
-          );
-        }
-      }
+      this.handleJobError(error, data, clipId, jobMetricId);
+      this.clearJobResources(data.videoId, String(job.id ?? ''), timeout);
 
       if (controller.signal.aborted) {
         const cancelled = this.clipsService._isVideoCancelled(data.videoId);
-        clearTimeout(timeout);
-        this.clipsService._clearJobController(String(job.id ?? ''));
-        if (cancelled) {
-          throw new UnrecoverableError('Cancelled by user');
-        } else {
-          throw new UnrecoverableError('Timeout');
-        }
+        throw new UnrecoverableError(cancelled ? 'Cancelled by user' : 'Timeout');
       }
-      clearTimeout(timeout);
-      this.clipsService._clearJobController(String(job.id ?? ''));
       throw error;
     }
   }
 
-  /**
-   * Upload clip to Cloudinary with 2 retries
-   * @param filePath - Path to clip file
-   * @param clipId - Unique clip identifier
-   */
-  private async uploadToCloudinary(
-    filePath: string,
-    clipId: string,
-  ): Promise<any> {
-    try {
-      const buffer = await this.cloudinaryService.readFileToBuffer(filePath);
-      // Upload with 2 retries (3 total attempts)
-      const result = await this.cloudinaryService.uploadVideoFromBuffer(
-        buffer,
-        clipId,
-        {}, // default options
-        2, // 2 retries
-      );
+  // ── Uploaded video processing ──────────────────────────────────────────────
 
-      return result;
+  /**
+   * Process an uploaded video job:
+   * 1. Detect viral timestamps via VideoService
+   * 2. Clean up the temporary uploaded file
+   * Returns a placeholder Clip — actual clips are enqueued separately.
+   */
+  private async processUploadedVideo(job: Job<any>): Promise<Clip> {
+    const { videoId, inputPath, userId } = job.data;
+    this.logger.log(`Processing uploaded video ${videoId} (job: ${job.id})`);
+
+    try {
+      // ── Step 1: video_download ─────────────────────────────────────────
+      await job.updateProgress({ percent: PROGRESS.VIDEO_DOWNLOAD, step: 'video_download' });
+
+      // ── Step 2: ai_analysis — detect viral timestamps ──────────────────
+      await job.updateProgress({ percent: PROGRESS.AI_ANALYSIS, step: 'ai_analysis' });
+      const videoService = this.clipsService['videoService'] as VideoService;
+      const moments = await videoService.detectViralTimestamps(Number(videoId));
+      this.logger.log(`Detected ${moments.length} viral moments for video ${videoId}`);
+
+      // ── Step 3: cleanup temp file ──────────────────────────────────────
+      await this.safeDeleteLocalFile(inputPath);
+      await job.updateProgress({ percent: PROGRESS.DONE, step: 'done' });
+
+      return this.buildUploadProcessedClip(videoId, userId);
     } catch (error) {
       this.logger.error(
-        `Upload to Cloudinary failed for ${clipId}: ${error.message}`,
+        `Failed to process uploaded video ${videoId}: ${error.message}`,
+        error.stack,
       );
-      return {
-        error: error.message,
-        secure_url: '',
-        public_id: clipId,
-      };
+      await this.safeDeleteLocalFile(inputPath);
+      throw error;
     }
   }
 
+  // ── BullMQ worker event handlers ───────────────────────────────────────────
+
   /**
    * Called by BullMQ after a job has exhausted ALL retry attempts.
-   *
-   * Responsibilities:
-   *  1. Log the terminal failure with job.failedReason
-   *  2. Emit CLIP_GENERATION_FAILED_EVENT so listeners can:
-   *     - Set Video.status = 'failed' and Video.processingError = failedReason
-   *     - Trigger a user notification (email / push — future work)
-   *  3. Emit clip.failed WebSocket event to the affected user
-   *
-   * NOTE: this handler fires only on the FINAL failure, not on intermediate
-   * retries. Intermediate failures are handled silently by BullMQ's backoff.
+   * Emits CLIP_GENERATION_FAILED_EVENT and a WebSocket clip.failed event.
+   * NOTE: fires only on the FINAL failure, not on intermediate retries.
    */
   @OnWorkerEvent('failed')
   onFailed(job: Job<ClipGenerationJob>, error: Error): void {
@@ -346,102 +223,38 @@ export class ClipGenerationProcessor extends WorkerHost {
     const isFinalAttempt = job.attemptsMade >= maxAttempts;
 
     if (!isFinalAttempt) {
-      // Intermediate failure — compute the next backoff delay for the log message
-      const backoffDelay = job.opts.backoff
-        ? typeof job.opts.backoff === 'number'
-          ? job.opts.backoff
-          : // exponential: delay * 2^(attemptsMade - 1)
-            (job.opts.backoff.delay ?? 2000) *
-            Math.pow(2, job.attemptsMade - 1)
-        : 0;
-
-      this.logger.warn(
-        `[RETRY] Clip job ${job.id} failed on attempt ${job.attemptsMade}/${maxAttempts} — ` +
-          `videoId=${job.data.videoId} — ` +
-          `reason: ${error.message} — ` +
-          `retrying in ~${Math.round(backoffDelay / 1000)}s`,
-      );
+      this.logRetryWarning(job, error, maxAttempts);
       return;
     }
 
-    // Final failure — log and notify the rest of the system
-    // Record final failure for metrics
-    const jobMetricId = `${CLIP_GENERATION_QUEUE}:${job.id}`;
+    // Final failure — record metrics, log, and notify the system
     this.metricsService.recordJobFailure(CLIP_GENERATION_QUEUE, 'final_failure');
-
     this.logger.error(
       `[FINAL FAILURE] Clip job ${job.id} exhausted all ${maxAttempts} attempts — ` +
-        `videoId=${job.data.videoId} — ` +
-        `reason: ${error.message}`,
+        `videoId=${job.data.videoId} — reason: ${error.message}`,
       error.stack,
     );
 
     void this.clipsService.refreshQueueDepth();
-
-    const payload: ClipGenerationFailedPayload = {
-      jobId: job.id,
-      videoId: job.data.videoId,
-      failedReason: job.failedReason ?? error.message,
-      attemptsMade: job.attemptsMade,
-    };
-
-    this.eventEmitter.emit(CLIP_GENERATION_FAILED_EVENT, payload);
-
-    // Emit WebSocket event to the affected user (fire-and-forget)
-    void this.resolveUserId(job.data.videoId).then((userId) => {
-      if (!userId) return;
-      this.clipsGateway.emitFailed(userId, {
-        jobId: job.id,
-        videoId: job.data.videoId,
-        reason: job.failedReason ?? error.message,
-        attemptsMade: job.attemptsMade,
-      });
-    });
+    this.emitClipGenerationFailedEvent(job, error);
+    void this.emitFailedWebSocketEvent(job, error);
   }
 
   /**
    * Called by BullMQ after a job completes successfully.
-   *
-   * Responsibilities:
-   *  1. Update the Clip record in Prisma with new URLs and status='success'
-   *  2. Emit clip.completed WebSocket event to the affected user
+   * Updates the Clip record in Prisma and emits a clip.completed WebSocket event.
    */
   @OnWorkerEvent('completed')
   async onCompleted(job: Job<ClipGenerationJob>, result: Clip): Promise<void> {
-    const { clipId } = job.data;
-    if (!clipId) {
-      this.logger.debug(
-        `Job ${job.id} completed but no clipId provided for database update`,
-      );
-    } else {
-      this.logger.log(
-        `Job ${job.id} completed. Updating clip ${clipId} in database.`,
-      );
-      await this.clipsService.refreshQueueDepth();
+    await this.updateClipInDatabase(job, result);
+    await this.clipsService.refreshQueueDepth();
 
-      try {
-        await this.clipsService.updateClip(clipId, {
-          clipUrl: result.clipUrl,
-          thumbnail: result.thumbnail,
-          status: result.status,
-          duration: result.duration,
-          error: result.error,
-          localFilePath: result.localFilePath,
-        });
-      } catch (error) {
-        this.logger.error(
-          `Failed to update clip ${clipId} after successful generation: ${error.message}`,
-        );
-      }
-    }
-
-    // Emit clip.completed WebSocket event to the user
     const userId = await this.resolveUserId(job.data.videoId);
     if (userId) {
       this.clipsGateway.emitCompleted(userId, {
         jobId: job.id,
         videoId: job.data.videoId,
-        clipId: clipId,
+        clipId: job.data.clipId,
         clipUrl: result.clipUrl,
         thumbnail: result.thumbnail,
         status: result.status ?? 'success',
@@ -451,39 +264,204 @@ export class ClipGenerationProcessor extends WorkerHost {
 
   /**
    * Called by BullMQ on every job.updateProgress() call.
-   * Resolves the userId via in-memory map first, then Prisma as fallback,
-   * then emits the typed progress event over WebSocket.
+   * Resolves the userId and emits a typed progress event over WebSocket.
    */
   @OnWorkerEvent('progress')
   onProgress(job: Job<ClipGenerationJob>, progress: number | object): void {
-    const rawPercent =
-      typeof progress === 'object' && progress !== null
-        ? (progress as any).percent
-        : progress;
-    const step: ClipProgressStep =
-      typeof progress === 'object' && progress !== null
-        ? ((progress as any).step ?? 'ffmpeg_cut')
-        : this.stepFromPercent(Number(rawPercent));
-
-    const percent = Math.max(0, Math.min(100, Math.round(Number(rawPercent) || 0)));
-
+    const { percent, step } = this.parseProgress(progress);
     const clipId = `${job.data.videoId}-${job.data.startTime}-${job.data.endTime}`;
 
-    // Try in-memory map first, then fall back to Prisma asynchronously
     const video = this.clipsService._getVideo(job.data.videoId);
     if (video?.userId) {
       this.emitProgressEvent(String(video.userId), job, percent, step, clipId);
     } else {
-      // Resolve userId from Prisma and emit asynchronously
       void this.resolveUserId(job.data.videoId).then((userId) => {
-        if (!userId) return;
-        this.emitProgressEvent(userId, job, percent, step, clipId);
+        if (userId) this.emitProgressEvent(userId, job, percent, step, clipId);
       });
     }
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────
 
+  /**
+   * Set up a job-level AbortController and timeout.
+   * Registers the controller with ClipsService so it can be cancelled externally.
+   */
+  private setupJobTimeout(
+    videoId: string,
+    jobId: string,
+  ): { controller: AbortController; timeout: NodeJS.Timeout } {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), JOB_TIMEOUT_MS);
+    this.clipsService._registerJobController(videoId, jobId, controller);
+    return { controller, timeout };
+  }
+
+  /** Clear the timeout and deregister the job controller. */
+  private clearJobResources(videoId: string, jobId: string, timeout: NodeJS.Timeout): void {
+    clearTimeout(timeout);
+    this.clipsService._clearJobController(jobId);
+  }
+
+  /**
+   * Run FFmpeg to cut the clip, then compute virality score.
+   * Returns the actual clip duration and virality score.
+   */
+  private async cutAndAnalyze(
+    job: Job<ClipGenerationJob>,
+    data: ClipGenerationJob,
+    controller: AbortController,
+  ): Promise<{ actualDuration: number; viralityScore: number }> {
+    await cutClip({
+      inputPath: data.inputPath,
+      outputPath: data.outputPath,
+      startTime: data.startTime,
+      endTime: data.endTime,
+      videoDuration: data.videoDuration,
+      signal: controller.signal,
+    });
+    await job.updateProgress({ percent: PROGRESS.FFMPEG_CUT, step: 'ffmpeg_cut' });
+
+    const metadata = await getVideoMetadata(data.outputPath);
+    const actualDuration = Math.round(metadata.duration);
+
+    const viralityScore =
+      data.existingViralityScore ??
+      calculateViralityScore({
+        durationSeconds: actualDuration,
+        positionRatio: data.positionRatio,
+        transcript: data.transcript,
+      });
+
+    this.logger.log(
+      `Clip cut — videoId=${data.videoId} duration=${data.endTime - data.startTime}s ` +
+        `position=${(data.positionRatio * 100).toFixed(0)}% viralityScore=${viralityScore}`,
+    );
+
+    return { actualDuration, viralityScore };
+  }
+
+  /**
+   * Upload the clip to Cloudinary, racing against the abort signal.
+   * Returns the upload result (may contain an error field on failure).
+   */
+  private async uploadWithAbort(
+    filePath: string,
+    clipId: string,
+    controller: AbortController,
+  ): Promise<any> {
+    const abortPromise = new Promise<never>((_, reject) => {
+      controller.signal.addEventListener('abort', () => reject(new Error('Aborted')), { once: true });
+    });
+    return Promise.race([this.uploadToCloudinary(filePath, clipId), abortPromise]);
+  }
+
+  /**
+   * Upload clip buffer to Cloudinary with 2 retries (3 total attempts).
+   * Returns an object with `error` set on failure instead of throwing.
+   */
+  private async uploadToCloudinary(filePath: string, clipId: string): Promise<any> {
+    try {
+      const buffer = await this.cloudinaryService.readFileToBuffer(filePath);
+      return await this.cloudinaryService.uploadVideoFromBuffer(buffer, clipId, {}, 2);
+    } catch (error) {
+      this.logger.error(`Upload to Cloudinary failed for ${clipId}: ${error.message}`);
+      return { error: error.message, secure_url: '', public_id: clipId };
+    }
+  }
+
+  /**
+   * Handle errors from the main clip processing try/catch.
+   * Records metrics and attempts cleanup of the local file for non-upload errors.
+   */
+  private handleJobError(
+    error: Error,
+    data: ClipGenerationJob,
+    clipId: string,
+    jobMetricId: string,
+  ): void {
+    this.metricsService.incrementClipsGenerated('failure');
+    this.metricsService.recordJobCompletion(jobMetricId, CLIP_GENERATION_QUEUE, 'failure');
+    this.metricsService.recordJobFailure(CLIP_GENERATION_QUEUE, error.message);
+    this.logger.error(`Clip generation failed for ${clipId}: ${error.message}`, error.stack);
+
+    // Only clean up local file for non-upload errors (upload errors preserve the file as fallback)
+    const isUploadError = error.message?.includes('Cloudinary') || error.message?.includes('upload');
+    if (!isUploadError) {
+      void this.safeDeleteLocalFile(data.outputPath);
+    }
+  }
+
+  /** Delete a local file, logging a warning on failure instead of throwing. */
+  private async safeDeleteLocalFile(filePath: string): Promise<void> {
+    try {
+      await this.cloudinaryService.deleteLocalFile(filePath);
+    } catch (err) {
+      this.logger.warn(`Cleanup failed for ${filePath}: ${err.message}`);
+    }
+  }
+
+  /** Update the Clip record in Prisma after a successful job. */
+  private async updateClipInDatabase(job: Job<ClipGenerationJob>, result: Clip): Promise<void> {
+    const { clipId } = job.data;
+    if (!clipId) {
+      this.logger.debug(`Job ${job.id} completed but no clipId provided for database update`);
+      return;
+    }
+    this.logger.log(`Job ${job.id} completed. Updating clip ${clipId} in database.`);
+    try {
+      await this.clipsService.updateClip(clipId, {
+        clipUrl: result.clipUrl,
+        thumbnail: result.thumbnail,
+        status: result.status,
+        duration: result.duration,
+        error: result.error,
+        localFilePath: result.localFilePath,
+      });
+    } catch (error) {
+      this.logger.error(`Failed to update clip ${clipId} after successful generation: ${error.message}`);
+    }
+  }
+
+  /** Emit the CLIP_GENERATION_FAILED_EVENT for downstream listeners. */
+  private emitClipGenerationFailedEvent(job: Job<ClipGenerationJob>, error: Error): void {
+    const payload: ClipGenerationFailedPayload = {
+      jobId: job.id,
+      videoId: job.data.videoId,
+      failedReason: job.failedReason ?? error.message,
+      attemptsMade: job.attemptsMade,
+    };
+    this.eventEmitter.emit(CLIP_GENERATION_FAILED_EVENT, payload);
+  }
+
+  /** Emit a clip.failed WebSocket event to the affected user (fire-and-forget). */
+  private async emitFailedWebSocketEvent(job: Job<ClipGenerationJob>, error: Error): Promise<void> {
+    const userId = await this.resolveUserId(job.data.videoId);
+    if (!userId) return;
+    this.clipsGateway.emitFailed(userId, {
+      jobId: job.id,
+      videoId: job.data.videoId,
+      reason: job.failedReason ?? error.message,
+      attemptsMade: job.attemptsMade,
+    });
+  }
+
+  /** Log a warning for intermediate (non-final) job failures. */
+  private logRetryWarning(job: Job<ClipGenerationJob>, error: Error, maxAttempts: number): void {
+    const backoffDelay = job.opts.backoff
+      ? typeof job.opts.backoff === 'number'
+        ? job.opts.backoff
+        : (job.opts.backoff.delay ?? 2000) * Math.pow(2, job.attemptsMade - 1)
+      : 0;
+
+    this.logger.warn(
+      `[RETRY] Clip job ${job.id} failed on attempt ${job.attemptsMade}/${maxAttempts} — ` +
+        `videoId=${job.data.videoId} — reason: ${error.message} — ` +
+        `retrying in ~${Math.round(backoffDelay / 1000)}s`,
+    );
+  }
+
+  /** Emit a progress WebSocket event to the user. */
   private emitProgressEvent(
     userId: string,
     job: Job<ClipGenerationJob>,
@@ -508,10 +486,23 @@ export class ClipGenerationProcessor extends WorkerHost {
     });
   }
 
+  /** Parse a raw BullMQ progress value into { percent, step }. */
+  private parseProgress(progress: number | object): { percent: number; step: ClipProgressStep } {
+    const rawPercent =
+      typeof progress === 'object' && progress !== null
+        ? (progress as any).percent
+        : progress;
+    const step: ClipProgressStep =
+      typeof progress === 'object' && progress !== null
+        ? ((progress as any).step ?? 'ffmpeg_cut')
+        : this.stepFromPercent(Number(rawPercent));
+    const percent = Math.max(0, Math.min(100, Math.round(Number(rawPercent) || 0)));
+    return { percent, step };
+  }
+
   /**
-   * Resolves the userId for a given videoId.
-   * Checks the in-memory store first (fast path) then falls back to a
-   * Prisma query (for jobs where the video was never cached in memory).
+   * Resolve the userId for a given videoId.
+   * Checks the in-memory store first (fast path), then falls back to Prisma.
    */
   private async resolveUserId(videoId: string): Promise<string | null> {
     const video = this.clipsService._getVideo(videoId);
@@ -528,7 +519,7 @@ export class ClipGenerationProcessor extends WorkerHost {
     }
   }
 
-  /** Infer a step label from a legacy bare-number progress value */
+  /** Infer a step label from a legacy bare-number progress value. */
   private stepFromPercent(percent: number): ClipProgressStep {
     if (percent <= 10) return 'video_download';
     if (percent <= 30) return 'ai_analysis';
@@ -537,77 +528,91 @@ export class ClipGenerationProcessor extends WorkerHost {
     return 'done';
   }
 
-  /**
-   * Process uploaded video - detect viral timestamps and generate clips
-   * This is a special job type triggered by video upload endpoint
-   */
-  private async processUploadedVideo(job: Job<any>): Promise<Clip> {
-    const data = job.data;
-    const videoId = data.videoId;
-    const inputPath = data.inputPath;
+  // ── Clip builder helpers ───────────────────────────────────────────────────
 
-    this.logger.log(`Processing uploaded video ${videoId} (job: ${job.id})`);
+  /** Build a Clip object for a successful generation. */
+  private buildSuccessClip(
+    data: ClipGenerationJob,
+    clipId: string,
+    actualDuration: number,
+    viralityScore: number,
+    uploadResult: any,
+  ): Clip {
+    return {
+      id: clipId,
+      videoId: data.videoId,
+      userId: '',
+      startTime: data.startTime,
+      endTime: data.endTime,
+      duration: actualDuration,
+      positionRatio: data.positionRatio,
+      transcript: data.transcript,
+      viralityScore,
+      clipUrl: uploadResult.secure_url,
+      thumbnail: uploadResult.thumbnail_url,
+      status: 'success',
+      selected: false,
+      postStatus: null,
+      caption: generateCaption(data.title, clipId, data.transcript),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  }
 
-    try {
-      // ── Step 1: video_download ─────────────────────────────────────────
-      await job.updateProgress({ percent: PROGRESS.VIDEO_DOWNLOAD, step: 'video_download' });
+  /** Build a Clip object when Cloudinary upload failed (keeps local file as fallback). */
+  private buildUploadFailedClip(
+    data: ClipGenerationJob,
+    clipId: string,
+    actualDuration: number,
+    viralityScore: number,
+    errorMessage: string,
+  ): Clip {
+    this.metricsService.incrementClipsGenerated('failure');
+    this.logger.error(
+      `Cloudinary upload failed after retries for ${clipId}: ${errorMessage}. ` +
+        `Keeping local file as fallback: ${data.outputPath}`,
+    );
+    return {
+      id: clipId,
+      videoId: data.videoId,
+      userId: '',
+      startTime: data.startTime,
+      endTime: data.endTime,
+      duration: actualDuration,
+      positionRatio: data.positionRatio,
+      transcript: data.transcript,
+      viralityScore,
+      clipUrl: '',
+      thumbnail: undefined,
+      status: 'upload_failed',
+      localFilePath: data.outputPath,
+      error: `Cloudinary upload failed: ${errorMessage}`,
+      selected: false,
+      postStatus: null,
+      caption: generateCaption(data.title, clipId, data.transcript),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  }
 
-      // Import VideoService dynamically to detect viral timestamps
-      const videoService = this.clipsService['videoService'] as VideoService;
-
-      // ── Step 2: ai_analysis ────────────────────────────────────────────
-      await job.updateProgress({ percent: PROGRESS.AI_ANALYSIS, step: 'ai_analysis' });
-
-      // Detect viral timestamps (will also update video with processing stats)
-      const moments = await videoService.detectViralTimestamps(Number(videoId));
-
-      this.logger.log(
-        `Detected ${moments.length} viral moments for video ${videoId}`,
-      );
-
-      // ── Step 3: done (cleanup) ─────────────────────────────────────────
-      // Clean up the temporary uploaded file after processing
-      try {
-        await this.cloudinaryService.deleteLocalFile(inputPath);
-        this.logger.log(`Cleaned up uploaded temp file: ${inputPath}`);
-      } catch (cleanupError) {
-        this.logger.warn(`Failed to cleanup temp file ${inputPath}: ${cleanupError.message}`);
-      }
-
-      await job.updateProgress({ percent: PROGRESS.DONE, step: 'done' });
-
-      // Return placeholder result (actual clips are created separately)
-      return {
-        id: `upload-${videoId}`,
-        videoId: String(videoId),
-        userId: String(data.userId || ''),
-        startTime: 0,
-        endTime: 0,
-        duration: 0,
-        positionRatio: 0,
-        clipUrl: '',
-        status: 'upload_processed' as const,
-        selected: false,
-        postStatus: null,
-        caption: '',
-        viralityScore: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-    } catch (error) {
-      this.logger.error(
-        `Failed to process uploaded video ${videoId}: ${error.message}`,
-        error.stack,
-      );
-
-      // Clean up temp file on failure
-      try {
-        await this.cloudinaryService.deleteLocalFile(inputPath);
-      } catch {
-        // Ignore cleanup errors
-      }
-
-      throw error;
-    }
+  /** Build a placeholder Clip for a completed uploaded-video processing job. */
+  private buildUploadProcessedClip(videoId: string, userId: string): Clip {
+    return {
+      id: `upload-${videoId}`,
+      videoId: String(videoId),
+      userId: String(userId || ''),
+      startTime: 0,
+      endTime: 0,
+      duration: 0,
+      positionRatio: 0,
+      clipUrl: '',
+      status: 'upload_processed' as const,
+      selected: false,
+      postStatus: null,
+      caption: '',
+      viralityScore: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
   }
 }


### PR DESCRIPTION
Closes #300

## Changes
Refactored the monolithic `ClipGenerationProcessor` (22KB) into focused private methods:

**Processing methods**
- `processClipJob()` — orchestrates the standard clip generation flow
- `processUploadedVideo()` — handles upload-triggered video processing

**Step helpers**
- `setupJobTimeout()` / `clearJobResources()` — AbortController lifecycle
- `cutAndAnalyze()` — FFmpeg cut + virality score calculation
- `uploadWithAbort()` — Cloudinary upload racing against abort signal
- `uploadToCloudinary()` — retry-aware upload with graceful error return

**Error handling**
- `handleJobError()` — centralized metrics + cleanup for job failures
- `safeDeleteLocalFile()` — cleanup that warns instead of throwing

**Event emitters**
- `emitClipGenerationFailedEvent()` — EventEmitter2 notification
- `emitFailedWebSocketEvent()` — WebSocket clip.failed event
- `logRetryWarning()` — intermediate retry log

**Clip builders**
- `buildSuccessClip()`, `buildUploadFailedClip()`, `buildUploadProcessedClip()`

**Utilities**
- `updateClipInDatabase()`, `parseProgress()`, `resolveUserId()`, `stepFromPercent()`

Each method has a clear JSDoc comment explaining its responsibility. Step comments (Step 1/2/3/4) mark the processing stages within each flow.