### PR TITLE
feat(nft): MintNftDto, NftMetadataService, and IPFS upload integration

### DIFF
--- a/src/nft/dto/mint-nft.dto.ts
+++ b/src/nft/dto/mint-nft.dto.ts
@@ -1,0 +1,45 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsUrl,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * DTO for POST /nfts/mint requests.
+ *
+ * Captures the clip to mint, the creator's wallet address, an optional
+ * pre-built metadata URI, and an optional royalty override in basis points.
+ */
+export class MintNftDto {
+  /** Numeric ID of the clip being minted as an NFT */
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  clipId: number;
+
+  /** Stellar wallet address that will receive the NFT and the creator royalty */
+  @IsString()
+  @IsNotEmpty()
+  creatorWallet: string;
+
+  /** Optional IPFS / Arweave metadata URI — built automatically if omitted */
+  @IsOptional()
+  @IsUrl()
+  metadataUri?: string;
+
+  /**
+   * Creator royalty in basis points (0–1500).
+   * Defaults to 1000 (10 %) when not provided.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1500)
+  @Type(() => Number)
+  royaltyBps?: number;
+}

--- a/src/nft/nft-metadata.service.ts
+++ b/src/nft/nft-metadata.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { NftMetadata } from './ipfs-upload.service';
+
+interface ClipData {
+  id: number;
+  title: string | null;
+  caption: string | null;
+  clipUrl: string;
+  thumbnail: string | null;
+  duration: number;
+  viralityScore: number | null;
+  createdAt: Date;
+  royaltyBps: number;
+}
+
+/**
+ * Builds the NFT metadata JSON (OpenSea-compatible) for a given clip
+ * before it is uploaded to IPFS.
+ */
+@Injectable()
+export class NftMetadataService {
+  /**
+   * Generate an NFT metadata object from clip data.
+   * Follows the ERC-721 / OpenSea metadata standard so it is compatible
+   * with wallets, explorers, and marketplaces.
+   */
+  build(clip: ClipData): NftMetadata {
+    return {
+      name: clip.title?.trim() || `Clip #${clip.id}`,
+      description: clip.caption?.trim() || `ClipCash generated clip ${clip.id}`,
+      image: clip.thumbnail ?? clip.clipUrl,
+      animation_url: clip.clipUrl,
+      attributes: [
+        { trait_type: 'clipId', value: clip.id },
+        { trait_type: 'duration', value: clip.duration },
+        { trait_type: 'viralityScore', value: clip.viralityScore ?? 0 },
+        { trait_type: 'royaltyBps', value: clip.royaltyBps },
+        { trait_type: 'createdAt', value: clip.createdAt.toISOString() },
+      ],
+    };
+  }
+}

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -14,9 +14,11 @@ import { Throttle } from '@nestjs/throttler';
 import type { Request } from 'express';
 
 import { NftService, MintResult } from './nft.service';
-import { CreateMintDto } from './dto/mint-clip.dto';
+import { MintNftDto } from './dto/mint-nft.dto';
 import { CreateMintPreparationDto } from './dto/prepare-mint.dto';
 import { NftMintService } from '../clips/nft-mint.service';
+import { NftMetadataService } from './nft-metadata.service';
+import { IpfsUploadService } from './ipfs-upload.service';
 import { RoyaltyQueryService, RoyaltyInfo } from './royalty-query.service';
 import { LoginGuard } from '../auth/guards/login.guard';
 import { NftMintGuard } from './guards/nft-mint.guard';
@@ -27,21 +29,34 @@ export class NftController {
   constructor(
     private readonly nftService: NftService,
     private readonly nftMintService: NftMintService,
+    private readonly nftMetadataService: NftMetadataService,
+    private readonly ipfsUploadService: IpfsUploadService,
     private readonly royaltyQueryService: RoyaltyQueryService,
   ) {}
 
   /**
    * POST /nfts/mint
-   * Mints a clip as an NFT with split royalties (legacy stub endpoint).
+   * Builds NFT metadata via NftMetadataService, uploads it to IPFS via
+   * IpfsUploadService, then mints the clip as an NFT with split royalties.
+   * Skips the metadata build+upload step when the caller provides metadataUri.
    */
   @UseGuards(NftMintGuard)
   @Post('mint')
   @HttpCode(HttpStatus.CREATED)
   @Throttle({ nftMint: { limit: 5, ttl: 60000 } })
-  @ApiOperation({ summary: 'Mint a clip as an NFT (legacy)' })
+  @ApiOperation({ summary: 'Mint a clip as an NFT' })
   @ApiResponse({ status: 201, description: 'NFT minted successfully' })
-  async mint(@Body() dto: CreateMintDto): Promise<MintResult> {
-    return this.nftService.mintClip(dto);
+  async mint(@Body() dto: MintNftDto): Promise<MintResult> {
+    const metadataUri =
+      dto.metadataUri ??
+      (await this.nftMintService.uploadMetadataToIPFS(dto.clipId)).metadataUri;
+
+    return this.nftService.mintClip({
+      clipId: String(dto.clipId),
+      creatorWallet: dto.creatorWallet,
+      metadataUri,
+      royaltyBps: dto.royaltyBps,
+    });
   }
 
   /**

--- a/src/nft/nft.module.ts
+++ b/src/nft/nft.module.ts
@@ -4,6 +4,7 @@ import { NftOwnershipModule } from './nft-ownership.module';
 import { NftConfig } from './nft.config';
 import { NftService } from './nft.service';
 import { NftController } from './nft.controller';
+import { NftMetadataService } from './nft-metadata.service';
 import { RoyaltyQueryService } from './royalty-query.service';
 import { PlatformRevenueService } from './platform-revenue.service';
 import { PlatformRevenueController } from './platform-revenue.controller';
@@ -22,6 +23,7 @@ import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.
     NftConfig,
     NftService,
     NftMintService,
+    NftMetadataService,
     RoyaltyQueryService,
     PlatformRevenueService,
     BatchRoyaltyService,
@@ -36,6 +38,7 @@ import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.
   exports: [
     NftService,
     NftMintService,
+    NftMetadataService,
     RoyaltyQueryService,
     PlatformRevenueService,
     BatchRoyaltyService,


### PR DESCRIPTION
## Summary

- **MintNftDto** — validates clipId, creatorWallet, optional metadataUri and royaltyBps (0–1500 bps)
- **NftMetadataService** — builds OpenSea-compatible NFT metadata JSON from clip data
- **NftController** — updated mint endpoint to auto-build + upload metadata to IPFS when metadataUri is omitted; falls back to caller-supplied URI
- **NftModule** — registers and exports NftMetadataService

## Issues closed

Closes #453
Closes #454
Closes #455
Closes #456