### PR TITLE
feat(web3): IPFS metadata, royalty query, Stellar subscriptions & unsigned payouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,8 @@ STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL="https://horizon-testnet.stellar.org"
 # Platform wallet address for receiving subscription payments
 STELLAR_WALLET_ADDRESS="your_stellar_wallet_address"
+# Optional USDC issuer for subscription payments (asset=usdc)
+# STELLAR_USDC_ISSUER="G..."
 
 # ── Payout Limits ─────────────────────────────────────────────────────────────
 # Minimum and maximum payout amounts per currency.

--- a/src/clips/nft-mint.service.spec.ts
+++ b/src/clips/nft-mint.service.spec.ts
@@ -148,6 +148,7 @@ const nftOwnershipMock = {
 
 const royaltyConfigMock = {
   getCreatorRoyaltyBps: jest.fn().mockReturnValue(1000),
+  getPlatformWallet: jest.fn().mockReturnValue('GDV76E6XN6A3Q3WXVZ4KPRQ7L6E6XN6A3Q3WXVZ4KPRQ7L6E6XN6'),
   buildRoyaltyMap: jest.fn(),
 };
 
@@ -210,6 +211,13 @@ function makeService(): NftMintService {
       description: 'A test clip',
       image: 'https://cdn.example.com/thumb.jpg',
       animation_url: 'https://cdn.example.com/video.mp4',
+      seller_fee_basis_points: 1000,
+      fee_recipient: 'GDV76E6XN6A3Q3WXVZ4KPRQ7L6E6XN6A3Q3WXVZ4KPRQ7L6E6XN6',
+      royalty: {
+        bps: 1000,
+        percent: 10,
+        recipient: 'GDV76E6XN6A3Q3WXVZ4KPRQ7L6E6XN6A3Q3WXVZ4KPRQ7L6E6XN6',
+      },
     });
 
     const attrs: Array<{ trait_type: string; value: string | number }> =
@@ -340,6 +348,8 @@ function makeService(): NftMintService {
     expect(meta).toHaveProperty('image');
     expect(meta).toHaveProperty('animation_url');
     expect(meta).toHaveProperty('attributes');
+    expect(meta).toHaveProperty('seller_fee_basis_points');
+    expect(meta).toHaveProperty('royalty');
     expect(Array.isArray((meta as any).attributes)).toBe(true);
   });
 

--- a/src/clips/nft-mint.service.ts
+++ b/src/clips/nft-mint.service.ts
@@ -67,6 +67,16 @@ export class NftMintService {
       );
     }
 
+    const royaltyBps = this.royaltyConfigurationService.getCreatorRoyaltyBps(
+      clip.royaltyBps,
+    );
+    let royaltyRecipient: string | undefined;
+    try {
+      royaltyRecipient = this.royaltyConfigurationService.getPlatformWallet();
+    } catch {
+      royaltyRecipient = undefined;
+    }
+
     const metadata = this.buildMetadata({
       id: clip.id,
       title: clip.title,
@@ -77,9 +87,8 @@ export class NftMintService {
       viralityScore: clip.viralityScore,
       createdAt: clip.createdAt,
       postStatus: clip.postStatus,
-      royaltyBps: this.royaltyConfigurationService.getCreatorRoyaltyBps(
-        clip.royaltyBps,
-      ),
+      royaltyBps,
+      royaltyRecipient,
     });
 
     const metadataUri = await this.ipfsUploadService.uploadMetadata(
@@ -281,9 +290,11 @@ export class NftMintService {
     createdAt: Date;
     postStatus: unknown;
     royaltyBps: number;
+    royaltyRecipient?: string | null;
   }): NftMetadata {
     const platforms = this.extractPlatforms(clip.postStatus);
     const viralityScore = clip.viralityScore ?? 0;
+    const royaltyRecipient = clip.royaltyRecipient?.trim() || undefined;
 
     const attributes: NftAttribute[] = [
       { trait_type: 'Clip Duration', value: clip.duration },
@@ -300,6 +311,13 @@ export class NftMintService {
       image: clip.thumbnail || clip.clipUrl,
       animation_url: clip.clipUrl,
       attributes,
+      seller_fee_basis_points: clip.royaltyBps,
+      ...(royaltyRecipient ? { fee_recipient: royaltyRecipient } : {}),
+      royalty: {
+        bps: clip.royaltyBps,
+        percent: clip.royaltyBps / 100,
+        ...(royaltyRecipient ? { recipient: royaltyRecipient } : {}),
+      },
     };
   }
 

--- a/src/nft/ipfs-upload.service.spec.ts
+++ b/src/nft/ipfs-upload.service.spec.ts
@@ -28,7 +28,9 @@ describe('IpfsUploadService', () => {
     description: 'Test clip',
     image: 'https://cdn.example.com/thumb.jpg',
     animation_url: 'https://cdn.example.com/video.mp4',
-    attributes: [{ trait_type: 'royaltyBps', value: 1000 }],
+    attributes: [{ trait_type: 'Royalty BPS', value: 1000 }],
+    seller_fee_basis_points: 1000,
+    royalty: { bps: 1000, percent: 10 },
   };
 
   beforeEach(() => {
@@ -131,6 +133,8 @@ describe('IpfsUploadService', () => {
         { trait_type: 'Creation Date', value: '2026-06-25T12:00:00Z' },
         { trait_type: 'Platforms Posted To', value: 'TikTok, Instagram' },
       ],
+      seller_fee_basis_points: 1000,
+      royalty: { bps: 1000, percent: 10 },
     };
 
     it('does not throw for valid metadata', () => {
@@ -234,6 +238,14 @@ describe('IpfsUploadService', () => {
 
       const uri = await service.uploadMetadata(validMetadata, 10);
       expect(uri).toBe('ipfs://bafyValidCid');
+    });
+
+    it('throws when royalty info is missing', () => {
+      const { royalty: _royalty, seller_fee_basis_points: _bps, ...rest } =
+        validMetadata;
+      expect(() =>
+        service.validateMetadata(rest as NftMetadata),
+      ).toThrow(BadRequestException);
     });
   });
 });

--- a/src/nft/ipfs-upload.service.ts
+++ b/src/nft/ipfs-upload.service.ts
@@ -10,6 +10,12 @@ export interface NftMetadataAttribute {
   value: string | number;
 }
 
+export interface NftRoyaltyInfo {
+  bps: number;
+  percent: number;
+  recipient?: string;
+}
+
 export interface NftMetadata {
   name: string;
   description: string;
@@ -17,6 +23,12 @@ export interface NftMetadata {
   animation_url: string;
   external_url?: string;
   attributes: NftMetadataAttribute[];
+  /** OpenSea-compatible creator royalty in basis points (e.g. 1000 = 10%). */
+  seller_fee_basis_points: number;
+  /** Optional royalty recipient (Stellar G... address when known). */
+  fee_recipient?: string;
+  /** Explicit royalty block for marketplaces / mint clients. */
+  royalty: NftRoyaltyInfo;
 }
 
 export type IpfsProvider = 'pinata' | 'nftstorage';
@@ -90,6 +102,24 @@ export class IpfsUploadService {
           `NFT metadata attribute "${attr.trait_type}" has a null or undefined value`,
         );
       }
+    }
+    if (
+      typeof metadata.seller_fee_basis_points !== 'number' ||
+      !Number.isFinite(metadata.seller_fee_basis_points) ||
+      metadata.seller_fee_basis_points < 0
+    ) {
+      throw new BadRequestException(
+        'NFT metadata is missing required royalty field: seller_fee_basis_points',
+      );
+    }
+    if (
+      !metadata.royalty ||
+      typeof metadata.royalty.bps !== 'number' ||
+      typeof metadata.royalty.percent !== 'number'
+    ) {
+      throw new BadRequestException(
+        'NFT metadata is missing required royalty info (royalty.bps / royalty.percent)',
+      );
     }
   }
 

--- a/src/nft/nft-metadata.service.ts
+++ b/src/nft/nft-metadata.service.ts
@@ -11,6 +11,7 @@ interface ClipData {
   viralityScore: number | null;
   createdAt: Date;
   royaltyBps: number;
+  royaltyRecipient?: string | null;
 }
 
 /**
@@ -25,18 +26,28 @@ export class NftMetadataService {
    * with wallets, explorers, and marketplaces.
    */
   build(clip: ClipData): NftMetadata {
+    const royaltyBps = clip.royaltyBps;
+    const royaltyRecipient = clip.royaltyRecipient?.trim() || undefined;
+
     return {
       name: clip.title?.trim() || `Clip #${clip.id}`,
       description: clip.caption?.trim() || `ClipCash generated clip ${clip.id}`,
       image: clip.thumbnail ?? clip.clipUrl,
       animation_url: clip.clipUrl,
       attributes: [
-        { trait_type: 'clipId', value: clip.id },
-        { trait_type: 'duration', value: clip.duration },
-        { trait_type: 'viralityScore', value: clip.viralityScore ?? 0 },
-        { trait_type: 'royaltyBps', value: clip.royaltyBps },
-        { trait_type: 'createdAt', value: clip.createdAt.toISOString() },
+        { trait_type: 'Clip Duration', value: clip.duration },
+        { trait_type: 'Virality Score', value: clip.viralityScore ?? 0 },
+        { trait_type: 'Creation Date', value: clip.createdAt.toISOString() },
+        { trait_type: 'Royalty BPS', value: royaltyBps },
+        { trait_type: 'Royalty Percent', value: royaltyBps / 100 },
       ],
+      seller_fee_basis_points: royaltyBps,
+      ...(royaltyRecipient ? { fee_recipient: royaltyRecipient } : {}),
+      royalty: {
+        bps: royaltyBps,
+        percent: royaltyBps / 100,
+        ...(royaltyRecipient ? { recipient: royaltyRecipient } : {}),
+      },
     };
   }
 }

--- a/src/nft/nft.module.ts
+++ b/src/nft/nft.module.ts
@@ -16,9 +16,17 @@ import { NftMintGuard } from './guards/nft-mint.guard';
 import { PrismaModule } from '../prisma/prisma.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.module';
+import { RedisModule } from '../redis/redis.module';
 
 @Module({
-  imports: [PrismaModule, StellarModule, CircuitBreakerModule, IpfsUploadModule, NftOwnershipModule],
+  imports: [
+    PrismaModule,
+    StellarModule,
+    CircuitBreakerModule,
+    IpfsUploadModule,
+    NftOwnershipModule,
+    RedisModule,
+  ],
   providers: [
     NftConfig,
     NftService,

--- a/src/nft/royalty-query.service.ts
+++ b/src/nft/royalty-query.service.ts
@@ -8,10 +8,13 @@ import { StellarService } from '../stellar/stellar.service';
 import { RedisService } from '../redis/redis.service';
 import StellarSdk from '@stellar/stellar-sdk';
 import { CacheKeyBuilder } from './cache-key.util';
-import Redis from 'ioredis';
-import { CircuitBreakerService, CircuitBreakerConfig } from '../common/circuit-breaker/circuit-breaker.service';
+import {
+  CircuitBreakerService,
+  CircuitBreakerConfig,
+} from '../common/circuit-breaker/circuit-breaker.service';
 
-const CACHE_TTL_SECONDS = 300; // 5 minutes
+/** Redis cache TTL for on-chain royalty responses (5 minutes). */
+const CACHE_TTL_SECONDS = 300;
 
 export interface RoyaltyInfo {
   royaltyBps: number;
@@ -21,7 +24,6 @@ export interface RoyaltyInfo {
 @Injectable()
 export class RoyaltyQueryService {
   private readonly logger = new Logger(RoyaltyQueryService.name);
-  private readonly redis: Redis;
 
   private readonly CONTRACT_ID =
     process.env.SOROBAN_NFT_CONTRACT_ID ||
@@ -36,15 +38,9 @@ export class RoyaltyQueryService {
 
   constructor(
     private readonly stellarService: StellarService,
+    private readonly redisService: RedisService,
     private readonly circuitBreakerService: CircuitBreakerService,
-  ) {
-    this.redis = new Redis({
-      host: process.env.REDIS_HOST ?? 'localhost',
-      port: parseInt(process.env.REDIS_PORT ?? '6379', 10),
-      password: process.env.REDIS_PASSWORD || undefined,
-      lazyConnect: true,
-    });
-  }
+  ) {}
 
   /**
    * Returns royalty info for a given NFT mint address (token ID).
@@ -53,7 +49,7 @@ export class RoyaltyQueryService {
   async getRoyaltyInfo(mintAddress: string): Promise<RoyaltyInfo> {
     const cacheKey = CacheKeyBuilder.royalty(mintAddress);
 
-    const cached = await this.redis.get(cacheKey);
+    const cached = await this.redisService.get(cacheKey);
     if (cached) {
       this.logger.debug(`Cache hit for royalty:${mintAddress}`);
       return JSON.parse(cached) as RoyaltyInfo;
@@ -61,7 +57,11 @@ export class RoyaltyQueryService {
 
     const result = await this.queryOnChainRoyalty(mintAddress);
 
-    await this.redis.setex(cacheKey, CACHE_TTL_SECONDS, JSON.stringify(result));
+    await this.redisService.setex(
+      cacheKey,
+      CACHE_TTL_SECONDS,
+      JSON.stringify(result),
+    );
 
     return result;
   }
@@ -100,22 +100,24 @@ export class RoyaltyQueryService {
 
     let simulation: Awaited<ReturnType<typeof server.simulateTransaction>>;
     try {
-      // Simulate transaction with circuit breaker protection
       simulation = await this.circuitBreakerService.execute(
         this.sorobanCircuitBreakerConfig,
         async () => server.simulateTransaction(tx),
       );
     } catch (err) {
-      // Handle ServiceUnavailableException from circuit breaker
       if (err.name === 'ServiceUnavailableException') {
-        this.logger.error(`Soroban service unavailable during royalty query for ${mintAddress}`);
+        this.logger.error(
+          `Soroban service unavailable during royalty query for ${mintAddress}`,
+        );
         throw new InternalServerErrorException(
           'Soroban service temporarily unavailable. Please try again later.',
         );
       }
 
       const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Soroban simulation failed for token ${mintAddress}: ${msg}`);
+      this.logger.error(
+        `Soroban simulation failed for token ${mintAddress}: ${msg}`,
+      );
       throw new InternalServerErrorException(
         `Failed to query royalty from contract: ${msg}`,
       );
@@ -127,9 +129,8 @@ export class RoyaltyQueryService {
       );
     }
 
-    const results = (
-      simulation as { results?: Array<{ xdr: string }> }
-    ).results;
+    const results = (simulation as { results?: Array<{ xdr: string }> })
+      .results;
 
     if (!results?.[0]?.xdr) {
       throw new InternalServerErrorException(
@@ -138,9 +139,10 @@ export class RoyaltyQueryService {
     }
 
     const returnValue = StellarSdk.xdr.ScVal.fromXDR(results[0].xdr, 'base64');
-    const royaltyMap = StellarSdk.scValToNative(returnValue) as Map<string, bigint> | Record<string, bigint>;
+    const royaltyMap = StellarSdk.scValToNative(returnValue) as
+      | Map<string, bigint>
+      | Record<string, bigint>;
 
-    // Extract first (creator) entry from the royalty map
     const entries: [string, bigint][] =
       royaltyMap instanceof Map
         ? Array.from(royaltyMap.entries())

--- a/src/payouts/payouts.controller.ts
+++ b/src/payouts/payouts.controller.ts
@@ -44,8 +44,8 @@ export class PayoutsController {
   }
 
   @Post('initiate-stellar')
-  @ApiOperation({ summary: 'Prepare a Stellar payout transaction' })
-  @ApiResponse({ status: 201, description: 'Stellar payout transaction prepared' })
+  @ApiOperation({ summary: 'Prepare an unsigned Stellar payout transaction' })
+  @ApiResponse({ status: 201, description: 'Unsigned Stellar payout XDR returned; payout marked pending' })
   @ApiResponse({ status: 400, description: 'Invalid payout request or insufficient balance' })
   @ApiResponse({ status: 404, description: 'Payout not found' })
   async initiateStellarPayout(

--- a/src/payouts/payouts.service.spec.ts
+++ b/src/payouts/payouts.service.spec.ts
@@ -602,12 +602,10 @@ describe('PayoutsService', () => {
       });
 
       beforeEach(() => {
-        process.env.STELLAR_PLATFORM_SECRET = 'SOME_SECRET';
         process.env.STELLAR_WALLET_ADDRESS = mockPlatformAddress;
       });
 
       afterEach(() => {
-        delete process.env.STELLAR_PLATFORM_SECRET;
         delete process.env.STELLAR_WALLET_ADDRESS;
       });
 
@@ -658,16 +656,11 @@ describe('PayoutsService', () => {
           sequenceNumber: () => '1',
           accountId: () => mockPlatformAddress,
         } as any);
-        jest.spyOn(StellarSdk.Keypair, 'fromSecret').mockReturnValue({
-          publicKey: () => mockPlatformAddress,
-          sign: () => Buffer.from([]),
-        } as any);
         jest.spyOn(StellarSdk.Operation, 'payment').mockImplementation(() => ({} as any));
         jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'addOperation').mockImplementation(function () { return this; });
         jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'setTimeout').mockImplementation(function () { return this; });
         jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'build').mockImplementation(function () {
           return {
-            sign: () => {},
             hash: () => Buffer.from('aabbccdd', 'hex'),
             toXDR: () => 'mock-xdr-min',
           };
@@ -680,6 +673,7 @@ describe('PayoutsService', () => {
 
         const result = await service.initiateStellarPayout(1, 78, MIN);
         expect(result.status).toBe('pending');
+        expect(result.stellarXdr).toBe('mock-xdr-min');
       });
     });
 
@@ -756,16 +750,14 @@ describe('PayoutsService', () => {
 
   describe('initiateStellarPayout', () => {
     beforeEach(() => {
-      process.env.STELLAR_PLATFORM_SECRET = 'SOME_SECRET';
       process.env.STELLAR_WALLET_ADDRESS = mockPlatformAddress;
     });
 
     afterEach(() => {
-      delete process.env.STELLAR_PLATFORM_SECRET;
       delete process.env.STELLAR_WALLET_ADDRESS;
     });
 
-    it('should create a pending payout transaction and store XDR', async () => {
+    it('should create a pending payout transaction and store unsigned XDR', async () => {
       const destination = StellarSdk.Keypair.random().publicKey();
       mockPrismaService.payout.findFirst
         .mockResolvedValueOnce({
@@ -791,10 +783,6 @@ describe('PayoutsService', () => {
         sequenceNumber: () => '1',
         accountId: () => mockPlatformAddress,
       } as any);
-      jest.spyOn(StellarSdk.Keypair, 'fromSecret').mockReturnValue({
-        publicKey: () => mockPlatformAddress,
-        sign: () => Buffer.from([]),
-      } as any);
       jest.spyOn(StellarSdk.Operation, 'payment').mockImplementation(() => ({} as any));
       jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'addOperation').mockImplementation(function () {
         return this;
@@ -802,9 +790,10 @@ describe('PayoutsService', () => {
       jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'setTimeout').mockImplementation(function () {
         return this;
       });
+      const signSpy = jest.fn();
       jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'build').mockImplementation(function () {
         return {
-          sign: () => {},
+          sign: signSpy,
           hash: () => Buffer.from('deadbeef', 'hex'),
           toXDR: () => 'mock-xdr',
         };
@@ -815,6 +804,7 @@ describe('PayoutsService', () => {
       expect(result.status).toBe('pending');
       expect(result.stellarXdr).toBe('mock-xdr');
       expect(result.transactionId).toBe('deadbeef');
+      expect(signSpy).not.toHaveBeenCalled();
       expect(mockPrismaService.payout.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: 44 },

--- a/src/payouts/payouts.service.ts
+++ b/src/payouts/payouts.service.ts
@@ -142,16 +142,9 @@ export class PayoutsService {
       );
     }
 
-    const platformSecret = process.env.STELLAR_PLATFORM_SECRET;
-    if (!platformSecret) {
-      throw new InternalServerErrorException(
-        'STELLAR_PLATFORM_SECRET environment variable is not set',
-      );
-    }
-
-    const sourceKeyPair = StellarSdk.Keypair.fromSecret(platformSecret);
+    // Build an *unsigned* payment transaction for the platform (or ops) to sign later.
     const server = new StellarSdk.Horizon.Server(this.stellarService.horizonUrl);
-    const sourceAccount = await server.loadAccount(sourceKeyPair.publicKey());
+    const sourceAccount = await server.loadAccount(platformAddress);
 
     const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
       fee: StellarSdk.BASE_FEE,
@@ -166,8 +159,6 @@ export class PayoutsService {
       )
       .setTimeout(60)
       .build();
-
-    transaction.sign(sourceKeyPair);
 
     const transactionId = transaction.hash().toString('hex');
     const stellarXdr = transaction.toXDR();

--- a/src/subscriptions/dto/create-stellar-subscription.dto.ts
+++ b/src/subscriptions/dto/create-stellar-subscription.dto.ts
@@ -1,29 +1,58 @@
-import { IsString, IsNotEmpty, IsEnum, IsNumber, IsOptional } from 'class-validator';
+import { IsString, IsNotEmpty, IsEnum, IsNumber, IsOptional, ValidateIf } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateStellarSubscriptionDto {
+  @ApiProperty({ example: 'pro', description: 'Subscription plan identifier' })
   @IsString()
   @IsNotEmpty()
   plan: string;
 
+  @ApiProperty({
+    enum: ['xlm', 'usdc', 'custom'],
+    description:
+      'Payment asset. Use xlm for native XLM, usdc for USDC, or custom for other Stellar assets (provide assetCode + assetIssuer).',
+  })
   @IsString()
   @IsEnum(['xlm', 'usdc', 'custom'])
   asset: string;
 
+  @ApiProperty({ example: 10, description: 'Payment amount in the selected asset' })
   @IsNumber()
   @IsNotEmpty()
   amount: number;
 
+  @ApiPropertyOptional({ description: 'Connected Stellar wallet ID' })
   @IsString()
   @IsOptional()
   walletId?: string;
 
+  @ApiPropertyOptional({ description: 'Override destination Stellar address' })
   @IsString()
   @IsOptional()
   destinationAddress?: string;
 
+  @ApiPropertyOptional({ description: 'Payment memo for tracking' })
   @IsString()
   @IsOptional()
   memo?: string;
+
+  @ApiPropertyOptional({
+    description: 'Required when asset is custom — Stellar asset code (e.g. EURC)',
+    example: 'EURC',
+  })
+  @ValidateIf((o: CreateStellarSubscriptionDto) => o.asset === 'custom')
+  @IsString()
+  @IsNotEmpty()
+  assetCode?: string;
+
+  @ApiPropertyOptional({
+    description: 'Required when asset is custom — issuing account public key',
+    example: 'G...',
+  })
+  @ValidateIf((o: CreateStellarSubscriptionDto) => o.asset === 'custom')
+  @IsString()
+  @IsNotEmpty()
+  assetIssuer?: string;
 }
 
 export class StellarPaymentIntentDto {
@@ -34,4 +63,5 @@ export class StellarPaymentIntentDto {
   memo: string;
   expiresAt: Date;
   status: 'pending' | 'completed' | 'expired';
+  assetIssuer?: string | null;
 }

--- a/src/subscriptions/stellar-payment.service.spec.ts
+++ b/src/subscriptions/stellar-payment.service.spec.ts
@@ -70,16 +70,13 @@ describe('StellarPaymentService', () => {
       const mockPaymentIntent = {
         id: 'intent-id',
         amount: 10,
-        asset: 'xlm',
+        asset: 'XLM',
         destination: 'GDEST',
         memo: 'memo',
         status: 'pending',
         expiresAt: new Date(),
       };
       mockPrismaService.wallet.findFirst.mockResolvedValue(mockWallet);
-      mockPrismaService.stellarPaymentIntent.create.mockResolvedValue(
-        mockPaymentIntent,
-      );
       mockPrismaService.stellarPaymentIntent.create.mockResolvedValue(mockPaymentIntent);
 
       const result = await service.createPaymentIntent(userId, dto);
@@ -87,12 +84,18 @@ describe('StellarPaymentService', () => {
       expect(result).toEqual({
         id: 'intent-id',
         amount: 10,
-        asset: 'xlm',
-        destination: mockWallet.address,
+        asset: 'XLM',
+        destination: 'GDEST',
         memo: expect.stringMatching(/^CLIPS-/),
         expiresAt: mockPaymentIntent.expiresAt,
         status: 'pending',
+        assetIssuer: null,
       });
+      expect(mockPrismaService.stellarPaymentIntent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ asset: 'XLM' }),
+        }),
+      );
     });
 
     it('should throw error if wallet not found', async () => {

--- a/src/subscriptions/stellar-payment.service.ts
+++ b/src/subscriptions/stellar-payment.service.ts
@@ -1,10 +1,16 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
-import { Horizon, Asset } from '@stellar/stellar-sdk';
-import { CreateStellarSubscriptionDto, StellarPaymentIntentDto } from './dto/create-stellar-subscription.dto';
+import { Horizon } from '@stellar/stellar-sdk';
+import {
+  CreateStellarSubscriptionDto,
+  StellarPaymentIntentDto,
+} from './dto/create-stellar-subscription.dto';
 import { StellarService } from '../stellar/stellar.service';
-import { CircuitBreakerService, CircuitBreakerConfig } from '../common/circuit-breaker/circuit-breaker.service';
+import {
+  CircuitBreakerService,
+  CircuitBreakerConfig,
+} from '../common/circuit-breaker/circuit-breaker.service';
 
 @Injectable()
 export class StellarPaymentService {
@@ -29,10 +35,12 @@ export class StellarPaymentService {
   }
 
   /**
-   * Generate a payment intent for subscription
+   * Generate a payment intent for subscription (XLM, USDC, or custom Stellar asset).
    */
-  async createPaymentIntent(userId: number, dto: CreateStellarSubscriptionDto): Promise<StellarPaymentIntentDto> {
-    // Get user's Stellar wallet
+  async createPaymentIntent(
+    userId: number,
+    dto: CreateStellarSubscriptionDto,
+  ): Promise<StellarPaymentIntentDto> {
     const wallet = await this.prisma.wallet.findFirst({
       where: {
         userId,
@@ -42,14 +50,15 @@ export class StellarPaymentService {
     });
 
     if (!wallet) {
-      throw new Error('Stellar wallet not found. Please connect a wallet first.');
+      throw new BadRequestException(
+        'Stellar wallet not found. Please connect a wallet first.',
+      );
     }
 
-    // Generate unique memo for payment tracking
     const memo = dto.memo || this.generatePaymentMemo(userId);
-    
-    // Create payment intent record
-    const destination = dto.destinationAddress ?? this.configService.get<string>('STELLAR_WALLET_ADDRESS');
+    const destination =
+      dto.destinationAddress ??
+      this.configService.get<string>('STELLAR_WALLET_ADDRESS');
     if (!destination) {
       throw new BadRequestException('STELLAR_WALLET_ADDRESS not configured');
     }
@@ -58,15 +67,19 @@ export class StellarPaymentService {
       throw new BadRequestException('Invalid Stellar address format');
     }
 
+    const { asset, assetIssuer } = this.resolveAsset(dto);
+
     const paymentIntent = await this.prisma.stellarPaymentIntent.create({
       data: {
         userId,
         amount: dto.amount,
-        asset: dto.asset,
+        asset,
         destination,
         memo,
         status: 'pending',
-        expiresAt: new Date(Date.now() + this.PAYMENT_EXPIRY_MINUTES * 60 * 1000),
+        expiresAt: new Date(
+          Date.now() + this.PAYMENT_EXPIRY_MINUTES * 60 * 1000,
+        ),
         plan: dto.plan,
       },
     });
@@ -74,26 +87,31 @@ export class StellarPaymentService {
     return {
       id: paymentIntent.id,
       amount: dto.amount,
-      asset: dto.asset,
+      asset,
       destination,
       memo,
       expiresAt: paymentIntent.expiresAt,
       status: 'pending',
+      assetIssuer,
     };
   }
 
   /**
-   * Verify Stellar payment transaction
+   * Verify Stellar payment transaction.
+   * On success: marks intent completed and activates subscription.
+   * On failure: leaves subscription inactive and returns false.
    */
-  async verifyPayment(paymentIntentId: string, transactionHash: string): Promise<boolean> {
+  async verifyPayment(
+    paymentIntentId: string,
+    transactionHash: string,
+  ): Promise<boolean> {
     try {
-      // Get the transaction from Stellar network with circuit breaker
       const transaction = await this.circuitBreakerService.execute(
         this.horizonCircuitBreakerConfig,
-        async () => this.server.transactions().transaction(transactionHash).call(),
+        async () =>
+          this.server.transactions().transaction(transactionHash).call(),
       );
 
-      // Get the payment intent
       const paymentIntent = await this.prisma.stellarPaymentIntent.findUnique({
         where: { id: paymentIntentId },
       });
@@ -102,32 +120,38 @@ export class StellarPaymentService {
         return false;
       }
 
-      // Fetch operations for the transaction
+      if (paymentIntent.expiresAt.getTime() <= Date.now()) {
+        await this.prisma.stellarPaymentIntent.update({
+          where: { id: paymentIntentId },
+          data: { status: 'expired' },
+        });
+        return false;
+      }
+
       const operationsPage = await transaction.operations().call();
       const operations = operationsPage.records;
-
-      // Verify transaction details match our payment intent
-      const payment = operations.find(op => op.type === 'payment');
+      const payment = operations.find((op) => op.type === 'payment');
 
       if (!payment) {
         return false;
       }
 
-      // Get asset code
-      const assetCode = payment.asset_type === 'native' ? 'XLM' : payment.asset_code;
+      const paidAsset = this.extractPaidAsset(payment);
+      const expected = this.parseStoredAsset(paymentIntent.asset);
 
-      // Verify payment matches our intent
       const isValidPayment =
         payment.destination === paymentIntent.destination &&
-        assetCode === paymentIntent.asset &&
+        this.assetsMatch(paidAsset, expected) &&
         parseFloat(payment.amount) === paymentIntent.amount &&
         transaction.memo === paymentIntent.memo;
 
       if (!isValidPayment) {
+        this.logger.warn(
+          `Stellar payment verification failed for intent ${paymentIntentId}`,
+        );
         return false;
       }
 
-      // Mark payment as completed
       await this.prisma.stellarPaymentIntent.update({
         where: { id: paymentIntentId },
         data: {
@@ -136,24 +160,30 @@ export class StellarPaymentService {
         },
       });
 
-      // Activate subscription
-      await this.activateSubscription(paymentIntent.userId, paymentIntent.plan, transactionHash, paymentIntent.memo);
+      await this.activateSubscription(
+        paymentIntent.userId,
+        paymentIntent.plan,
+        transactionHash,
+        paymentIntent.memo,
+      );
 
       return true;
     } catch (error) {
       if (error.name === 'ServiceUnavailableException') {
-        this.logger.error(`Stellar service unavailable during payment verification: ${error.message}`);
+        this.logger.error(
+          `Stellar service unavailable during payment verification: ${error.message}`,
+        );
         throw error;
       }
       this.logger.error(`Error verifying Stellar payment: ${error.message}`);
+      // Failed verification must leave subscription inactive
       return false;
     }
   }
 
-  /**
-   * Get pending payment intents for a user
-   */
-  async getPendingPaymentIntents(userId: number): Promise<StellarPaymentIntentDto[]> {
+  async getPendingPaymentIntents(
+    userId: number,
+  ): Promise<StellarPaymentIntentDto[]> {
     const intents = await this.prisma.stellarPaymentIntent.findMany({
       where: {
         userId,
@@ -162,31 +192,38 @@ export class StellarPaymentService {
       },
     });
 
-    return intents.map(intent => ({
-      id: intent.id,
-      amount: intent.amount,
-      asset: intent.asset,
-      destination: intent.destination,
-      memo: intent.memo,
-      expiresAt: intent.expiresAt,
-      status: intent.status as 'pending' | 'completed' | 'expired',
-    }));
+    return intents.map((intent) => {
+      const parsed = this.parseStoredAsset(intent.asset);
+      return {
+        id: intent.id,
+        amount: intent.amount,
+        asset: parsed.code,
+        destination: intent.destination,
+        memo: intent.memo,
+        expiresAt: intent.expiresAt,
+        status: intent.status as 'pending' | 'completed' | 'expired',
+        assetIssuer: parsed.issuer,
+      };
+    });
   }
 
-  /**
-   * Activate subscription for a user
-   */
-  private async activateSubscription(userId: number, plan: string, stellarTxHash?: string, stellarMemo?: string): Promise<void> {
-    const planDurations = {
-      'pro': 30, // 30 days
-      'agency': 30, // 30 days
+  private async activateSubscription(
+    userId: number,
+    plan: string,
+    stellarTxHash?: string,
+    stellarMemo?: string,
+  ): Promise<void> {
+    const planDurations: Record<string, number> = {
+      pro: 30,
+      agency: 30,
     };
 
     const duration = planDurations[plan] || 30;
     const startDate = new Date();
-    const endDate = new Date(startDate.getTime() + duration * 24 * 60 * 60 * 1000);
+    const endDate = new Date(
+      startDate.getTime() + duration * 24 * 60 * 60 * 1000,
+    );
 
-    // Deactivate existing subscriptions
     await this.prisma.subscription.updateMany({
       where: {
         userId,
@@ -198,7 +235,6 @@ export class StellarPaymentService {
       },
     });
 
-    // Create new subscription
     await this.prisma.subscription.create({
       data: {
         userId,
@@ -213,18 +249,12 @@ export class StellarPaymentService {
     });
   }
 
-  /**
-   * Generate unique payment memo
-   */
   private generatePaymentMemo(userId: number): string {
     const timestamp = Date.now().toString(36);
     const random = Math.random().toString(36).substr(2, 5);
     return `CLIPS-${userId}-${timestamp}-${random}`;
   }
 
-  /**
-   * Process expired payment intents
-   */
   async processExpiredPaymentIntents(): Promise<void> {
     await this.prisma.stellarPaymentIntent.updateMany({
       where: {
@@ -284,7 +314,93 @@ export class StellarPaymentService {
       },
     });
 
-    await this.activateSubscription(paymentIntent.userId, paymentIntent.plan, params.transactionId, params.memo);
+    await this.activateSubscription(
+      paymentIntent.userId,
+      paymentIntent.plan,
+      params.transactionId,
+      params.memo,
+    );
     return true;
+  }
+
+  /**
+   * Normalize asset selection into a stored code (and optional issuer).
+   * XLM / USDC are uppercase; custom assets are stored as CODE:ISSUER.
+   */
+  private resolveAsset(dto: CreateStellarSubscriptionDto): {
+    asset: string;
+    assetIssuer: string | null;
+  } {
+    const kind = dto.asset.toLowerCase();
+
+    if (kind === 'xlm') {
+      return { asset: 'XLM', assetIssuer: null };
+    }
+
+    if (kind === 'usdc') {
+      const issuer =
+        this.configService.get<string>('STELLAR_USDC_ISSUER') ?? null;
+      return {
+        asset: issuer ? `USDC:${issuer}` : 'USDC',
+        assetIssuer: issuer,
+      };
+    }
+
+    // custom — future Stellar assets
+    const code = dto.assetCode?.trim().toUpperCase();
+    const issuer = dto.assetIssuer?.trim();
+    if (!code || !issuer) {
+      throw new BadRequestException(
+        'Custom Stellar assets require assetCode and assetIssuer',
+      );
+    }
+    const issuerCheck = this.stellarService.validateAddress(issuer);
+    if (!issuerCheck.valid) {
+      throw new BadRequestException('Invalid assetIssuer Stellar address');
+    }
+    return { asset: `${code}:${issuer}`, assetIssuer: issuer };
+  }
+
+  private parseStoredAsset(stored: string): {
+    code: string;
+    issuer: string | null;
+  } {
+    if (stored.includes(':')) {
+      const [code, issuer] = stored.split(':');
+      return { code: code.toUpperCase(), issuer: issuer || null };
+    }
+    return { code: stored.toUpperCase(), issuer: null };
+  }
+
+  private extractPaidAsset(payment: {
+    asset_type: string;
+    asset_code?: string;
+    asset_issuer?: string;
+  }): { code: string; issuer: string | null } {
+    if (payment.asset_type === 'native') {
+      return { code: 'XLM', issuer: null };
+    }
+    return {
+      code: (payment.asset_code ?? '').toUpperCase(),
+      issuer: payment.asset_issuer ?? null,
+    };
+  }
+
+  private assetsMatch(
+    paid: { code: string; issuer: string | null },
+    expected: { code: string; issuer: string | null },
+  ): boolean {
+    if (paid.code !== expected.code) {
+      return false;
+    }
+    // Native XLM has no issuer
+    if (expected.code === 'XLM') {
+      return true;
+    }
+    // If we stored an issuer, require an exact match; otherwise accept any issuer for that code
+    if (!expected.issuer) {
+      return true;
+    }
+    return paid.issuer === expected.issuer;
   }
 }

--- a/src/subscriptions/subscriptions.controller.ts
+++ b/src/subscriptions/subscriptions.controller.ts
@@ -23,7 +23,9 @@ export class SubscriptionsController {
   constructor(private readonly stellarPaymentService: StellarPaymentService) {}
 
   @Post('create-stellar')
-  @ApiOperation({ summary: 'Create Stellar payment intent for subscription' })
+  @ApiOperation({
+    summary: 'Create Stellar payment intent for subscription (XLM, USDC, or custom asset)',
+  })
   @ApiResponse({
     status: 201,
     description: 'Payment intent created successfully',
@@ -62,12 +64,15 @@ export class SubscriptionsController {
   }
 
   @Post('stellar/verify')
-  @ApiOperation({ summary: 'Verify Stellar payment transaction' })
+  @ApiOperation({
+    summary: 'Verify Stellar payment and activate subscription on success',
+  })
   @ApiQuery({ name: 'paymentIntentId', description: 'Payment intent ID' })
   @ApiQuery({ name: 'transactionHash', description: 'Stellar transaction hash' })
   @ApiResponse({
     status: 200,
-    description: 'Payment verification result',
+    description:
+      'Payment verification result. verified=true activates the subscription; verified=false leaves it inactive.',
   })
   @HttpCode(HttpStatus.OK)
   async verifyStellarPayment(

--- a/test/payouts.e2e-spec.ts
+++ b/test/payouts.e2e-spec.ts
@@ -156,7 +156,7 @@ describe('Payouts E2E', () => {
       .expect(400);
   });
 
-  it('POST /payouts/initiate-stellar prepares a pending Stellar payout transaction', async () => {
+  it('POST /payouts/initiate-stellar prepares a pending unsigned Stellar payout transaction', async () => {
     const destination = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
     mockPrisma.payout.findFirst
@@ -183,10 +183,6 @@ describe('Payouts E2E', () => {
       sequenceNumber: () => '1',
       accountId: () => 'GPLATFORM',
     } as any);
-    jest.spyOn(StellarSdk.Keypair, 'fromSecret').mockReturnValue({
-      publicKey: () => 'GPLATFORM',
-      sign: () => Buffer.from([]),
-    } as any);
     jest.spyOn(StellarSdk.Operation, 'payment').mockImplementation(() => ({} as any));
     jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'addOperation').mockImplementation(function () {
       return this;
@@ -194,15 +190,15 @@ describe('Payouts E2E', () => {
     jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'setTimeout').mockImplementation(function () {
       return this;
     });
+    const signSpy = jest.fn();
     jest.spyOn(StellarSdk.TransactionBuilder.prototype, 'build').mockImplementation(function () {
       return {
-        sign: () => {},
+        sign: signSpy,
         hash: () => Buffer.from('abcd', 'hex'),
         toXDR: () => 'mock-stellar-xdr',
       };
     });
 
-    process.env.STELLAR_PLATFORM_SECRET = 'SOME_SECRET';
     process.env.STELLAR_WALLET_ADDRESS = 'GPLATFORM';
 
     const res = await request(app.getHttpServer())
@@ -213,6 +209,7 @@ describe('Payouts E2E', () => {
     expect(res.body.status).toBe('pending');
     expect(res.body.stellarXdr).toBe('mock-stellar-xdr');
     expect(res.body.transactionId).toBe('abcd');
+    expect(signSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
closes #533 
closes #535 
closes #536 
closes #538


### PR description

## Summary
Completes four Web3/NFT/Stellar tasks: ERC-721 metadata upload to IPFS with royalty fields, cached on-chain royalty queries, Stellar subscription payments (XLM + future assets), and unsigned payout transaction preparation.

## Task 1 — Upload Clip Metadata to IPFS Before Minting
- `uploadMetadataToIPFS()` builds ERC-721/OpenSea metadata and uploads via Pinata or nft.storage
- Metadata includes `name`, `description`, `image`, `animation_url`, `attributes`, plus royalty info (`seller_fee_basis_points`, `fee_recipient`, `royalty`)
- Returned CID/URI is saved on `Clip.metadataUri` and returned for minting
- Pre-upload validation rejects incomplete metadata (including missing royalty fields)

## Task 2 — On-chain Royalty Query Endpoint
- `GET /nfts/:mintAddress/royalty` queries the Soroban `get_royalties` contract
- Responses cached in Redis via `RedisService` with a **5-minute** TTL
- Returns `{ "royaltyBps": number, "recipient": "G..." }`

## Task 3 — Stellar Subscription Payments
- Payment method `stellar` with endpoints:
  - `POST /subscriptions/create-stellar` — create payment intent
  - `POST /subscriptions/stellar/verify` — verify payment
- Supports **XLM**, **USDC**, and **custom** Stellar assets (`assetCode` + `assetIssuer`)
- Successful verification activates the subscription; failed verification leaves it inactive
- Asset codes normalized (fixes XLM/`xlm` mismatch)

## Task 4 — Prepare Stellar Payout Transaction
- `POST /payouts/initiate-stellar` validates amount/method/wallet/balance
- Builds and returns an **unsigned** Stellar payment XDR (no platform secret signing)
- Stores pending payout with `stellarXdr` / `transactionId`
- Rejects invalid amounts, wrong methods, missing wallets, and insufficient balance

## Test plan
- [ ] Upload metadata for a clip → confirm IPFS URI persisted on `Clip.metadataUri` and royalty fields present
- [ ] `GET /nfts/:id/royalty` → confirm response shape; second call is a Redis cache hit within 5 minutes
- [ ] Create XLM subscription intent → verify with valid tx → subscription becomes `active`
- [ ] Verify with invalid/mismatched tx → subscription stays inactive
- [ ] Create custom-asset intent with `assetCode` + `assetIssuer`
- [ ] `POST /payouts/initiate-stellar` → returns unsigned XDR, payout status `pending`, invalid amounts rejected