### PR TITLE
feat: resolve issues #384 #385 #386 #387

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,7 +74,7 @@ model Clip {
   caption       String?
   startTime     Float
   endTime       Float
-  duration      Int
+  duration      Float
   viralityScore Float?
   royaltyBps    Int?
   postStatus    Json?

--- a/src/clips/clip-generation.processor.ts
+++ b/src/clips/clip-generation.processor.ts
@@ -334,7 +334,7 @@ export class ClipGenerationProcessor extends WorkerHost implements OnModuleInit 
     await job.updateProgress({ percent: PROGRESS.FFMPEG_CUT, step: 'ffmpeg_cut' });
 
     const metadata = await getVideoMetadata(data.outputPath);
-    const actualDuration = Math.round(metadata.duration);
+    const actualDuration = parseFloat(metadata.duration.toFixed(3));
 
     const viralityScore =
       data.existingViralityScore ??
@@ -426,6 +426,7 @@ export class ClipGenerationProcessor extends WorkerHost implements OnModuleInit 
         thumbnail: result.thumbnail,
         status: result.status,
         duration: result.duration,
+        caption: result.caption,
         error: result.error,
         localFilePath: result.localFilePath,
       });

--- a/src/clips/clips.controller.ts
+++ b/src/clips/clips.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Body,
   Param,
   Query,
@@ -155,5 +156,29 @@ export class ClipsController {
       (req as any).user?.id ?? (req.headers['x-user-id'] as string) ?? 0,
     );
     return this.clipsService.regenerate(userId, Number(id));
+  }
+
+  @Patch(':id/caption')
+  @ApiOperation({
+    summary: 'Update clip caption',
+    description: 'Update the auto-generated caption for a clip. Useful for customizing social media posts.',
+  })
+  @ApiParam({ name: 'id', description: 'Clip ID' })
+  @ApiResponse({ status: 200, description: 'Caption updated' })
+  @ApiResponse({ status: 400, description: 'Invalid request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Clip not found' })
+  async updateCaption(
+    @Param('id') id: string,
+    @Body('caption') caption: string,
+    @Req() req: Request,
+  ) {
+    if (!caption || typeof caption !== 'string') {
+      throw new BadRequestException('caption is required and must be a string');
+    }
+    const userId: number = Number(
+      (req as any).user?.id ?? (req.headers['x-user-id'] as string) ?? 0,
+    );
+    return this.clipsService.updateCaption(Number(id), userId, caption);
   }
 }

--- a/src/clips/clips.service.ts
+++ b/src/clips/clips.service.ts
@@ -471,6 +471,36 @@ export class ClipsService {
     return this.cancelledVideos.has(videoId);
   }
 
+  async updateCaption(
+    id: number,
+    userId: number,
+    caption: string,
+  ): Promise<{ id: number; caption: string }> {
+    const clip = await this.prisma.clip.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        video: { select: { userId: true } },
+      },
+    });
+
+    if (!clip) {
+      throw new BadRequestException(`Clip ${id} not found`);
+    }
+
+    if (clip.video.userId !== userId) {
+      throw new ForbiddenException('You do not have permission to update this clip');
+    }
+
+    await this.prisma.clip.update({
+      where: { id },
+      data: { caption, updatedAt: new Date() },
+    });
+
+    this.logger.log(`Clip ${id} caption updated`);
+    return { id, caption };
+  }
+
   async cancelVideo(
     videoId: string,
   ): Promise<{ cancelled: boolean; removedJobs: number; abortedJobs: number }> {

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -13,7 +13,7 @@ export class JobsController {
     summary: 'List failed jobs',
     description: 'Lists failed jobs in the specified queue. Useful for monitoring and debugging.',
   })
-  @ApiQuery({ name: 'type', required: false, description: 'Queue type (default: clip-generation)', example: 'clip-generation' })
+  @ApiQuery({ name: 'type', required: false, description: 'Queue type (default: clip-generation). Supported: clip-generation, clip-posting, nft-mint', example: 'clip-generation' })
   @ApiResponse({ status: 200, description: 'List of failed jobs returned' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getFailedJobs(@Query('type') type: string) {
@@ -23,13 +23,14 @@ export class JobsController {
   @Post('retry/:jobId')
   @ApiOperation({
     summary: 'Retry failed job',
-    description: 'Retries a specific failed job by its ID.',
+    description: 'Retries a specific failed job by its ID. Optionally specify the queue type to narrow the search.',
   })
   @ApiParam({ name: 'jobId', description: 'Job ID to retry', example: 'job_abc123' })
+  @ApiQuery({ name: 'type', required: false, description: 'Queue type to search (optional). Searches all queues if omitted.', example: 'clip-generation' })
   @ApiResponse({ status: 200, description: 'Job retry initiated' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Job not found' })
-  async retryJob(@Param('jobId') jobId: string) {
-    return this.jobsService.retryJob(jobId);
+  async retryJob(@Param('jobId') jobId: string, @Query('type') type?: string) {
+    return this.jobsService.retryJob(jobId, type);
   }
 }

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -3,11 +3,15 @@ import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
 import { QueueCleanupService } from './queue-cleanup.service';
 import { CLIP_GENERATION_QUEUE } from '../clips/clip-generation.queue';
+import { CLIP_POSTING_QUEUE } from '../clips/clip-posting.queue';
+import { NFT_MINT_QUEUE } from '../clips/nft-mint.queue';
 import { registerQueue } from '../common';
 
 @Module({
   imports: [
     registerQueue(CLIP_GENERATION_QUEUE),
+    registerQueue(CLIP_POSTING_QUEUE),
+    registerQueue(NFT_MINT_QUEUE),
   ],
   controllers: [JobsController],
   providers: [JobsService, QueueCleanupService],

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -5,26 +5,51 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
-import { Queue, Job } from 'bullmq';
+import { Queue } from 'bullmq';
 import { CLIP_GENERATION_QUEUE } from '../clips/clip-generation.queue';
+import { CLIP_POSTING_QUEUE } from '../clips/clip-posting.queue';
+import { NFT_MINT_QUEUE } from '../clips/nft-mint.queue';
+
+const SUPPORTED_QUEUES = [
+  CLIP_GENERATION_QUEUE,
+  CLIP_POSTING_QUEUE,
+  NFT_MINT_QUEUE,
+] as const;
 
 @Injectable()
 export class JobsService {
   private readonly logger = new Logger(JobsService.name);
 
+  private readonly queueMap: Record<string, Queue>;
+
   constructor(
     @InjectQueue(CLIP_GENERATION_QUEUE) private readonly clipQueue: Queue,
-  ) {}
+    @InjectQueue(CLIP_POSTING_QUEUE) private readonly postingQueue: Queue,
+    @InjectQueue(NFT_MINT_QUEUE) private readonly mintQueue: Queue,
+  ) {
+    this.queueMap = {
+      [CLIP_GENERATION_QUEUE]: clipQueue,
+      [CLIP_POSTING_QUEUE]: postingQueue,
+      [NFT_MINT_QUEUE]: mintQueue,
+    };
+  }
+
+  private resolveQueue(type: string): Queue {
+    const queue = this.queueMap[type];
+    if (!queue) {
+      throw new BadRequestException(
+        `Unsupported queue type: "${type}". Supported: ${SUPPORTED_QUEUES.join(', ')}`,
+      );
+    }
+    return queue;
+  }
 
   /**
    * Returns failed jobs from the specified queue.
    */
   async getFailedJobs(type: string) {
-    if (type !== 'clip-generation') {
-      throw new BadRequestException(`Unsupported job type: ${type}`);
-    }
-
-    const failedJobs = await this.clipQueue.getFailed();
+    const queue = this.resolveQueue(type);
+    const failedJobs = await queue.getFailed();
 
     return failedJobs.map((job) => ({
       id: job.id,
@@ -39,23 +64,27 @@ export class JobsService {
   }
 
   /**
-   * Retries a specific job by ID.
+   * Retries a specific job by ID from the specified queue.
    */
-  async retryJob(jobId: string) {
-    const job = await this.clipQueue.getJob(jobId);
-    if (!job) {
-      throw new NotFoundException(`Job ${jobId} not found`);
+  async retryJob(jobId: string, type?: string) {
+    const queues = type ? [this.resolveQueue(type)] : Object.values(this.queueMap);
+
+    for (const queue of queues) {
+      const job = await queue.getJob(jobId);
+      if (!job) continue;
+
+      const state = await job.getState();
+      if (state !== 'failed') {
+        throw new BadRequestException(
+          `Job ${jobId} is not in failed state (current state: ${state})`,
+        );
+      }
+
+      await job.retry();
+      this.logger.log(`Job ${jobId} retried from ${queue.name}`);
+      return { message: `Job ${jobId} retried successfully`, queue: queue.name };
     }
 
-    const state = await job.getState();
-    if (state !== 'failed') {
-      throw new BadRequestException(
-        `Job ${jobId} is not in failed state (current state: ${state})`,
-      );
-    }
-
-    await job.retry();
-    this.logger.log(`Job ${jobId} retried from DLQ`);
-    return { message: `Job ${jobId} retried successfully` };
+    throw new NotFoundException(`Job ${jobId} not found in any queue`);
   }
 }


### PR DESCRIPTION
### Issue #384 - Support Direct Video Uploads ✅
Already implemented via `POST /videos/upload` with `FileInterceptor`, disk storage, format/size/duration validation, and `sourceType: 'upload'` tracking.

### Issue #385 - Fix Clip Duration Calculation 🎯
- **`prisma/schema.prisma`**: Changed `Clip.duration` from `Int` to `Float` to eliminate rounding errors
- **`clip-generation.processor.ts`**: Replaced `Math.round(metadata.duration)` with `parseFloat(metadata.duration.toFixed(3))` for precise duration from ffprobe

### Issue #386 - Auto-Generate Clip Captions 📝
- Captions already auto-generated via `caption.util.ts` with format `🔥 {title} 🚀`
- **`clip-generation.processor.ts`**: Caption now saved to database in `updateClipInDatabase`
- **`clips.service.ts`**: Added `updateCaption()` method with ownership validation
- **`clips.controller.ts`**: Added `PATCH /clips/:id/caption` endpoint for editing
- Caption editing also available through existing `POST /clips/bulk-update`

### Issue #387 - Dead-Letter Queue Monitoring 🔍
- **`jobs.module.ts`**: Registered all queues (clip-generation, clip-posting, nft-mint)
- **`jobs.service.ts`**: Rewrote to support multiple queue types via a queue map; `retryJob()` now searches all queues when no type is specified
- **`jobs.controller.ts`**: `POST /jobs/retry/:jobId` accepts optional `type` query param

Closes #384, Closes #385, Closes #386, Closes #387