### PR TITLE
feat(wallets): validated chain config layer for multi-chain support

### DIFF
--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -202,7 +202,7 @@ export class PayoutsService {
     }
 
     const wallet = await this.prisma.wallet.findFirst({
-      where: { userId, deletedAt: null },
+      where: { userId, chain: 'stellar', deletedAt: null },
     });
 
     if (!wallet) {
@@ -311,7 +311,7 @@ export class PayoutsService {
 
     if (method === 'stellar') {
       const wallet = await this.prisma.wallet.findFirst({
-        where: { userId, deletedAt: null },
+        where: { userId, chain: 'stellar', deletedAt: null },
       });
 
       if (!wallet) {

--- a/src/subscriptions/stellar-payment.service.ts
+++ b/src/subscriptions/stellar-payment.service.ts
@@ -34,8 +34,9 @@ export class StellarPaymentService {
   async createPaymentIntent(userId: number, dto: CreateStellarSubscriptionDto): Promise<StellarPaymentIntentDto> {
     // Get user's Stellar wallet
     const wallet = await this.prisma.wallet.findFirst({
-      where: { 
+      where: {
         userId,
+        chain: 'stellar',
         ...(dto.walletId && { id: parseInt(dto.walletId) }),
       },
     });

--- a/src/wallets/chain.constants.spec.ts
+++ b/src/wallets/chain.constants.spec.ts
@@ -1,0 +1,47 @@
+import {
+  SUPPORTED_CHAINS,
+  DEFAULT_CHAIN,
+  isSupportedChain,
+  assertSupportedChain,
+} from './chain.constants';
+
+describe('chain constants', () => {
+  it('exports exactly stellar, solana, and base as supported chains', () => {
+    expect([...SUPPORTED_CHAINS]).toEqual(['stellar', 'solana', 'base']);
+  });
+
+  it('sets stellar as the default chain', () => {
+    expect(DEFAULT_CHAIN).toBe('stellar');
+  });
+});
+
+describe('isSupportedChain', () => {
+  it.each([...SUPPORTED_CHAINS])('returns true for "%s"', (chain) => {
+    expect(isSupportedChain(chain)).toBe(true);
+  });
+
+  it.each(['ethereum', 'bitcoin', 'polygon', '', 'STELLAR', 'Solana'])(
+    'returns false for unsupported value "%s"',
+    (chain) => {
+      expect(isSupportedChain(chain)).toBe(false);
+    },
+  );
+});
+
+describe('assertSupportedChain', () => {
+  it.each([...SUPPORTED_CHAINS])('returns the chain value for "%s"', (chain) => {
+    expect(assertSupportedChain(chain)).toBe(chain);
+  });
+
+  it('throws when chain is not supported', () => {
+    expect(() => assertSupportedChain('ethereum')).toThrow(
+      'Unsupported chain "ethereum"',
+    );
+  });
+
+  it('includes the list of supported chains in the error message', () => {
+    expect(() => assertSupportedChain('bitcoin')).toThrow(
+      'stellar, solana, base',
+    );
+  });
+});

--- a/src/wallets/chain.constants.ts
+++ b/src/wallets/chain.constants.ts
@@ -1,0 +1,18 @@
+export const SUPPORTED_CHAINS = ['stellar', 'solana', 'base'] as const;
+
+export type SupportedChain = (typeof SUPPORTED_CHAINS)[number];
+
+export const DEFAULT_CHAIN: SupportedChain = 'stellar';
+
+export function isSupportedChain(value: string): value is SupportedChain {
+  return (SUPPORTED_CHAINS as readonly string[]).includes(value);
+}
+
+export function assertSupportedChain(value: string): SupportedChain {
+  if (!isSupportedChain(value)) {
+    throw new Error(
+      `Unsupported chain "${value}". Supported chains: ${SUPPORTED_CHAINS.join(', ')}`,
+    );
+  }
+  return value;
+}

--- a/src/wallets/dto/connect-wallet.dto.ts
+++ b/src/wallets/dto/connect-wallet.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, IsNotEmpty, IsIn } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsIn, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { SUPPORTED_CHAINS, DEFAULT_CHAIN } from '../chain.constants';
 
 /** @deprecated Use CreateWalletConnectionDto */
 export type ConnectWalletDto = CreateWalletConnectionDto;
@@ -10,11 +11,17 @@ export class CreateWalletConnectionDto {
   @IsNotEmpty()
   address: string;
 
-  @ApiProperty({ description: 'The blockchain network', example: 'stellar' })
+  @ApiPropertyOptional({
+    description: `The blockchain network. Defaults to "${DEFAULT_CHAIN}" when omitted.`,
+    enum: SUPPORTED_CHAINS,
+    default: DEFAULT_CHAIN,
+  })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  @IsIn(['stellar'])
-  chain: string;
+  @IsIn([...SUPPORTED_CHAINS], {
+    message: `chain must be one of: ${SUPPORTED_CHAINS.join(', ')}`,
+  })
+  chain?: string;
 
   @ApiProperty({ description: 'The wallet provider type', example: 'freighter' })
   @IsString()

--- a/src/wallets/wallet-management.service.spec.ts
+++ b/src/wallets/wallet-management.service.spec.ts
@@ -7,6 +7,7 @@ import {
 import { WalletManagementService } from './wallet-management.service';
 import { WalletValidationService } from './wallet-validation.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { DEFAULT_CHAIN, SUPPORTED_CHAINS } from './chain.constants';
 
 jest.mock('../prisma/prisma.service', () => ({
   PrismaService: class PrismaService {},
@@ -28,6 +29,7 @@ const mockPrisma = {
 
 const mockWalletValidationService = {
   validateStellarAddress: jest.fn(),
+  validateAddressForChain: jest.fn(),
 };
 
 const baseWallet = {
@@ -47,7 +49,7 @@ describe('WalletManagementService.disconnect', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    mockWalletValidationService.validateStellarAddress.mockImplementation(() => undefined);
+    mockWalletValidationService.validateAddressForChain.mockImplementation(() => undefined);
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WalletManagementService,
@@ -115,7 +117,7 @@ describe('WalletManagementService.connect', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    mockWalletValidationService.validateStellarAddress.mockImplementation(() => undefined);
+    mockWalletValidationService.validateAddressForChain.mockImplementation(() => undefined);
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WalletManagementService,
@@ -129,47 +131,116 @@ describe('WalletManagementService.connect', () => {
     service = module.get<WalletManagementService>(WalletManagementService);
   });
 
-  const dto = {
+  const stellarDto = {
     address: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
-    chain: 'stellar',
+    chain: 'stellar' as const,
     type: 'freighter',
   };
 
-  it('validates address before upsert', async () => {
-    mockWalletValidationService.validateStellarAddress.mockImplementation(() => {
-      throw new BadRequestException('Invalid Stellar address format');
+  it('rejects unsupported chain values before touching the database', async () => {
+    mockWalletValidationService.validateAddressForChain.mockImplementation(() => {
+      throw new BadRequestException('chain must be one of: stellar, solana, base');
     });
-    await expect(service.connect(42, dto)).rejects.toThrow(BadRequestException);
+    await expect(
+      service.connect(42, { ...stellarDto, chain: 'ethereum' as any }),
+    ).rejects.toThrow(BadRequestException);
     expect(mockPrisma.wallet.upsert).not.toHaveBeenCalled();
   });
 
-  it('upserts a wallet after validation', async () => {
-    mockPrisma.wallet.upsert.mockResolvedValue({ id: 1, userId: 42, ...dto });
+  it('defaults chain to stellar when not provided', async () => {
+    const dtoWithoutChain = { address: stellarDto.address, type: stellarDto.type };
+    mockPrisma.wallet.upsert.mockResolvedValue({ id: 1, ...dtoWithoutChain, chain: DEFAULT_CHAIN });
 
-    const result = await service.connect(42, dto);
+    await service.connect(42, dtoWithoutChain as any);
 
-    expect(mockWalletValidationService.validateStellarAddress).toHaveBeenCalledWith(
-      dto.address,
+    expect(mockPrisma.wallet.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          address_chain: {
+            address: stellarDto.address,
+            chain: DEFAULT_CHAIN,
+          },
+        },
+        create: expect.objectContaining({ chain: DEFAULT_CHAIN }),
+      }),
     );
+  });
+
+  it('calls validateAddressForChain with the resolved chain', async () => {
+    mockPrisma.wallet.upsert.mockResolvedValue({ id: 1, userId: 42, ...stellarDto });
+
+    await service.connect(42, stellarDto);
+
+    expect(mockWalletValidationService.validateAddressForChain).toHaveBeenCalledWith(
+      stellarDto.address,
+      'stellar',
+    );
+  });
+
+  it('aborts when validateAddressForChain throws', async () => {
+    mockWalletValidationService.validateAddressForChain.mockImplementation(() => {
+      throw new BadRequestException('Invalid Stellar address format');
+    });
+    await expect(service.connect(42, stellarDto)).rejects.toThrow(BadRequestException);
+    expect(mockPrisma.wallet.upsert).not.toHaveBeenCalled();
+  });
+
+  it('upserts a stellar wallet with explicit chain after validation', async () => {
+    mockPrisma.wallet.upsert.mockResolvedValue({ id: 1, userId: 42, ...stellarDto });
+
+    const result = await service.connect(42, stellarDto);
+
     expect(mockPrisma.wallet.upsert).toHaveBeenCalledWith({
       where: {
         address_chain: {
-          address: dto.address,
-          chain: dto.chain,
+          address: stellarDto.address,
+          chain: 'stellar',
         },
       },
       update: expect.objectContaining({
         userId: 42,
-        type: dto.type,
+        type: stellarDto.type,
         deletedAt: null,
       }),
       create: {
         userId: 42,
-        address: dto.address,
-        chain: dto.chain,
-        type: dto.type,
+        address: stellarDto.address,
+        chain: 'stellar',
+        type: stellarDto.type,
       },
     });
     expect(result.id).toBe(1);
+  });
+
+  it.each(SUPPORTED_CHAINS)(
+    'upserts a wallet for each supported chain "%s"',
+    async (chain) => {
+      const dto = { address: stellarDto.address, chain, type: 'freighter' };
+      mockPrisma.wallet.upsert.mockResolvedValue({ id: 1, userId: 42, ...dto });
+
+      await service.connect(42, dto);
+
+      expect(mockPrisma.wallet.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ chain }),
+        }),
+      );
+    },
+  );
+
+  it('masks the wallet address in the response', async () => {
+    const fullAddress = 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3';
+    mockPrisma.wallet.upsert.mockResolvedValue({
+      id: 1,
+      userId: 42,
+      address: fullAddress,
+      chain: 'stellar',
+      type: 'freighter',
+    });
+
+    const result = await service.connect(42, { ...stellarDto, address: fullAddress });
+
+    expect(result.address).not.toBe(fullAddress);
+    expect(result.address).toContain('****');
   });
 });

--- a/src/wallets/wallet-management.service.ts
+++ b/src/wallets/wallet-management.service.ts
@@ -6,6 +6,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { ConnectWalletDto } from './dto/connect-wallet.dto';
 import { WalletValidationService } from './wallet-validation.service';
+import { DEFAULT_CHAIN, SupportedChain } from './chain.constants';
 import { maskAddress } from './wallet.utils';
 
 export interface DisconnectResult {
@@ -92,13 +93,15 @@ export class WalletManagementService {
   }
 
   async connect(userId: number, dto: ConnectWalletDto) {
-    this.walletValidationService.validateStellarAddress(dto.address);
+    const chain = (dto.chain ?? DEFAULT_CHAIN) as SupportedChain;
+
+    this.walletValidationService.validateAddressForChain(dto.address, chain);
 
     const wallet = await this.prisma.wallet.upsert({
       where: {
         address_chain: {
           address: dto.address,
-          chain: dto.chain,
+          chain,
         },
       },
       update: {
@@ -110,7 +113,7 @@ export class WalletManagementService {
       create: {
         userId,
         address: dto.address,
-        chain: dto.chain,
+        chain,
         type: dto.type,
       },
     });

--- a/src/wallets/wallet-validation.service.spec.ts
+++ b/src/wallets/wallet-validation.service.spec.ts
@@ -21,22 +21,138 @@ describe('WalletValidationService', () => {
     service = module.get<WalletValidationService>(WalletValidationService);
   });
 
-  it('throws BadRequestException when address is invalid', () => {
-    mockStellarService.validateAddress.mockReturnValue({ valid: false });
-    expect(() => service.validateStellarAddress('bad')).toThrow(
-      BadRequestException,
-    );
-    expect(() => service.validateStellarAddress('bad')).toThrow(
-      'Invalid Stellar address format',
-    );
+  describe('validateStellarAddress', () => {
+    it('throws BadRequestException when address is invalid', () => {
+      mockStellarService.validateAddress.mockReturnValue({ valid: false });
+      expect(() => service.validateStellarAddress('bad')).toThrow(
+        BadRequestException,
+      );
+      expect(() => service.validateStellarAddress('bad')).toThrow(
+        'Invalid Stellar address format',
+      );
+    });
+
+    it('does not throw when address is valid', () => {
+      mockStellarService.validateAddress.mockReturnValue({ valid: true });
+      expect(() =>
+        service.validateStellarAddress(
+          'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+        ),
+      ).not.toThrow();
+    });
   });
 
-  it('does not throw when address is valid', () => {
-    mockStellarService.validateAddress.mockReturnValue({ valid: true });
-    expect(() =>
-      service.validateStellarAddress(
-        'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
-      ),
-    ).not.toThrow();
+  describe('validateAddressForChain', () => {
+    describe('stellar', () => {
+      it('delegates to validateStellarAddress', () => {
+        mockStellarService.validateAddress.mockReturnValue({ valid: true });
+        expect(() =>
+          service.validateAddressForChain(
+            'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+            'stellar',
+          ),
+        ).not.toThrow();
+        expect(mockStellarService.validateAddress).toHaveBeenCalledTimes(1);
+      });
+
+      it('throws when the Stellar address is invalid', () => {
+        mockStellarService.validateAddress.mockReturnValue({ valid: false });
+        expect(() =>
+          service.validateAddressForChain('bad-address', 'stellar'),
+        ).toThrow(BadRequestException);
+      });
+    });
+
+    describe('solana', () => {
+      it('accepts a valid base58 Solana public key (32 chars)', () => {
+        expect(() =>
+          service.validateAddressForChain(
+            '11111111111111111111111111111112',
+            'solana',
+          ),
+        ).not.toThrow();
+      });
+
+      it('accepts a valid base58 Solana public key (44 chars)', () => {
+        expect(() =>
+          service.validateAddressForChain(
+            'So11111111111111111111111111111111111111112',
+            'solana',
+          ),
+        ).not.toThrow();
+      });
+
+      it('throws BadRequestException for an invalid Solana address', () => {
+        expect(() =>
+          service.validateAddressForChain('not-a-valid-address', 'solana'),
+        ).toThrow(BadRequestException);
+      });
+
+      it('throws for a Solana address with invalid base58 characters (0, O, I, l)', () => {
+        expect(() =>
+          service.validateAddressForChain('0OIl1111111111111111111111111111', 'solana'),
+        ).toThrow(BadRequestException);
+      });
+
+      it('does not call StellarService for a Solana address', () => {
+        service.validateAddressForChain(
+          'So11111111111111111111111111111111111111112',
+          'solana',
+        );
+        expect(mockStellarService.validateAddress).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('base', () => {
+      it('accepts a valid EVM address', () => {
+        expect(() =>
+          service.validateAddressForChain(
+            '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+            'base',
+          ),
+        ).not.toThrow();
+      });
+
+      it('accepts a lowercase EVM address', () => {
+        expect(() =>
+          service.validateAddressForChain(
+            '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+            'base',
+          ),
+        ).not.toThrow();
+      });
+
+      it('throws BadRequestException for a missing 0x prefix', () => {
+        expect(() =>
+          service.validateAddressForChain(
+            'd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+            'base',
+          ),
+        ).toThrow(BadRequestException);
+      });
+
+      it('throws BadRequestException for an address that is too short', () => {
+        expect(() =>
+          service.validateAddressForChain('0x1234', 'base'),
+        ).toThrow(BadRequestException);
+      });
+
+      it('throws BadRequestException for non-hex characters', () => {
+        expect(() =>
+          service.validateAddressForChain(
+            '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604Z',
+            'base',
+          ),
+        ).toThrow(BadRequestException);
+      });
+
+      it('does not call StellarService for a Base address', () => {
+        service.validateAddressForChain(
+          '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+          'base',
+        );
+        expect(mockStellarService.validateAddress).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/wallets/wallet-validation.service.ts
+++ b/src/wallets/wallet-validation.service.ts
@@ -1,14 +1,43 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { StellarService } from '../stellar/stellar.service';
+import { SupportedChain } from './chain.constants';
 
 @Injectable()
 export class WalletValidationService {
   constructor(private readonly stellarService: StellarService) {}
 
+  validateAddressForChain(address: string, chain: SupportedChain): void {
+    switch (chain) {
+      case 'stellar':
+        this.validateStellarAddress(address);
+        break;
+      case 'solana':
+        this.validateSolanaAddress(address);
+        break;
+      case 'base':
+        this.validateEvmAddress(address);
+        break;
+    }
+  }
+
   validateStellarAddress(address: string): void {
     const validation = this.stellarService.validateAddress(address);
     if (!validation.valid) {
       throw new BadRequestException('Invalid Stellar address format');
+    }
+  }
+
+  private validateSolanaAddress(address: string): void {
+    // Solana public keys are base58-encoded 32-byte Ed25519 keys (32–44 chars)
+    if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)) {
+      throw new BadRequestException('Invalid Solana address format');
+    }
+  }
+
+  private validateEvmAddress(address: string): void {
+    // Base (and all EVM chains) use 0x-prefixed 40-character hex addresses
+    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) {
+      throw new BadRequestException('Invalid Base address format');
     }
   }
 }


### PR DESCRIPTION
Closes #364

---

## Summary

Prepares the wallet infrastructure for multi-chain support by introducing a centralized, validated chain configuration layer and making `stellar` the explicit default throughout the application.

- Replaces every hardcoded `'stellar'` chain assumption with a single-source-of-truth constant file
- Expands wallet connect validation to accept `stellar`, `solana`, and `base`; rejects anything else at the API boundary with a clear message
- Makes `chain` optional in the connect payload — existing clients that omit it receive Stellar behaviour unchanged
- Scopes all Stellar-specific wallet DB queries to `chain: 'stellar'` so future wallets on other networks are never accidentally selected

---

## Changed Files

| File | Change |
|------|--------|
| `src/wallets/chain.constants.ts` | **New** — `SUPPORTED_CHAINS`, `SupportedChain`, `DEFAULT_CHAIN`, `isSupportedChain()`, `assertSupportedChain()` |
| `src/wallets/chain.constants.spec.ts` | **New** — full test suite for constants and helpers |
| `src/wallets/dto/connect-wallet.dto.ts` | Expand `@IsIn` to all three chains; make `chain` `@IsOptional` with documented default |
| `src/wallets/wallet-validation.service.ts` | Add `validateAddressForChain()` dispatcher; Solana (base58) and Base (0x-hex) validators |
| `src/wallets/wallet-validation.service.spec.ts` | Extended to cover all three chains, invalid addresses, and no cross-chain leakage |
| `src/wallets/wallet-management.service.ts` | Default `chain = dto.chain ?? DEFAULT_CHAIN`; call `validateAddressForChain` |
| `src/wallets/wallet-management.service.spec.ts` | Updated mocks; new tests for default assignment, per-chain upsert, unsupported rejection |
| `src/payouts/payouts.service.ts` | Add `chain: 'stellar'` to both Stellar wallet `findFirst` queries |
| `src/subscriptions/stellar-payment.service.ts` | Add `chain: 'stellar'` to payment intent wallet lookup |

---

## Architecture

```
SUPPORTED_CHAINS = ['stellar', 'solana', 'base']   ← only place to add a new chain
DEFAULT_CHAIN    = 'stellar'

API boundary (DTO)
  └─ @IsIn([...SUPPORTED_CHAINS])  →  rejects unknown chains with 400
  └─ @IsOptional()                 →  missing chain defaults to 'stellar' in service

Service layer
  └─ chain = dto.chain ?? DEFAULT_CHAIN
  └─ validateAddressForChain(address, chain)
       ├─ stellar → StrKey.isValidEd25519PublicKey (existing Stellar SDK)
       ├─ solana  → base58 regex (stub ready for @solana/web3.js)
       └─ base    → 0x-hex regex (stub ready for viem / ethers)

DB queries (Stellar-specific paths)
  └─ where: { ..., chain: 'stellar' }   ← explicit, never picks up future chains
```

---

## Backward Compatibility

- Existing Stellar wallets: no schema migration needed — all records already have `chain = 'stellar'`
- Existing API clients that send `chain: 'stellar'` explicitly: unchanged behaviour
- Existing API clients that omit `chain`: now accepted and treated as `stellar` (previously rejected by `@IsNotEmpty`)
- All Stellar payout and subscription flows: unchanged — chain filter added to queries, same result set for existing data

---

## Adding a New Chain (Future)

1. Append the chain name to `SUPPORTED_CHAINS` in `chain.constants.ts`
2. Add a `case` to `validateAddressForChain` in `wallet-validation.service.ts`
3. Implement chain-specific RPC/SDK integration in the new case

No other files need changes to support additional networks.

---

## Test Plan

- [ ] `chain.constants.spec.ts` — `isSupportedChain`, `assertSupportedChain`, `DEFAULT_CHAIN`, `SUPPORTED_CHAINS` membership
- [ ] `wallet-validation.service.spec.ts` — all three chains pass valid addresses, each rejects invalid formats, no cross-chain `StellarService` calls
- [ ] `wallet-management.service.spec.ts` — default chain assignment, per-chain upsert shape, unsupported chain rejected before DB write, address masking
- [ ] Existing disconnect tests: no regression (unchanged code path)
- [ ] Manual: `POST /wallets/connect` without `chain` field → wallet created with `chain: 'stellar'`
- [ ] Manual: `POST /wallets/connect` with `chain: 'ethereum'` → `400 Bad Request` with `chain must be one of: stellar, solana, base`
- [ ] Manual: existing Stellar payout and subscription flows unaffected
