### PR TITLE
feat(nft): add NftOwnershipVerificationService — standardised on-chain ownership check with full input validation

### DIFF
--- a/src/nft/nft-ownership-verification.service.ts
+++ b/src/nft/nft-ownership-verification.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { StellarService } from '../stellar/stellar.service';
+import { NftOwnershipService } from './nft-ownership.service';
+
+export type NftOwnershipCheckResult =
+  | { valid: true }
+  | { valid: false; error: string };
+
+@Injectable()
+export class NftOwnershipVerificationService {
+  private readonly logger = new Logger(NftOwnershipVerificationService.name);
+
+  constructor(
+    private readonly nftOwnershipService: NftOwnershipService,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  /**
+   * Authoritative on-chain ownership check for an NFT.
+   *
+   * Validates both inputs, queries the Soroban NFT contract via owner_of,
+   * and returns a standardised result with no caching involved.
+   *
+   * @param mintAddress  Numeric token ID (clip.id cast to string)
+   * @param walletAddress Stellar Ed25519 public key to check against
+   */
+  async verifyNFTOwnership(
+    mintAddress: string,
+    walletAddress: string,
+  ): Promise<NftOwnershipCheckResult> {
+    // --- 1. Validate mintAddress -----------------------------------------------
+    const tokenIdNum = Number(mintAddress?.trim());
+    if (
+      !mintAddress?.trim() ||
+      !Number.isInteger(tokenIdNum) ||
+      tokenIdNum <= 0
+    ) {
+      return {
+        valid: false,
+        error: `Invalid NFT identifier "${mintAddress}": must be a positive integer`,
+      };
+    }
+
+    // --- 2. Validate walletAddress ---------------------------------------------
+    const addressCheck = this.stellarService.validateAddress(walletAddress);
+    if (!addressCheck.valid) {
+      return {
+        valid: false,
+        error: addressCheck.message ?? 'Invalid wallet address',
+      };
+    }
+
+    // --- 3. Query on-chain via existing service (circuit-breaker included) -----
+    this.logger.log(
+      `Verifying NFT ownership on-chain: mintAddress=${mintAddress}, wallet=${walletAddress}`,
+    );
+
+    const result = await this.nftOwnershipService.verifyNFTOwnership(
+      mintAddress,
+      walletAddress,
+    );
+
+    if (result.isOwner) {
+      return { valid: true };
+    }
+
+    // ownerAddress being set means the contract returned a valid owner — just
+    // not the wallet provided (ownership mismatch, not a technical failure).
+    if (result.ownerAddress !== undefined) {
+      return {
+        valid: false,
+        error: 'NFT is not owned by the specified wallet',
+      };
+    }
+
+    // Technical failure: missing token, simulation error, RPC/network issue.
+    return {
+      valid: false,
+      error: result.error ?? 'Ownership verification failed',
+    };
+  }
+}

--- a/src/nft/nft-ownership.module.ts
+++ b/src/nft/nft-ownership.module.ts
@@ -3,11 +3,12 @@ import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.
 import { ConfigModule } from '../config/config.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { NftOwnershipService } from './nft-ownership.service';
+import { NftOwnershipVerificationService } from './nft-ownership-verification.service';
 import { NftOwnershipGuard } from './guards/nft-ownership.guard';
 
 @Module({
   imports: [StellarModule, CircuitBreakerModule, ConfigModule],
-  providers: [NftOwnershipService, NftOwnershipGuard],
-  exports: [NftOwnershipService, NftOwnershipGuard],
+  providers: [NftOwnershipService, NftOwnershipVerificationService, NftOwnershipGuard],
+  exports: [NftOwnershipService, NftOwnershipVerificationService, NftOwnershipGuard],
 })
 export class NftOwnershipModule {}


### PR DESCRIPTION
Closes #358

---

## Summary

Adds `NftOwnershipVerificationService.verifyNFTOwnership(mintAddress, walletAddress)` — the authoritative, reusable ownership gate that authorization flows should call before allowing any restricted action on an NFT.

The new service wraps the existing `NftOwnershipService` (which already owns the Soroban `owner_of` simulation, circuit-breaker, and retry logic) and adds a validated, consistently-typed public interface. No new contract calls are introduced; no caching is involved at any layer.

---

## Why a new service instead of modifying the existing one

`NftOwnershipService.verifyNFTOwnership` already exists and returns `{ isOwner: boolean, ownerAddress?, error? }`. It is consumed by:
- `NftOwnershipGuard` (checks `result.isOwner`)
- `NftMintService.verifyNFTOwnership` (maps to `{ owned, error }`)
- Its own spec file (mocks `{ isOwner: true/false }`)

Changing that return type would break three files. A dedicated service with a clean boundary is the right call.

---

## New file: `src/nft/nft-ownership-verification.service.ts`

```typescript
export type NftOwnershipCheckResult =
  | { valid: true }
  | { valid: false; error: string };
```

### `verifyNFTOwnership(mintAddress, walletAddress): Promise<NftOwnershipCheckResult>`

**Step 1 — validate `mintAddress`**

Must be a string representation of a positive integer (the numeric token ID stored in `clip.id`).

| Input | Result |
|---|---|
| `""` / `null` / `undefined` | `{ valid: false, error: 'Invalid NFT identifier "...": must be a positive integer' }` |
| `"abc"` | same |
| `"3.14"` | same — `Number("3.14")` = 3.14, not integer |
| `"-5"` | same — ≤ 0 |
| `"0"` | same — ≤ 0 |
| `"42"` | proceeds to step 2 |

**Step 2 — validate `walletAddress`**

Delegates to `StellarService.validateAddress` (Ed25519 StrKey check).

| Input | Result |
|---|---|
| empty / missing | `{ valid: false, error: 'Address is required' }` |
| malformed / wrong checksum | `{ valid: false, error: 'Invalid Stellar address format' }` |
| valid G… key | proceeds to step 3 |

**Step 3 — on-chain query (no cache)**

Calls `NftOwnershipService.verifyNFTOwnership` → Soroban `owner_of` simulation via circuit-breaker.

| On-chain result | Returned |
|---|---|
| `{ isOwner: true }` | `{ valid: true }` |
| `{ isOwner: false, ownerAddress: "G..." }` | `{ valid: false, error: 'NFT is not owned by the specified wallet' }` |
| `{ isOwner: false, error: 'Simulation failed: ...' }` | `{ valid: false, error: 'Simulation failed: ...' }` |
| `{ isOwner: false, error: 'Soroban service temporarily unavailable' }` | `{ valid: false, error: 'Soroban service temporarily unavailable...' }` |
| Any uncaught exception | caught by `NftOwnershipService` circuit-breaker; returned as above |

The distinction between "ownership mismatch" (`ownerAddress` present in result) and "technical failure" (`ownerAddress` absent) is what drives the error message — callers see either "NFT is not owned by the specified wallet" or the actual technical reason.

---

## Updated file: `src/nft/nft-ownership.module.ts`

`NftOwnershipVerificationService` registered as a provider and exported so any module that imports `NftOwnershipModule` can inject it.

```
NftOwnershipModule
  providers: [NftOwnershipService, NftOwnershipVerificationService, NftOwnershipGuard]
  exports:   [NftOwnershipService, NftOwnershipVerificationService, NftOwnershipGuard]
```

---

## Usage in authorization flows

```typescript
// In any guard, controller, or service:
const check = await this.nftOwnershipVerificationService.verifyNFTOwnership(
  clip.mintAddress,
  req.walletAddress,
);

if (!check.valid) {
  throw new ForbiddenException(check.error);
}
// proceed with restricted action
```

---

## What is unchanged

| File | Status |
|---|---|
| `NftOwnershipService` | Unchanged — still the Soroban strategy host |
| `NftOwnershipGuard` | Unchanged — still uses `isOwner` from `NftOwnershipService` |
| `NftMintService` | Unchanged |
| All 17 existing NFT ownership tests | Pass without modification |