### PR TITLE
feat(wallets): add GET /wallets/:id/balance endpoint for XLM balance and low-funds warning

### DIFF
--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -1,6 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+  BadGatewayException,
+} from '@nestjs/common';
 import { StrKey, Horizon } from '@stellar/stellar-sdk';
 import { CircuitBreakerService, CircuitBreakerConfig } from '../common/circuit-breaker/circuit-breaker.service';
+
+export const LOW_BALANCE_THRESHOLD_XLM = 2.0;
+
+export interface WalletBalanceResult {
+  balance: number;
+  warning: boolean;
+}
 
 export type StellarNetwork = 'testnet' | 'public';
 
@@ -106,6 +119,54 @@ export class StellarService {
       );
       return 0;
     });
+  }
+
+  /**
+   * Fetches the native XLM balance for a Stellar address with strict error propagation.
+   * Unlike getAccountBalance, this throws typed exceptions for callers that need to
+   * surface them to the HTTP layer (e.g. the wallet balance endpoint).
+   */
+  async getWalletBalance(address: string): Promise<WalletBalanceResult> {
+    const validation = this.validateAddress(address);
+    if (!validation.valid) {
+      throw new BadRequestException(
+        validation.message ?? 'Invalid Stellar address',
+      );
+    }
+
+    let balance: number;
+    try {
+      balance = await this.circuitBreakerService.execute(
+        this.horizonCircuitBreakerConfig,
+        async () => {
+          const server = new Horizon.Server(this.horizonUrl);
+          const account = await server.loadAccount(address);
+          const native = account.balances.find(
+            (b) => b.asset_type === 'native',
+          );
+          return native ? parseFloat(native.balance) : 0;
+        },
+      );
+    } catch (err: unknown) {
+      const e = err as { name?: string; status?: number; response?: { status?: number }; message?: string };
+
+      if (e.name === 'ServiceUnavailableException') {
+        throw err;
+      }
+
+      const httpStatus = e?.response?.status ?? e?.status;
+      if (httpStatus === 404) {
+        throw new NotFoundException(
+          `Stellar account not found for address: ${address}`,
+        );
+      }
+
+      const msg = e.message ?? 'Unknown Horizon error';
+      this.logger.error(`Horizon balance fetch failed for ${address}: ${msg}`);
+      throw new BadGatewayException(`Horizon request failed: ${msg}`);
+    }
+
+    return { balance, warning: balance < LOW_BALANCE_THRESHOLD_XLM };
   }
 
   validateAddress(address: string): { valid: boolean; message?: string } {

--- a/src/wallets/wallet-balance.service.ts
+++ b/src/wallets/wallet-balance.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { StellarService, WalletBalanceResult } from '../stellar/stellar.service';
+
+@Injectable()
+export class WalletBalanceService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  async getBalance(walletId: number, userId: number): Promise<WalletBalanceResult> {
+    const wallet = await this.prisma.wallet.findUnique({
+      where: { id: walletId },
+      select: { id: true, userId: true, address: true, deletedAt: true },
+    });
+
+    if (!wallet || wallet.userId !== userId || wallet.deletedAt !== null) {
+      throw new NotFoundException(`Wallet ${walletId} not found`);
+    }
+
+    return this.stellarService.getWalletBalance(wallet.address);
+  }
+}

--- a/src/wallets/wallets.controller.ts
+++ b/src/wallets/wallets.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Delete,
+  Get,
   Param,
   ParseIntPipe,
   Req,
@@ -14,8 +15,10 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@ne
 import { Throttle } from '@nestjs/throttler';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { WalletsService, DisconnectResult } from './wallets.service';
+import { WalletBalanceService } from './wallet-balance.service';
 import { CreateWalletConnectionDto } from './dto/connect-wallet.dto';
 import { WalletOwnershipGuard } from './guards/wallet-ownership.guard';
+import { WalletBalanceResult } from '../stellar/stellar.service';
 
 interface AuthRequest extends Request {
   user: { userId: number; email: string | null };
@@ -26,7 +29,42 @@ interface AuthRequest extends Request {
 @Controller('wallets')
 @Auth()
 export class WalletsController {
-  constructor(private readonly walletsService: WalletsService) {}
+  constructor(
+    private readonly walletsService: WalletsService,
+    private readonly walletBalanceService: WalletBalanceService,
+  ) {}
+
+  @Get(':id/balance')
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
+  @UseGuards(WalletOwnershipGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get wallet XLM balance',
+    description:
+      'Returns the current native XLM balance for the specified wallet and a warning flag when funds are below the 2 XLM threshold that may cause NFT mint failures.',
+  })
+  @ApiParam({ name: 'id', description: 'Wallet ID', type: 'number' })
+  @ApiResponse({
+    status: 200,
+    description: 'Balance retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        balance: { type: 'number', example: 5.2, description: 'Available XLM balance' },
+        warning: { type: 'boolean', example: false, description: 'True when balance is below 2 XLM' },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid wallet address stored on record' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Wallet not found or Stellar account does not exist' })
+  @ApiResponse({ status: 502, description: 'Horizon network request failed' })
+  async getBalance(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthRequest,
+  ): Promise<WalletBalanceResult> {
+    return this.walletBalanceService.getBalance(id, req.user.userId);
+  }
 
   @Delete(':id')
   @Throttle({ walletDisconnect: { limit: 10, ttl: 60000 } })

--- a/src/wallets/wallets.module.ts
+++ b/src/wallets/wallets.module.ts
@@ -3,6 +3,7 @@ import { AuthModule } from '../auth/auth.module';
 import { WalletsService } from './wallets.service';
 import { WalletValidationService } from './wallet-validation.service';
 import { WalletManagementService } from './wallet-management.service';
+import { WalletBalanceService } from './wallet-balance.service';
 import { WalletsController } from './wallets.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { StellarModule } from '../stellar/stellar.module';
@@ -12,9 +13,10 @@ import { StellarModule } from '../stellar/stellar.module';
   providers: [
     WalletValidationService,
     WalletManagementService,
+    WalletBalanceService,
     WalletsService,
   ],
   controllers: [WalletsController],
-  exports: [WalletValidationService, WalletManagementService, WalletsService],
+  exports: [WalletValidationService, WalletManagementService, WalletBalanceService, WalletsService],
 })
 export class WalletsModule {}


### PR DESCRIPTION
Closes #361

---

## Summary

Adds a `GET /wallets/:id/balance` endpoint that queries the Horizon API for a wallet's native XLM balance and returns a `warning` flag when funds are below the 2 XLM threshold that commonly causes NFT mint transaction failures.

- **Balance check before minting** — callers can gate `prepare-mint` on `warning: false` to avoid wasting a Soroban simulation on an underfunded wallet
- **Strict error propagation** — unlike the existing `getAccountBalance` (which silently returns 0 on any error), the new path surfaces typed HTTP errors so the endpoint response always reflects the actual cause of failure
- **Zero regressions** — all 64 existing wallet and Stellar tests pass; existing services are unchanged

---

## Changed files

### `src/stellar/stellar.service.ts`

Adds `getWalletBalance(address)` alongside the existing `getAccountBalance`:

| Error condition | HTTP status thrown |
|---|---|
| Invalid Stellar address (format check) | `400 Bad Request` |
| Account not found on Horizon (HTTP 404) | `404 Not Found` |
| Circuit breaker open | `503 Service Unavailable` (existing behaviour) |
| Any other Horizon failure | `502 Bad Gateway` |

Also exports `LOW_BALANCE_THRESHOLD_XLM = 2.0` and the `WalletBalanceResult` interface so they can be shared across the codebase.

```typescript
export interface WalletBalanceResult {
  balance: number;   // native XLM, numeric
  warning: boolean;  // true when balance < 2.0 XLM
}
```

### `src/wallets/wallet-balance.service.ts` *(new)*

Single-responsibility service that owns the "look up wallet → fetch balance" flow:

```typescript
async getBalance(walletId: number, userId: number): Promise<WalletBalanceResult>
```

1. Fetches wallet from DB (`PrismaService`) — 404 if not found, wrong owner, or soft-deleted
2. Delegates to `StellarService.getWalletBalance(wallet.address)`

Kept separate from `WalletManagementService` to avoid introducing a new constructor dependency into a class whose test suite instantiates it directly without a mock for `StellarService`.

### `src/wallets/wallets.controller.ts`

New route injected from `WalletBalanceService`:

```
GET /wallets/:id/balance
```

| Detail | Value |
|---|---|
| Auth | `@Auth()` (JWT, inherited from controller) |
| Ownership | `@UseGuards(WalletOwnershipGuard)` |
| Rate limit | 30 req / 60 s (`default` throttle key) |
| Response | `{ balance: number, warning: boolean }` |

Full Swagger docs with per-status descriptions (200, 400, 401, 404, 502).

### `src/wallets/wallets.module.ts`

Registers and exports `WalletBalanceService`.

---

## Request / response

```
GET /wallets/7/balance
Authorization: Bearer <jwt>

200 OK
{ "balance": 5.2, "warning": false }

200 OK  (low funds)
{ "balance": 1.3, "warning": true }

404 Not Found
{ "message": "Stellar account not found for address: G..." }

502 Bad Gateway
{ "message": "Horizon request failed: ..." }
```

---

## Error handling matrix

| Scenario | Status | Message |
|---|---|---|
| Invalid/malformed JWT | 401 | Unauthorized |
| Wallet belongs to another user | 404 | `Wallet N not found` (ownership guard) |
| Wallet soft-deleted | 404 | `Wallet N not found` |
| Stellar address format invalid | 400 | `Invalid Stellar address` |
| Account not funded / doesn't exist | 404 | `Stellar account not found for address: G...` |
| Horizon returns non-404 error | 502 | `Horizon request failed: <reason>` |
| Circuit breaker open | 503 | `Service unavailable` |

---

## Architecture notes

`getAccountBalance` (existing) swallows all Horizon errors and returns 0 — appropriate for internal callers that treat 0 as "assume unfunded." `getWalletBalance` (new) is the strict variant for HTTP-facing callers that need to surface the actual failure reason. Both share the same circuit breaker config so they apply the same fault-tolerance policy.

`WalletBalanceService` is intentionally separate from `WalletManagementService` to keep constructor dependencies stable across the existing test suite. The service is thin enough that it doesn't warrant a separate module.