### PR TITLE
feat(nft): standardize metadata attribute names and add pre-upload validation

### DIFF
--- a/src/clips/nft-mint.service.spec.ts
+++ b/src/clips/nft-mint.service.spec.ts
@@ -166,18 +166,164 @@ function makeService(): NftMintService {
       image: 'https://cdn.example.com/thumb.jpg',
       animation_url: 'https://cdn.example.com/video.mp4',
     });
-    expect((metadata as any).attributes).toEqual(
+
+    const attrs: Array<{ trait_type: string; value: string | number }> =
+      (metadata as any).attributes;
+
+    // Standard human-readable trait names
+    expect(attrs).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ trait_type: 'royaltyBps', value: 1000 }),
-        expect.objectContaining({ trait_type: 'royaltyPercent', value: 10 }),
+        { trait_type: 'Clip Duration', value: 27 },
+        { trait_type: 'Virality Score', value: 88 },
+        { trait_type: 'Creation Date', value: '2026-03-01T00:00:00.000Z' },
+        { trait_type: 'Royalty BPS', value: 1000 },
+        { trait_type: 'Royalty Percent', value: 10 },
+        { trait_type: 'Platforms Posted To', value: 'tiktok' },
       ]),
     );
+
+    // Legacy camelCase names must no longer be present
+    expect(attrs.map((a) => a.trait_type)).not.toContain('clipDuration');
+    expect(attrs.map((a) => a.trait_type)).not.toContain('viralityScore');
+    expect(attrs.map((a) => a.trait_type)).not.toContain('createdAt');
+    expect(attrs.map((a) => a.trait_type)).not.toContain('royaltyBps');
+    expect(attrs.map((a) => a.trait_type)).not.toContain('royaltyPercent');
+    expect(attrs.map((a) => a.trait_type)).not.toContain('platformsPosted');
+
     expect(prismaMock.clip.update).toHaveBeenCalledWith({
       where: { id: 5 },
       data: { metadataUri: 'ipfs://bafyTestCid123' },
     });
     expect(result).toEqual({ clipId: 5, cid: 'bafyTestCid123', metadataUri: 'ipfs://bafyTestCid123' });
   });
+
+  it('defaults Virality Score to 0 when viralityScore is null', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      id: 7,
+      title: 'Clip',
+      caption: null,
+      clipUrl: 'https://cdn.example.com/v.mp4',
+      thumbnail: null,
+      duration: 15,
+      viralityScore: null,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      postStatus: null,
+    });
+    ipfsUploadMock.uploadMetadata.mockResolvedValue('ipfs://bafyNullVirality');
+    prismaMock.clip.update.mockResolvedValue({});
+
+    await service.uploadMetadataToIPFS(7);
+
+    const [meta] = ipfsUploadMock.uploadMetadata.mock.calls[0];
+    const virality = (meta as any).attributes.find(
+      (a: any) => a.trait_type === 'Virality Score',
+    );
+    expect(virality).toBeDefined();
+    expect(virality.value).toBe(0);
+  });
+
+  it('sets Platforms Posted To to empty string when no platforms are posted', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      id: 8,
+      title: 'No Platforms',
+      caption: 'A clip',
+      clipUrl: 'https://cdn.example.com/v.mp4',
+      thumbnail: null,
+      duration: 10,
+      viralityScore: 50,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      postStatus: null,
+    });
+    ipfsUploadMock.uploadMetadata.mockResolvedValue('ipfs://bafyNoPlatforms');
+    prismaMock.clip.update.mockResolvedValue({});
+
+    await service.uploadMetadataToIPFS(8);
+
+    const [meta] = ipfsUploadMock.uploadMetadata.mock.calls[0];
+    const platforms = (meta as any).attributes.find(
+      (a: any) => a.trait_type === 'Platforms Posted To',
+    );
+    expect(platforms).toBeDefined();
+    expect(platforms.value).toBe('');
+  });
+
+  it('joins multiple platforms with comma-space separator', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      id: 9,
+      title: 'Multi Platform',
+      caption: 'A clip',
+      clipUrl: 'https://cdn.example.com/v.mp4',
+      thumbnail: null,
+      duration: 30,
+      viralityScore: 75,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      postStatus: { tiktok: true, instagram: true, youtube: true },
+    });
+    ipfsUploadMock.uploadMetadata.mockResolvedValue('ipfs://bafyMulti');
+    prismaMock.clip.update.mockResolvedValue({});
+
+    await service.uploadMetadataToIPFS(9);
+
+    const [meta] = ipfsUploadMock.uploadMetadata.mock.calls[0];
+    const platforms = (meta as any).attributes.find(
+      (a: any) => a.trait_type === 'Platforms Posted To',
+    );
+    expect(platforms.value).toContain(', ');
+    expect(platforms.value).not.toContain('none');
+  });
+
+  it('generates standards-compliant metadata with all required top-level fields', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      id: 10,
+      title: 'Standards Clip',
+      caption: 'Testing standards',
+      clipUrl: 'https://cdn.example.com/v.mp4',
+      thumbnail: 'https://cdn.example.com/t.jpg',
+      duration: 60,
+      viralityScore: 90,
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      postStatus: {},
+    });
+    ipfsUploadMock.uploadMetadata.mockResolvedValue('ipfs://bafyStandards');
+    prismaMock.clip.update.mockResolvedValue({});
+
+    await service.uploadMetadataToIPFS(10);
+
+    const [meta] = ipfsUploadMock.uploadMetadata.mock.calls[0];
+    expect(meta).toHaveProperty('name');
+    expect(meta).toHaveProperty('description');
+    expect(meta).toHaveProperty('image');
+    expect(meta).toHaveProperty('animation_url');
+    expect(meta).toHaveProperty('attributes');
+    expect(Array.isArray((meta as any).attributes)).toBe(true);
+  });
+
+  it('uploads enriched metadata to IPFS and uses the resulting CID as metadataUri', async () => {
+    const expectedCid = 'bafyEnrichedCid456';
+    prismaMock.clip.findUnique.mockResolvedValue({
+      id: 11,
+      title: 'Enriched',
+      caption: 'Enriched clip',
+      clipUrl: 'https://cdn.example.com/v.mp4',
+      thumbnail: null,
+      duration: 45,
+      viralityScore: 92,
+      createdAt: new Date('2026-06-25T12:00:00.000Z'),
+      postStatus: { TikTok: true, Instagram: true, YouTube: true },
+    });
+    ipfsUploadMock.uploadMetadata.mockResolvedValue(`ipfs://${expectedCid}`);
+    prismaMock.clip.update.mockResolvedValue({});
+
+    const result = await service.uploadMetadataToIPFS(11);
+
+    expect(result.cid).toBe(expectedCid);
+    expect(result.metadataUri).toBe(`ipfs://${expectedCid}`);
+    expect(prismaMock.clip.update).toHaveBeenCalledWith({
+      where: { id: 11 },
+      data: { metadataUri: `ipfs://${expectedCid}` },
+    });
+  });
+});
 
 
 // ─── prepareMintTx ──────────────────────────────────────────────────────────

--- a/src/clips/nft-mint.service.ts
+++ b/src/clips/nft-mint.service.ts
@@ -283,16 +283,15 @@ export class NftMintService {
     royaltyBps: number;
   }): NftMetadata {
     const platforms = this.extractPlatforms(clip.postStatus);
+    const viralityScore = clip.viralityScore ?? 0;
+
     const attributes: NftAttribute[] = [
-      { trait_type: 'clipDuration', value: clip.duration },
-      { trait_type: 'viralityScore', value: clip.viralityScore ?? 0 },
-      { trait_type: 'createdAt', value: clip.createdAt.toISOString() },
-      { trait_type: 'royaltyBps', value: clip.royaltyBps },
-      { trait_type: 'royaltyPercent', value: clip.royaltyBps / 100 },
-      {
-        trait_type: 'platformsPosted',
-        value: platforms.length ? platforms.join(',') : 'none',
-      },
+      { trait_type: 'Clip Duration', value: clip.duration },
+      { trait_type: 'Virality Score', value: viralityScore },
+      { trait_type: 'Creation Date', value: clip.createdAt.toISOString() },
+      { trait_type: 'Royalty BPS', value: clip.royaltyBps },
+      { trait_type: 'Royalty Percent', value: clip.royaltyBps / 100 },
+      { trait_type: 'Platforms Posted To', value: platforms.join(', ') },
     ];
 
     return {

--- a/src/nft/ipfs-upload.service.spec.ts
+++ b/src/nft/ipfs-upload.service.spec.ts
@@ -112,4 +112,128 @@ describe('IpfsUploadService', () => {
       BadRequestException,
     );
   });
+
+  describe('validateMetadata', () => {
+    let service: IpfsUploadService;
+
+    beforeEach(() => {
+      service = createService();
+    });
+
+    const validMetadata: NftMetadata = {
+      name: 'Clip #1',
+      description: 'Test clip description',
+      image: 'https://cdn.example.com/thumb.jpg',
+      animation_url: 'https://cdn.example.com/video.mp4',
+      attributes: [
+        { trait_type: 'Clip Duration', value: 45 },
+        { trait_type: 'Virality Score', value: 92 },
+        { trait_type: 'Creation Date', value: '2026-06-25T12:00:00Z' },
+        { trait_type: 'Platforms Posted To', value: 'TikTok, Instagram' },
+      ],
+    };
+
+    it('does not throw for valid metadata', () => {
+      expect(() => service.validateMetadata(validMetadata)).not.toThrow();
+    });
+
+    it('throws BadRequestException when name is empty', () => {
+      expect(() =>
+        service.validateMetadata({ ...validMetadata, name: '' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when name is whitespace only', () => {
+      expect(() =>
+        service.validateMetadata({ ...validMetadata, name: '   ' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when description is empty', () => {
+      expect(() =>
+        service.validateMetadata({ ...validMetadata, description: '' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when image is empty', () => {
+      expect(() =>
+        service.validateMetadata({ ...validMetadata, image: '' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when animation_url is empty', () => {
+      expect(() =>
+        service.validateMetadata({ ...validMetadata, animation_url: '' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when attributes is not an array', () => {
+      expect(() =>
+        service.validateMetadata({ ...validMetadata, attributes: null as any }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when an attribute has an empty trait_type', () => {
+      expect(() =>
+        service.validateMetadata({
+          ...validMetadata,
+          attributes: [{ trait_type: '', value: 42 }],
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when an attribute has a null value', () => {
+      expect(() =>
+        service.validateMetadata({
+          ...validMetadata,
+          attributes: [{ trait_type: 'Clip Duration', value: null as any }],
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when an attribute has an undefined value', () => {
+      expect(() =>
+        service.validateMetadata({
+          ...validMetadata,
+          attributes: [{ trait_type: 'Virality Score', value: undefined as any }],
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('accepts numeric zero as a valid attribute value', () => {
+      expect(() =>
+        service.validateMetadata({
+          ...validMetadata,
+          attributes: [{ trait_type: 'Virality Score', value: 0 }],
+        }),
+      ).not.toThrow();
+    });
+
+    it('accepts empty string as a valid attribute value (e.g. no platforms posted)', () => {
+      expect(() =>
+        service.validateMetadata({
+          ...validMetadata,
+          attributes: [{ trait_type: 'Platforms Posted To', value: '' }],
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects metadata before upload when validation fails', async () => {
+      const invalidMetadata = { ...validMetadata, name: '' };
+      await expect(service.uploadMetadata(invalidMetadata, 99)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('uploads when all required fields and attributes are valid', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ IpfsHash: 'bafyValidCid' }),
+      });
+
+      const uri = await service.uploadMetadata(validMetadata, 10);
+      expect(uri).toBe('ipfs://bafyValidCid');
+    });
+  });
 });

--- a/src/nft/ipfs-upload.service.ts
+++ b/src/nft/ipfs-upload.service.ts
@@ -49,6 +49,51 @@ export class IpfsUploadService {
   ) {}
 
   /**
+   * Validates that metadata satisfies NFT standards before upload.
+   * Throws BadRequestException when required fields are absent or any
+   * attribute contains an empty trait_type or a null/undefined value.
+   */
+  validateMetadata(metadata: NftMetadata): void {
+    if (!metadata.name?.trim()) {
+      throw new BadRequestException(
+        'NFT metadata is missing required field: name',
+      );
+    }
+    if (!metadata.description?.trim()) {
+      throw new BadRequestException(
+        'NFT metadata is missing required field: description',
+      );
+    }
+    if (!metadata.image?.trim()) {
+      throw new BadRequestException(
+        'NFT metadata is missing required field: image',
+      );
+    }
+    if (!metadata.animation_url?.trim()) {
+      throw new BadRequestException(
+        'NFT metadata is missing required field: animation_url',
+      );
+    }
+    if (!Array.isArray(metadata.attributes)) {
+      throw new BadRequestException(
+        'NFT metadata attributes must be an array',
+      );
+    }
+    for (const attr of metadata.attributes) {
+      if (!attr.trait_type?.trim()) {
+        throw new BadRequestException(
+          'NFT metadata attribute has an empty trait_type',
+        );
+      }
+      if (attr.value === null || attr.value === undefined) {
+        throw new BadRequestException(
+          `NFT metadata attribute "${attr.trait_type}" has a null or undefined value`,
+        );
+      }
+    }
+  }
+
+  /**
    * Upload NFT metadata JSON to IPFS via Pinata or nft.storage.
    * Returns an ipfs:// URI for the pinned content.
    */
@@ -56,6 +101,7 @@ export class IpfsUploadService {
     metadata: NftMetadata,
     clipId: number,
   ): Promise<string> {
+    this.validateMetadata(metadata);
     const provider = this.resolveProvider();
 
     return this.circuitBreakerService.execute(


### PR DESCRIPTION
Closes #363

---

## Summary

- **Rename `trait_type` values** in `buildMetadata()` from camelCase to human-readable NFT standard names:
  - `clipDuration` → `Clip Duration`
  - `viralityScore` → `Virality Score`
  - `createdAt` → `Creation Date`
  - `royaltyBps` → `Royalty BPS`
  - `royaltyPercent` → `Royalty Percent`
  - `platformsPosted` → `Platforms Posted To`
- **Fix platforms join separator** from `","` to `", "` for consistent display in wallets and marketplaces
- **Null-safe `viralityScore`** already used `?? 0`; extracted to a named variable for clarity
- **Empty platforms** produces an empty string instead of the sentinel string `"none"`, making the attribute value predictable and standards-compliant
- **Add `IpfsUploadService.validateMetadata()`** — guards all required NFT metadata fields (`name`, `description`, `image`, `animation_url`, attributes array integrity) and throws `BadRequestException` before any IPFS provider API call is made

## Test plan

- [ ] Verify all renamed attributes appear with the new human-readable names in generated metadata
- [ ] Verify legacy camelCase trait names are no longer present
- [ ] Confirm `Virality Score` defaults to `0` when `viralityScore` is `null`
- [ ] Confirm `Platforms Posted To` is `""` when no platforms are posted
- [ ] Confirm `Platforms Posted To` uses `", "` separator for multiple platforms
- [ ] Confirm `validateMetadata` rejects metadata missing `name`, `description`, `image`, or `animation_url`
- [ ] Confirm `validateMetadata` rejects attributes with empty `trait_type` or `null`/`undefined` value
- [ ] Confirm numeric zero is accepted as a valid attribute value
- [ ] Confirm `fetch` is never called when validation fails
- [ ] Confirm valid metadata continues to upload successfully to IPFS and stores the CID as `metadataUri`