### PR TITLE
feat(payouts): automatic Stellar on-chain transaction tracking

### DIFF
--- a/src/payouts/payouts.module.ts
+++ b/src/payouts/payouts.module.ts
@@ -15,6 +15,8 @@ import { EncryptionModule } from '../encryption/encryption.module';
 import { MetricsModule } from '../metrics/metrics.module';
 import { PayoutRetryProcessor } from './payout-retry.processor';
 import { PAYOUT_RETRY_QUEUE, PAYOUT_RETRY_QUEUE_PRIORITY } from './payout-retry.queue';
+import { StellarConfirmationProcessor } from './stellar-confirmation.processor';
+import { STELLAR_CONFIRMATION_QUEUE } from './stellar-confirmation.queue';
 import { PayoutApprovalService } from './payout-approval.service';
 
 @Module({
@@ -27,6 +29,9 @@ import { PayoutApprovalService } from './payout-approval.service';
     BullModule.registerQueue({
       name: PAYOUT_RETRY_QUEUE,
       defaultJobOptions: { priority: PAYOUT_RETRY_QUEUE_PRIORITY },
+    }),
+    BullModule.registerQueue({
+      name: STELLAR_CONFIRMATION_QUEUE,
     }),
   ],
   controllers: [
@@ -41,6 +46,7 @@ import { PayoutApprovalService } from './payout-approval.service';
     FeeService,
     PayoutMethodService,
     PayoutRetryProcessor,
+    StellarConfirmationProcessor,
     PayoutApprovalService,
   ],
   exports: [PayoutsService, FeeService, PayoutMethodService],

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -14,9 +14,9 @@ import { StellarService } from '../stellar/stellar.service';
 import { PayoutReceiptService } from './payout-receipt.service';
 import { EarningsService } from '../earnings/earnings.service';
 import { PAYOUT_RETRY_QUEUE, MAX_PAYOUT_RETRIES, PAYOUT_RETRY_BACKOFF_BASE } from './payout-retry.queue';
+import { STELLAR_CONFIRMATION_MAX_POLLS } from './stellar-confirmation.queue';
 import { FeeService } from './fee.service';
 import { PayoutApprovalService } from './payout-approval.service';
-import { FeeService } from './fee.service';
 
 const OPEN_PAYOUT_STATUSES = [
   'pending',
@@ -171,6 +171,7 @@ export class PayoutsService {
         transactionId,
         stellarXdr,
         externalTransactionId: transactionId,
+        onChainTxHash: transactionId,
       },
     });
 
@@ -762,5 +763,81 @@ export class PayoutsService {
       id: updated.id,
       status: updated.status,
     };
+  }
+
+  async pollPendingStellarPayouts(): Promise<void> {
+    const pending = await this.prisma.payout.findMany({
+      where: {
+        method: 'stellar',
+        status: { in: ['pending', 'processing'] },
+        onChainTxHash: { not: null },
+        confirmedAt: null,
+      },
+      select: { id: true, onChainTxHash: true, retryCount: true },
+    });
+
+    if (pending.length === 0) return;
+
+    this.logger.log(`Polling ${pending.length} pending Stellar payout(s) for on-chain confirmation`);
+
+    for (const payout of pending) {
+      try {
+        await this.confirmOneStellarPayout(payout.id, payout.onChainTxHash!, payout.retryCount);
+      } catch (error) {
+        this.logger.error(
+          `Confirmation poll failed for payout ${payout.id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  private async confirmOneStellarPayout(
+    payoutId: number,
+    txHash: string,
+    currentPollCount: number,
+  ): Promise<void> {
+    const result = await this.stellarService.getTransactionStatus(txHash);
+
+    if (result.found) {
+      if (result.successful) {
+        const updated = await this.prisma.payout.updateMany({
+          where: {
+            id: payoutId,
+            status: { in: ['pending', 'processing'] },
+            confirmedAt: null,
+          },
+          data: {
+            status: 'completed',
+            confirmedAt: result.confirmedAt ?? new Date(),
+          },
+        });
+        if (updated.count > 0) {
+          this.logger.log(`Payout ${payoutId} confirmed on-chain (tx: ${txHash})`);
+        }
+      } else {
+        await this.prisma.payout.updateMany({
+          where: { id: payoutId, status: { in: ['pending', 'processing'] } },
+          data: { status: 'failed' },
+        });
+        this.logger.warn(`Payout ${payoutId} rejected on-chain (tx: ${txHash})`);
+      }
+      return;
+    }
+
+    const newPollCount = currentPollCount + 1;
+    if (newPollCount >= STELLAR_CONFIRMATION_MAX_POLLS) {
+      await this.prisma.payout.updateMany({
+        where: { id: payoutId, status: { in: ['pending', 'processing'] } },
+        data: { status: 'failed', retryCount: newPollCount },
+      });
+      this.logger.warn(
+        `Payout ${payoutId} marked failed after ${newPollCount} unconfirmed polls (tx: ${txHash})`,
+      );
+    } else {
+      await this.prisma.payout.update({
+        where: { id: payoutId },
+        data: { retryCount: newPollCount, lastAttemptAt: new Date() },
+      });
+    }
   }
 }

--- a/src/payouts/stellar-confirmation.processor.spec.ts
+++ b/src/payouts/stellar-confirmation.processor.spec.ts
@@ -1,0 +1,405 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { StellarConfirmationProcessor } from './stellar-confirmation.processor';
+import { PayoutsService } from './payouts.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { StellarService } from '../stellar/stellar.service';
+import { CircuitBreakerService } from '../common/circuit-breaker/circuit-breaker.service';
+import {
+  STELLAR_CONFIRMATION_QUEUE,
+  STELLAR_CONFIRMATION_JOB,
+  STELLAR_CONFIRMATION_INTERVAL_MS,
+  STELLAR_CONFIRMATION_MAX_POLLS,
+} from './stellar-confirmation.queue';
+import { PAYOUT_RETRY_QUEUE } from './payout-retry.queue';
+
+const TX_HASH = 'abc123deadbeef';
+const CONFIRMED_AT = new Date('2025-01-15T10:00:00.000Z');
+
+const mockPrismaService = {
+  payout: {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    create: jest.fn(),
+    aggregate: jest.fn(),
+  },
+  wallet: { findFirst: jest.fn() },
+  user: { findUnique: jest.fn() },
+  earning: { aggregate: jest.fn() },
+  $transaction: jest.fn(),
+};
+
+const mockStellarService = {
+  horizonUrl: 'https://horizon-testnet.stellar.org',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+  getTransactionStatus: jest.fn(),
+  getAccountBalance: jest.fn(),
+  validateAddress: jest.fn().mockReturnValue({ valid: true }),
+};
+
+const mockQueue = {
+  add: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockPayoutRetryQueue = { add: jest.fn() };
+
+function buildModule(overrides: Record<string, unknown> = {}): Promise<TestingModule> {
+  return Test.createTestingModule({
+    providers: [
+      StellarConfirmationProcessor,
+      PayoutsService,
+      { provide: PrismaService, useValue: mockPrismaService },
+      { provide: StellarService, useValue: mockStellarService },
+      { provide: CircuitBreakerService, useValue: { execute: jest.fn() } },
+      {
+        provide: 'PayoutReceiptService',
+        useValue: { generateAndSendReceipt: jest.fn() },
+      },
+      {
+        provide: 'FeeService',
+        useValue: { calculateFee: jest.fn() },
+      },
+      {
+        provide: 'PayoutApprovalService',
+        useValue: { resolveInitialStatus: jest.fn(), requiresManualApproval: jest.fn() },
+      },
+      {
+        provide: 'EarningsService',
+        useValue: {},
+      },
+      { provide: getQueueToken(STELLAR_CONFIRMATION_QUEUE), useValue: mockQueue },
+      { provide: getQueueToken(PAYOUT_RETRY_QUEUE), useValue: mockPayoutRetryQueue },
+      ...Object.entries(overrides).map(([token, useValue]) => ({ provide: token, useValue })),
+    ],
+  }).compile();
+}
+
+describe('StellarConfirmationProcessor', () => {
+  let processor: StellarConfirmationProcessor;
+  let payoutsService: PayoutsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPrismaService.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockPrismaService) => Promise<unknown>) => fn(mockPrismaService),
+    );
+
+    const module = await buildModule();
+    processor = module.get<StellarConfirmationProcessor>(StellarConfirmationProcessor);
+    payoutsService = module.get<PayoutsService>(PayoutsService);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+  });
+
+  describe('onModuleInit', () => {
+    it('should schedule a repeatable confirmation poll job', async () => {
+      await processor.onModuleInit();
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        STELLAR_CONFIRMATION_JOB,
+        {},
+        expect.objectContaining({
+          repeat: { every: STELLAR_CONFIRMATION_INTERVAL_MS },
+          jobId: `${STELLAR_CONFIRMATION_JOB}-recurring`,
+        }),
+      );
+    });
+  });
+
+  describe('process', () => {
+    it('should delegate to pollPendingStellarPayouts', async () => {
+      const spy = jest.spyOn(payoutsService, 'pollPendingStellarPayouts').mockResolvedValue();
+      await processor.process({ id: 'job-1' } as any);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('PayoutsService.pollPendingStellarPayouts', () => {
+  let service: PayoutsService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPrismaService.$transaction.mockImplementation(
+      async (fn: (tx: typeof mockPrismaService) => Promise<unknown>) => fn(mockPrismaService),
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PayoutsService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: StellarService, useValue: mockStellarService },
+        { provide: CircuitBreakerService, useValue: { execute: jest.fn() } },
+        {
+          provide: 'PayoutReceiptService',
+          useValue: { generateAndSendReceipt: jest.fn() },
+        },
+        {
+          provide: 'FeeService',
+          useValue: { calculateFee: jest.fn() },
+        },
+        {
+          provide: 'PayoutApprovalService',
+          useValue: { resolveInitialStatus: jest.fn(), requiresManualApproval: jest.fn() },
+        },
+        { provide: 'EarningsService', useValue: {} },
+        { provide: getQueueToken(PAYOUT_RETRY_QUEUE), useValue: mockPayoutRetryQueue },
+      ],
+    }).compile();
+
+    service = module.get<PayoutsService>(PayoutsService);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  it('should do nothing when no pending Stellar payouts exist', async () => {
+    mockPrismaService.payout.findMany.mockResolvedValue([]);
+
+    await service.pollPendingStellarPayouts();
+
+    expect(mockPrismaService.payout.updateMany).not.toHaveBeenCalled();
+    expect(mockPrismaService.payout.update).not.toHaveBeenCalled();
+  });
+
+  it('should query only stellar payouts in pending/processing status with a tx hash and no confirmedAt', async () => {
+    mockPrismaService.payout.findMany.mockResolvedValue([]);
+
+    await service.pollPendingStellarPayouts();
+
+    expect(mockPrismaService.payout.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          method: 'stellar',
+          status: { in: ['pending', 'processing'] },
+          onChainTxHash: { not: null },
+          confirmedAt: null,
+        },
+      }),
+    );
+  });
+
+  describe('successful on-chain confirmation', () => {
+    it('should mark payout as completed with confirmedAt from Horizon', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 1, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({
+        found: true,
+        successful: true,
+        confirmedAt: CONFIRMED_AT,
+      });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.pollPendingStellarPayouts();
+
+      expect(mockPrismaService.payout.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          status: { in: ['pending', 'processing'] },
+          confirmedAt: null,
+        },
+        data: {
+          status: 'completed',
+          confirmedAt: CONFIRMED_AT,
+        },
+      });
+    });
+
+    it('should persist confirmedAt timestamp exactly as returned by Horizon', async () => {
+      const horizonTimestamp = new Date('2025-03-10T08:30:00.000Z');
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 2, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({
+        found: true,
+        successful: true,
+        confirmedAt: horizonTimestamp,
+      });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.pollPendingStellarPayouts();
+
+      const call = mockPrismaService.payout.updateMany.mock.calls[0][0];
+      expect(call.data.confirmedAt).toBe(horizonTimestamp);
+    });
+
+    it('should fall back to current time when Horizon does not return confirmedAt', async () => {
+      const before = new Date();
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 3, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({
+        found: true,
+        successful: true,
+        confirmedAt: undefined,
+      });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.pollPendingStellarPayouts();
+
+      const call = mockPrismaService.payout.updateMany.mock.calls[0][0];
+      const after = new Date();
+      expect(call.data.confirmedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(call.data.confirmedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+  });
+
+  describe('failed on-chain transaction', () => {
+    it('should mark payout as failed when transaction is rejected on-chain', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 4, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({
+        found: true,
+        successful: false,
+      });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.pollPendingStellarPayouts();
+
+      expect(mockPrismaService.payout.updateMany).toHaveBeenCalledWith({
+        where: { id: 4, status: { in: ['pending', 'processing'] } },
+        data: { status: 'failed' },
+      });
+    });
+
+    it('should not set confirmedAt when transaction fails on-chain', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 5, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({
+        found: true,
+        successful: false,
+      });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.pollPendingStellarPayouts();
+
+      const call = mockPrismaService.payout.updateMany.mock.calls[0][0];
+      expect(call.data).not.toHaveProperty('confirmedAt');
+    });
+  });
+
+  describe('retry behavior (transaction not yet found)', () => {
+    it('should increment retryCount when transaction is not yet on Horizon', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 6, onChainTxHash: TX_HASH, retryCount: 2 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({ found: false });
+      mockPrismaService.payout.update.mockResolvedValue({ id: 6 });
+
+      await service.pollPendingStellarPayouts();
+
+      expect(mockPrismaService.payout.update).toHaveBeenCalledWith({
+        where: { id: 6 },
+        data: { retryCount: 3, lastAttemptAt: expect.any(Date) },
+      });
+    });
+
+    it('should mark payout failed after max polls are exhausted', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 7, onChainTxHash: TX_HASH, retryCount: STELLAR_CONFIRMATION_MAX_POLLS - 1 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({ found: false });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.pollPendingStellarPayouts();
+
+      expect(mockPrismaService.payout.updateMany).toHaveBeenCalledWith({
+        where: { id: 7, status: { in: ['pending', 'processing'] } },
+        data: { status: 'failed', retryCount: STELLAR_CONFIRMATION_MAX_POLLS },
+      });
+    });
+
+    it('should not mark failed when one poll below the max threshold', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 8, onChainTxHash: TX_HASH, retryCount: STELLAR_CONFIRMATION_MAX_POLLS - 2 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({ found: false });
+      mockPrismaService.payout.update.mockResolvedValue({ id: 8 });
+
+      await service.pollPendingStellarPayouts();
+
+      expect(mockPrismaService.payout.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.payout.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('idempotency', () => {
+    it('should use updateMany with status filter to prevent double-completion', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 9, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({
+        found: true,
+        successful: true,
+        confirmedAt: CONFIRMED_AT,
+      });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 0 }); // already updated
+
+      await expect(service.pollPendingStellarPayouts()).resolves.not.toThrow();
+      expect(mockPrismaService.payout.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ confirmedAt: null }),
+        }),
+      );
+    });
+
+    it('should use updateMany with status filter to prevent double-failure', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 10, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockResolvedValue({
+        found: true,
+        successful: false,
+      });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 0 }); // already updated
+
+      await expect(service.pollPendingStellarPayouts()).resolves.not.toThrow();
+      expect(mockPrismaService.payout.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: { in: ['pending', 'processing'] } }),
+        }),
+      );
+    });
+  });
+
+  describe('error isolation', () => {
+    it('should continue processing remaining payouts when one throws a transient error', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 11, onChainTxHash: 'hash-fails', retryCount: 0 },
+        { id: 12, onChainTxHash: 'hash-ok', retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus
+        .mockRejectedValueOnce(new Error('Horizon connection timeout'))
+        .mockResolvedValueOnce({ found: true, successful: true, confirmedAt: CONFIRMED_AT });
+      mockPrismaService.payout.updateMany.mockResolvedValue({ count: 1 });
+
+      await expect(service.pollPendingStellarPayouts()).resolves.not.toThrow();
+
+      expect(mockPrismaService.payout.updateMany).toHaveBeenCalledTimes(1);
+      expect(mockPrismaService.payout.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ id: 12 }) }),
+      );
+    });
+
+    it('should not throw when all payouts encounter transient errors', async () => {
+      mockPrismaService.payout.findMany.mockResolvedValue([
+        { id: 13, onChainTxHash: TX_HASH, retryCount: 0 },
+      ]);
+      mockStellarService.getTransactionStatus.mockRejectedValue(
+        new Error('Circuit breaker open'),
+      );
+
+      await expect(service.pollPendingStellarPayouts()).resolves.not.toThrow();
+      expect(mockPrismaService.payout.updateMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/payouts/stellar-confirmation.processor.ts
+++ b/src/payouts/stellar-confirmation.processor.ts
@@ -1,0 +1,40 @@
+import { Processor, WorkerHost, InjectQueue } from '@nestjs/bullmq';
+import { Logger, OnModuleInit } from '@nestjs/common';
+import { Job, Queue } from 'bullmq';
+import { PayoutsService } from './payouts.service';
+import {
+  STELLAR_CONFIRMATION_QUEUE,
+  STELLAR_CONFIRMATION_JOB,
+  STELLAR_CONFIRMATION_INTERVAL_MS,
+} from './stellar-confirmation.queue';
+
+@Processor(STELLAR_CONFIRMATION_QUEUE, { concurrency: 1 })
+export class StellarConfirmationProcessor extends WorkerHost implements OnModuleInit {
+  private readonly logger = new Logger(StellarConfirmationProcessor.name);
+
+  constructor(
+    @InjectQueue(STELLAR_CONFIRMATION_QUEUE) private readonly queue: Queue,
+    private readonly payoutsService: PayoutsService,
+  ) {
+    super();
+  }
+
+  async onModuleInit(): Promise<void> {
+    await this.queue.add(
+      STELLAR_CONFIRMATION_JOB,
+      {},
+      {
+        repeat: { every: STELLAR_CONFIRMATION_INTERVAL_MS },
+        jobId: `${STELLAR_CONFIRMATION_JOB}-recurring`,
+      },
+    );
+    this.logger.log(
+      `Stellar confirmation poller scheduled every ${STELLAR_CONFIRMATION_INTERVAL_MS}ms`,
+    );
+  }
+
+  async process(job: Job): Promise<void> {
+    this.logger.debug(`Running Stellar confirmation poll (job ${job.id})`);
+    await this.payoutsService.pollPendingStellarPayouts();
+  }
+}

--- a/src/payouts/stellar-confirmation.queue.ts
+++ b/src/payouts/stellar-confirmation.queue.ts
@@ -1,0 +1,12 @@
+export const STELLAR_CONFIRMATION_QUEUE = 'stellar-confirmation';
+export const STELLAR_CONFIRMATION_JOB = 'poll-stellar-confirmations';
+
+export const STELLAR_CONFIRMATION_INTERVAL_MS = parseInt(
+  process.env.STELLAR_CONFIRMATION_INTERVAL_MS ?? '30000',
+  10,
+);
+
+export const STELLAR_CONFIRMATION_MAX_POLLS = parseInt(
+  process.env.STELLAR_CONFIRMATION_MAX_POLLS ?? '20',
+  10,
+);


### PR DESCRIPTION
Closes #362

---

## Summary

Adds an automatic background polling system that tracks Stellar payout transactions against the Horizon API, keeping `Payout` records synchronized with their actual on-chain state without any manual intervention.

### Problem

When a Stellar payout is initiated via `initiateStellarPayout`, the signed transaction XDR is prepared and the hash stored, but the confirmation status is never automatically reconciled with Horizon. If the transaction is submitted externally (e.g. by the user's wallet) or is delayed on the network, the payout record stays in `pending` indefinitely.

### Solution

- **Hash stored at preparation time** — `initiateStellarPayout` now writes `onChainTxHash` the moment the signed transaction is built, so the hash is available for polling before the XDR ever reaches Horizon.
- **Background poller** — `StellarConfirmationProcessor` (BullMQ `WorkerHost`, concurrency 1) schedules a repeatable job on startup that fires every **30 s** by default (`STELLAR_CONFIRMATION_INTERVAL_MS`).
- **Batch poll** — each tick calls `PayoutsService.pollPendingStellarPayouts()`, which finds every `pending`/`processing` Stellar payout that has an `onChainTxHash` and no `confirmedAt`, then checks each one against Horizon.
- **Status transitions**:
  - Horizon returns `successful: true` → `completed`, `confirmedAt` set to Horizon's `created_at` timestamp
  - Horizon returns `successful: false` → `failed`
  - Not found, below retry limit → `retryCount++`, `lastAttemptAt` updated
  - Not found, retry limit reached (`STELLAR_CONFIRMATION_MAX_POLLS`, default 20 ≈ 10 min) → `failed`
- **Idempotency** — all terminal status writes use `updateMany` with a `status: { in: [...] }` + `confirmedAt: null` filter so concurrent workers racing on the same record produce exactly one update.
- **Error isolation** — transient Horizon/network errors on one payout are caught and logged; remaining payouts in the batch still run. The existing `StellarService` circuit breaker (5 failures → 30 s recovery) protects against Horizon outages propagating to the job.

## Changed Files

| File | Change |
|------|--------|
| `src/payouts/stellar-confirmation.queue.ts` | New — queue name + env-configurable constants |
| `src/payouts/stellar-confirmation.processor.ts` | New — BullMQ processor + repeatable job scheduling |
| `src/payouts/stellar-confirmation.processor.spec.ts` | New — full test suite |
| `src/payouts/payouts.service.ts` | Store `onChainTxHash` in `initiateStellarPayout`; add `pollPendingStellarPayouts` + `confirmOneStellarPayout`; remove duplicate `FeeService` import |
| `src/payouts/payouts.module.ts` | Register `stellar-confirmation` queue and `StellarConfirmationProcessor` |

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `STELLAR_CONFIRMATION_INTERVAL_MS` | `30000` | How often (ms) the poller runs |
| `STELLAR_CONFIRMATION_MAX_POLLS` | `20` | Polls before an unconfirmed payout is marked `failed` |

## Test Plan

- [ ] All new unit tests pass: `stellar-confirmation.processor.spec.ts`
- [ ] Existing payout service tests pass (no regression from duplicate import removal and `onChainTxHash` addition)
- [ ] Manual: initiate a Stellar payout on testnet, observe `onChainTxHash` is stored immediately on the record
- [ ] Manual: confirm the poller updates status to `completed` and `confirmedAt` matches Horizon's `created_at`
- [ ] Manual: submit an invalid transaction hash, confirm payout is marked `failed` after `MAX_POLLS` attempts
- [ ] Manual: confirm that two simultaneous worker instances do not double-update the same payout record