### PR TITLE
fix: import registerQueue in ClipsModule

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -33,6 +33,10 @@ const mockPrisma = {
   },
 };
 
+mockPrisma.withTransaction = jest.fn(async (callback: (tx: typeof mockPrisma) => unknown) =>
+  callback(mockPrisma),
+);
+
 const mockJwt = { sign: jest.fn().mockReturnValue('mock.jwt.token') };
 
 const mockEmailDelivery = { enqueue: jest.fn() };

--- a/src/auth/auth.signup.spec.ts
+++ b/src/auth/auth.signup.spec.ts
@@ -18,24 +18,30 @@ describe('Auth - Password Strength Validation', () => {
   let stellarService: StellarService;
 
   beforeEach(async () => {
+    const prismaMock = {
+      user: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      refreshToken: {
+        create: jest.fn(),
+      },
+      emailVerificationToken: {
+        create: jest.fn(),
+      },
+      withTransaction: jest.fn(),
+    };
+    prismaMock.withTransaction.mockImplementation(async (callback: (tx: typeof prismaMock) => unknown) =>
+      callback(prismaMock),
+    );
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
         {
           provide: PrismaService,
-          useValue: {
-            user: {
-              findUnique: jest.fn(),
-              create: jest.fn(),
-              update: jest.fn(),
-            },
-            refreshToken: {
-              create: jest.fn(),
-            },
-            emailVerificationToken: {
-              create: jest.fn(),
-            },
-          },
+          useValue: prismaMock,
         },
         {
           provide: JwtService,

--- a/src/clips/clips.module.ts
+++ b/src/clips/clips.module.ts
@@ -1,18 +1,17 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { registerQueue } from '../common';
 import { ClipsController } from './clips.controller';
 import { ClipsService } from './clips.service';
 import { ClipGenerationProcessor } from './clip-generation.processor';
 import { CloudinaryService } from './cloudinary.service';
 import {
   CLIP_GENERATION_QUEUE,
-  CLIP_GENERATION_QUEUE_PRIORITY,
 } from './clip-generation.queue';
-import { NFT_MINT_QUEUE, NFT_MINT_QUEUE_PRIORITY } from './nft-mint.queue';
+import { NFT_MINT_QUEUE } from './nft-mint.queue';
 import { NftMintProcessor } from './nft-mint.processor';
 import {
   CLIP_POSTING_QUEUE,
-  CLIP_POSTING_QUEUE_PRIORITY,
 } from './clip-posting.queue';
 import { ClipPostingProcessor } from './clip-posting.processor';
 import { ClipsGateway } from './clips.gateway';


### PR DESCRIPTION
## Summary
- Add missing `registerQueue` import in `ClipsModule` after PR #473 queue registration refactor
- Fixes compilation failure on `main` (`registerQueue is not defined`)

## Context
PR #485 already merged issues #457–#460. PRs #481–#483 were closed as duplicates. This follow-up fixes a build break introduced when #473 landed on top.

## Test plan
- [x] `npm run build` passes