### PR TITLE
feat: queue config validation and retry analytics

### DIFF
--- a/src/config/bullmq.config.spec.ts
+++ b/src/config/bullmq.config.spec.ts
@@ -2,7 +2,10 @@ import { ConfigService } from '@nestjs/config';
 import {
   getBullMQWorkerConfig,
   validateWorkerConfig,
+  getBullMQConnectionConfig,
+  validateConnectionConfig,
   BullMQWorkerConfig,
+  BullMQConnectionConfig,
 } from './bullmq.config';
 
 describe('BullMQ Configuration', () => {
@@ -117,6 +120,87 @@ describe('BullMQ Configuration', () => {
       );
       expect(() => validateWorkerConfig(config)).toThrow(
         /BULLMQ_EMAIL_DELIVERY_CONCURRENCY should not exceed 50/,
+      );
+    });
+  });
+});
+
+describe('BullMQ Connection Configuration', () => {
+  describe('getBullMQConnectionConfig', () => {
+    it('should return defaults when env vars are not set', () => {
+      const configService = new ConfigService();
+      const config = getBullMQConnectionConfig(configService);
+
+      expect(config.redisHost).toBe('localhost');
+      expect(config.redisPort).toBe(6379);
+    });
+
+    it('should parse env vars correctly', () => {
+      const configService = new ConfigService({
+        REDIS_HOST: 'redis.prod.internal',
+        REDIS_PORT: '6380',
+      });
+      const config = getBullMQConnectionConfig(configService);
+
+      expect(config.redisHost).toBe('redis.prod.internal');
+      expect(config.redisPort).toBe(6380);
+    });
+  });
+
+  describe('validateConnectionConfig', () => {
+    it('should accept valid configuration', () => {
+      const config: BullMQConnectionConfig = { redisHost: 'localhost', redisPort: 6379 };
+      expect(() => validateConnectionConfig(config)).not.toThrow();
+    });
+
+    it('should reject empty REDIS_HOST', () => {
+      const config: BullMQConnectionConfig = { redisHost: '', redisPort: 6379 };
+      expect(() => validateConnectionConfig(config)).toThrow(
+        /REDIS_HOST must be a non-empty string/,
+      );
+    });
+
+    it('should reject whitespace-only REDIS_HOST', () => {
+      const config: BullMQConnectionConfig = { redisHost: '   ', redisPort: 6379 };
+      expect(() => validateConnectionConfig(config)).toThrow(
+        /REDIS_HOST must be a non-empty string/,
+      );
+    });
+
+    it('should reject REDIS_PORT of 0', () => {
+      const config: BullMQConnectionConfig = { redisHost: 'localhost', redisPort: 0 };
+      expect(() => validateConnectionConfig(config)).toThrow(
+        /REDIS_PORT must be a valid port number/,
+      );
+    });
+
+    it('should reject REDIS_PORT > 65535', () => {
+      const config: BullMQConnectionConfig = { redisHost: 'localhost', redisPort: 70000 };
+      expect(() => validateConnectionConfig(config)).toThrow(
+        /REDIS_PORT must be a valid port number/,
+      );
+    });
+
+    it('should reject NaN REDIS_PORT', () => {
+      const config: BullMQConnectionConfig = { redisHost: 'localhost', redisPort: NaN };
+      expect(() => validateConnectionConfig(config)).toThrow(
+        /REDIS_PORT must be a valid port number/,
+      );
+    });
+
+    it('should accept boundary port values', () => {
+      expect(() =>
+        validateConnectionConfig({ redisHost: 'localhost', redisPort: 1 }),
+      ).not.toThrow();
+      expect(() =>
+        validateConnectionConfig({ redisHost: 'localhost', redisPort: 65535 }),
+      ).not.toThrow();
+    });
+
+    it('should collect multiple errors', () => {
+      const config: BullMQConnectionConfig = { redisHost: '', redisPort: 0 };
+      expect(() => validateConnectionConfig(config)).toThrow(
+        /Invalid BullMQ connection configuration/,
       );
     });
   });

--- a/src/config/bullmq.config.ts
+++ b/src/config/bullmq.config.ts
@@ -23,6 +23,45 @@ export interface BullMQWorkerConfig {
   emailDeliveryConcurrency: number;
 }
 
+export interface BullMQConnectionConfig {
+  /** Redis host for BullMQ connection */
+  redisHost: string;
+  /** Redis port for BullMQ connection */
+  redisPort: number;
+}
+
+/**
+ * Load BullMQ Redis connection config from environment variables.
+ */
+export function getBullMQConnectionConfig(
+  configService: ConfigService,
+): BullMQConnectionConfig {
+  return {
+    redisHost: configService.get<string>('REDIS_HOST', 'localhost'),
+    redisPort: parseInt(configService.get<string>('REDIS_PORT', '6379'), 10),
+  };
+}
+
+/**
+ * Validate Redis connection configuration.
+ * Ensures REDIS_HOST is a non-empty string and REDIS_PORT is a valid port number.
+ */
+export function validateConnectionConfig(config: BullMQConnectionConfig): void {
+  const errors: string[] = [];
+
+  if (!config.redisHost || config.redisHost.trim() === '') {
+    errors.push('REDIS_HOST must be a non-empty string');
+  }
+
+  if (isNaN(config.redisPort) || config.redisPort < 1 || config.redisPort > 65535) {
+    errors.push('REDIS_PORT must be a valid port number between 1 and 65535');
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid BullMQ connection configuration:\n${errors.join('\n')}`);
+  }
+}
+
 /**
  * Load BullMQ worker configuration from environment variables
  * with sensible defaults for each queue type.

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ import { AppLoggerService } from './logger/logger.service';
 import {
   getBullMQWorkerConfig,
   validateWorkerConfig,
+  getBullMQConnectionConfig,
+  validateConnectionConfig,
 } from './config/bullmq.config';
 
 async function bootstrap() {
@@ -21,8 +23,21 @@ async function bootstrap() {
   const logger = new Logger('Bootstrap');
   const isProduction = process.env.NODE_ENV === 'production';
 
-  // Validate BullMQ worker configuration on startup
+  // Validate BullMQ Redis connection configuration on startup
   const configService = app.get(ConfigService);
+  const connectionConfig = getBullMQConnectionConfig(configService);
+  try {
+    validateConnectionConfig(connectionConfig);
+    logger.log(
+      `BullMQ connection configuration validated: ` +
+        `host=${connectionConfig.redisHost}, port=${connectionConfig.redisPort}`,
+    );
+  } catch (error) {
+    logger.error(`Invalid BullMQ connection configuration: ${error.message}`);
+    process.exit(1);
+  }
+
+  // Validate BullMQ worker configuration on startup
   const workerConfig = getBullMQWorkerConfig(configService);
   try {
     validateWorkerConfig(workerConfig);

--- a/src/metrics/queue-collector.service.spec.ts
+++ b/src/metrics/queue-collector.service.spec.ts
@@ -1,0 +1,120 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bullmq';
+import { QueueCollectorService } from './queue-collector.service';
+import { QueueMetricsService } from './queue-metrics.service';
+
+const mockQueue = (failedJobs: { attemptsMade: number; failedReason?: string }[]) => ({
+  getJobCounts: jest.fn().mockResolvedValue({
+    waiting: 1,
+    active: 0,
+    completed: 5,
+    failed: failedJobs.length,
+    delayed: 0,
+    prioritized: 0,
+  }),
+  getFailed: jest.fn().mockResolvedValue(failedJobs),
+});
+
+const mockMetrics = () => ({
+  recordQueueCounts: jest.fn(),
+  recordAvgRetryCount: jest.fn(),
+  recordFailureReasonCount: jest.fn(),
+});
+
+describe('QueueCollectorService', () => {
+  let service: QueueCollectorService;
+  let metrics: ReturnType<typeof mockMetrics>;
+  let queue: ReturnType<typeof mockQueue>;
+
+  async function build(
+    failedJobs: { attemptsMade: number; failedReason?: string }[],
+  ): Promise<void> {
+    queue = mockQueue(failedJobs);
+    metrics = mockMetrics();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueCollectorService,
+        { provide: QueueMetricsService, useValue: metrics },
+        { provide: getQueueToken('clip-generation'), useValue: queue },
+      ],
+    }).compile();
+
+    service = module.get<QueueCollectorService>(QueueCollectorService);
+  }
+
+  it('records average retry count of 0 when there are no failed jobs', async () => {
+    await build([]);
+    await service.collectMetrics();
+
+    expect(metrics.recordAvgRetryCount).toHaveBeenCalledWith('clip-generation', 0);
+  });
+
+  it('calculates correct average retry count', async () => {
+    await build([
+      { attemptsMade: 3, failedReason: 'timeout' },
+      { attemptsMade: 1, failedReason: 'timeout' },
+    ]);
+    await service.collectMetrics();
+
+    expect(metrics.recordAvgRetryCount).toHaveBeenCalledWith('clip-generation', 2);
+  });
+
+  it('aggregates failure reasons and records counts', async () => {
+    await build([
+      { attemptsMade: 2, failedReason: 'Error: ECONNREFUSED' },
+      { attemptsMade: 1, failedReason: 'Error: ECONNREFUSED' },
+      { attemptsMade: 3, failedReason: 'Error: timeout' },
+    ]);
+    await service.collectMetrics();
+
+    expect(metrics.recordFailureReasonCount).toHaveBeenCalledWith(
+      'clip-generation',
+      'Error: ECONNREFUSED',
+      2,
+    );
+    expect(metrics.recordFailureReasonCount).toHaveBeenCalledWith(
+      'clip-generation',
+      'Error: timeout',
+      1,
+    );
+  });
+
+  it('uses "unknown" as the reason when failedReason is undefined', async () => {
+    await build([{ attemptsMade: 1 }]);
+    await service.collectMetrics();
+
+    expect(metrics.recordFailureReasonCount).toHaveBeenCalledWith(
+      'clip-generation',
+      'unknown',
+      1,
+    );
+  });
+
+  it('truncates long failure reason strings to 120 chars', async () => {
+    const longReason = 'Error: ' + 'x'.repeat(200);
+    await build([{ attemptsMade: 1, failedReason: longReason }]);
+    await service.collectMetrics();
+
+    const calls = metrics.recordFailureReasonCount.mock.calls;
+    expect(calls[0][1]).toHaveLength(120);
+  });
+
+  it('uses only first line of multi-line failure reason', async () => {
+    await build([
+      { attemptsMade: 1, failedReason: 'Error: bad thing\n    at foo.ts:10\n    at bar.ts:5' },
+    ]);
+    await service.collectMetrics();
+
+    expect(metrics.recordFailureReasonCount).toHaveBeenCalledWith(
+      'clip-generation',
+      'Error: bad thing',
+      1,
+    );
+  });
+
+  it('returns registered queue names', async () => {
+    await build([]);
+    expect(service.getRegisteredQueues()).toContain('clip-generation');
+  });
+});

--- a/src/metrics/queue-collector.service.ts
+++ b/src/metrics/queue-collector.service.ts
@@ -90,14 +90,28 @@ export class QueueCollectorService implements OnModuleInit, OnModuleDestroy {
 
           this.queueMetrics.recordQueueCounts(queueName, counts);
 
-          // Calculate average retry count
+          // Aggregate retry counts and failure reasons from the last 100 failed jobs
           const failedJobs = await queue.getFailed(0, 100);
+
+          const totalRetries = failedJobs.reduce(
+            (sum, job) => sum + (job.attemptsMade || 0),
+            0,
+          );
           const avgRetries =
-            failedJobs.length > 0
-              ? failedJobs.reduce((sum, job) => sum + (job.attemptsMade || 0), 0) /
-                failedJobs.length
-              : 0;
+            failedJobs.length > 0 ? totalRetries / failedJobs.length : 0;
           this.queueMetrics.recordAvgRetryCount(queueName, avgRetries);
+
+          // Count occurrences of each failure reason and record them
+          const reasonCounts = new Map<string, number>();
+          for (const job of failedJobs) {
+            const reason = job.failedReason ?? 'unknown';
+            // Normalise: strip long stack details, keep first line only
+            const key = reason.split('\n')[0].slice(0, 120);
+            reasonCounts.set(key, (reasonCounts.get(key) ?? 0) + 1);
+          }
+          for (const [reason, count] of reasonCounts) {
+            this.queueMetrics.recordFailureReasonCount(queueName, reason, count);
+          }
 
           this.logger.debug(
             `Queue metrics [${queueName}]: waiting=${counts.waiting}, active=${counts.active}, ` +

--- a/src/metrics/queue-metrics.service.ts
+++ b/src/metrics/queue-metrics.service.ts
@@ -55,6 +55,13 @@ export class QueueMetricsService implements OnModuleInit, OnModuleDestroy {
     labelNames: ['queue'],
   });
 
+  // Gauge: failure reason counts by queue and reason
+  private readonly jobFailureReasons = new Gauge({
+    name: 'clipcash_queue_failure_reason_count',
+    help: 'Number of failed jobs by queue and failure reason (sampled from last 100 failed jobs)',
+    labelNames: ['queue', 'reason'],
+  });
+
   // Map to track job start times for duration calculation
   private readonly jobStartTimes = new Map<string, number>();
 
@@ -147,6 +154,17 @@ export class QueueMetricsService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Record failure reason counts for a queue (sampled from failed job list).
+   *
+   * @param queue Queue name
+   * @param reason Normalised failure reason string
+   * @param count Number of jobs with this reason in the current sample
+   */
+  recordFailureReasonCount(queue: string, reason: string, count: number): void {
+    this.jobFailureReasons.set({ queue, reason }, count);
+  }
+
+  /**
    * Get all metrics registered in this service.
    * Returns the metrics in Prometheus format.
    *
@@ -158,6 +176,7 @@ export class QueueMetricsService implements OnModuleInit, OnModuleDestroy {
     jobFailures: Counter;
     jobCompletions: Counter;
     jobRetryRate: Gauge;
+    jobFailureReasons: Gauge;
   } {
     return {
       jobCount: this.jobCount,
@@ -165,6 +184,7 @@ export class QueueMetricsService implements OnModuleInit, OnModuleDestroy {
       jobFailures: this.jobFailures,
       jobCompletions: this.jobCompletions,
       jobRetryRate: this.jobRetryRate,
+      jobFailureReasons: this.jobFailureReasons,
     };
   }
 


### PR DESCRIPTION
## Summary

Resolves two related BullMQ issues in a single clean change.

### #416 — Queue Configuration Validation

- Added `getBullMQConnectionConfig` and `validateConnectionConfig` to `src/config/bullmq.config.ts`
- Validates `REDIS_HOST` (non-empty string) and `REDIS_PORT` (1–65535) at startup
- Invalid config prints a clear error message and exits before the app starts

### #415 — Queue Retry Analytics

- `QueueCollectorService` now aggregates failure reasons from the last 100 failed jobs per queue
- Failure reasons are normalised (first line, max 120 chars) and counted per queue
- Exposed as a new Prometheus gauge: `clipcash_queue_failure_reason_count{queue, reason}`
- Average retry count per queue was already tracked; logic is now cleaner

## Tests

- 9 new tests for connection config validation (`bullmq.config.spec.ts`)
- 7 new tests for retry analytics in a new `queue-collector.service.spec.ts`
- All 27 tests pass

Closes #416
Closes #415