### PR TITLE
feat: resolve Stellar Wave issues #388, #389, #394, #395

### DIFF
--- a/prisma/migrations/20260624_add_video_metadata_and_payout_external_tx/migration.sql
+++ b/prisma/migrations/20260624_add_video_metadata_and_payout_external_tx/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: add metadata JSON field to Video (issue #388)
+ALTER TABLE "Video" ADD COLUMN "metadata" JSONB;
+
+-- AlterTable: add externalTransactionId to Payout (issue #395)
+ALTER TABLE "Payout" ADD COLUMN "externalTransactionId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,8 @@ model Video {
   processingError  String?
   // Schema: { momentsFound: number, inputQuality: string, durationSec: number, clipsGenerated: number, timeTakenMs: number, errorDetails?: string }
   processingStats  Json?
+  // Schema: { duration: number, width: number, height: number, format: string, fps: number, bitrate: number }
+  metadata         Json?
   targetPlatforms  Json?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
@@ -158,6 +160,7 @@ model Payout {
   method           String
   status           String
   transactionId    String?
+  externalTransactionId String?
   stellarXdr       String?
   onChainTxHash    String?
   confirmedAt      DateTime?

--- a/src/clips/ffmpeg.util.ts
+++ b/src/clips/ffmpeg.util.ts
@@ -21,6 +21,8 @@ export interface VideoMetadata {
   height: number;
   format: string;
   resolution: string;
+  fps: number;
+  bitrate: number;
 }
 
 /**
@@ -48,12 +50,27 @@ export async function getVideoMetadata(
       const height = stream.height || 0;
       const formatName = format.format_name || 'unknown';
 
+      // Parse frame rate from "num/den" string (e.g. "30/1" or "30000/1001")
+      let fps = 0;
+      if (stream.r_frame_rate) {
+        const parts = stream.r_frame_rate.split('/');
+        if (parts.length === 2) {
+          const num = parseFloat(parts[0]);
+          const den = parseFloat(parts[1]);
+          fps = den > 0 ? Math.round((num / den) * 100) / 100 : 0;
+        }
+      }
+
+      const bitrate = parseInt(format.bit_rate?.toString() || '0', 10);
+
       resolve({
         duration,
         width,
         height,
         format: formatName,
         resolution: `${width}x${height}`,
+        fps,
+        bitrate,
       });
     });
   });

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -258,6 +258,7 @@ export class PayoutsService {
     id: number;
     status: string;
     transactionId: string;
+    externalTransactionId: string | null;
     onChainTxHash: string | null;
   }> {
     // Performance: Use select to fetch only needed fields for payout processing (optimization #326)
@@ -267,8 +268,10 @@ export class PayoutsService {
         id: true,
         amount: true,
         currency: true,
+        method: true,
         status: true,
         stellarXdr: true,
+        retryCount: true,
         wallet: {
           select: {
             address: true,
@@ -345,6 +348,7 @@ export class PayoutsService {
         data: {
           status: 'completed',
           transactionId: transaction.hash().toString('hex'),
+          externalTransactionId: submitResult.hash,
           onChainTxHash: submitResult.hash,
           confirmedAt: new Date(),
         },
@@ -370,6 +374,7 @@ export class PayoutsService {
         id: payout.id,
         status: 'completed',
         transactionId: transaction.hash().toString('hex'),
+        externalTransactionId: submitResult.hash,
         onChainTxHash: submitResult.hash,
       };
     } catch (error) {

--- a/src/videos/video-upload.service.ts
+++ b/src/videos/video-upload.service.ts
@@ -23,6 +23,8 @@ export interface VideoValidationResult {
     width: number;
     height: number;
     format: string;
+    fps: number;
+    bitrate: number;
   };
 }
 
@@ -114,6 +116,8 @@ export class VideoUploadService {
             width: metadata.width,
             height: metadata.height,
             format: metadata.format,
+            fps: metadata.fps,
+            bitrate: metadata.bitrate,
           },
         };
       }
@@ -125,6 +129,8 @@ export class VideoUploadService {
           width: metadata.width,
           height: metadata.height,
           format: metadata.format,
+          fps: metadata.fps,
+          bitrate: metadata.bitrate,
         },
       };
     } catch (error) {
@@ -177,6 +183,14 @@ export class VideoUploadService {
           status: 'pending',
           duration: Math.round(validation.metadata!.duration),
           fileSize: BigInt(stats.size),
+          metadata: {
+            duration: validation.metadata!.duration,
+            width: validation.metadata!.width,
+            height: validation.metadata!.height,
+            format: validation.metadata!.format,
+            fps: validation.metadata!.fps,
+            bitrate: validation.metadata!.bitrate,
+          },
           processingStats: {
             inputQuality: `${validation.metadata!.height}p`,
             durationSec: validation.metadata!.duration,


### PR DESCRIPTION
## Summary

Resolves all four open Stellar Wave issues assigned to me in one commit.

---

### #388 — Extract Video Metadata on Upload

- Added `fps` and `bitrate` fields to `VideoMetadata` interface in `ffmpeg.util.ts`
- `fps` is parsed from FFprobe's `r_frame_rate` (e.g. `30000/1001` → `29.97`)
- `bitrate` is read from `format.bit_rate`
- Added `metadata Json?` field to the `Video` model in `schema.prisma`
- `video-upload.service.ts` now stores `{ duration, width, height, format, fps, bitrate }` on the `Video` record at upload time
- Migration: `20260624_add_video_metadata_and_payout_external_tx`

Closes #388

---

### #389 — Stellar Testnet vs Mainnet Configuration

Already fully implemented prior to this PR:
- `StellarService` reads `STELLAR_NETWORK=testnet|public` and sets the correct RPC URL, Horizon URL, and network passphrase
- `.env.example` documents the variable with comments

Closes #389

---

### #394 — Fiat vs Crypto Payout Selection

Already fully implemented prior to this PR:
- `CreatePayoutDto` has `method: 'fiat' | 'stellar'` with `@IsEnum` validation
- `requestPayoutWithDetails` stores `method` on the `Payout` record and routes to the correct wallet/payout-method lookup
- `Payout` model already has `method String` in the schema

Closes #394

---

### #395 — Store External Payment Processor Transaction IDs

- Added `externalTransactionId String?` field to `Payout` model in `schema.prisma`
- `processPayout` now stores `submitResult.hash` as `externalTransactionId` alongside `onChainTxHash`
- Field is included in the `processPayout` return type
- Also fixed a latent bug: `method` and `retryCount` were used in `processPayout` but missing from the Prisma `select` clause
- Migration: `20260624_add_video_metadata_and_payout_external_tx`

Closes #395

---

## Files Changed

| File | Change |
|------|--------|
| `prisma/schema.prisma` | Added `metadata Json?` to `Video`, `externalTransactionId String?` to `Payout` |
| `prisma/migrations/20260624_.../migration.sql` | New migration for both schema additions |
| `src/clips/ffmpeg.util.ts` | Added `fps` and `bitrate` to `VideoMetadata` interface and extraction logic |
| `src/videos/video-upload.service.ts` | Store full metadata on `Video` record at upload time |
| `src/payouts/payouts.service.ts` | Store `externalTransactionId`, fix missing `select` fields, expose in return type |