### PR TITLE
feat: mask wallet addresses, prevent posting posted clips, Stellar network config, Swagger docs

### DIFF
--- a/src/clips/clips.controller.ts
+++ b/src/clips/clips.controller.ts
@@ -18,8 +18,13 @@ import {
   ApiBearerAuth,
   ApiQuery,
   ApiParam,
+  ApiBody,
   ApiUnauthorizedResponse,
   ApiInternalServerErrorResponse,
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiForbiddenResponse,
+  ApiTooManyRequestsResponse,
 } from '@nestjs/swagger';
 import type { Request } from 'express';
 import { ClipsService } from './clips.service.js';
@@ -38,10 +43,79 @@ import {
 } from '../common/guards/queue-rate-limit.guard';
 import { DEFAULT_CLIP_ROYALTY_BPS } from './dto/create-clip.dto.js';
 
+// ── Shared schema fragments ──────────────────────────────────────────────────
+
+const ClipSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'number', example: 101 },
+    videoId: { type: 'number', example: 7 },
+    title: { type: 'string', example: 'The best 30 seconds of your video' },
+    caption: {
+      type: 'string',
+      example: 'Check this out! 🔥 #viral #clips',
+    },
+    clipUrl: {
+      type: 'string',
+      example: 'https://res.cloudinary.com/demo/video/upload/v1/clips/clip-101.mp4',
+    },
+    thumbnail: {
+      type: 'string',
+      example: 'https://res.cloudinary.com/demo/image/upload/v1/clips/thumb-101.jpg',
+    },
+    startTime: { type: 'number', example: 45.2 },
+    endTime: { type: 'number', example: 75.6 },
+    duration: { type: 'number', example: 30 },
+    viralityScore: { type: 'number', example: 87, nullable: true },
+    selected: { type: 'boolean', example: true },
+    postStatus: {
+      oneOf: [
+        { type: 'string', example: 'posted' },
+        {
+          type: 'object',
+          example: { tiktok: true, instagram: false },
+        },
+      ],
+      nullable: true,
+    },
+    nftStatus: {
+      type: 'string',
+      enum: ['none', 'minting', 'minted', 'failed'],
+      example: 'none',
+      nullable: true,
+    },
+    royaltyBps: {
+      type: 'number',
+      example: 1000,
+      description: 'NFT royalty in basis points (1000 = 10%)',
+    },
+    mintAddress: { type: 'string', nullable: true, example: null },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+};
+
+const ErrorSchema = (message: string) => ({
+  type: 'object',
+  properties: {
+    statusCode: { type: 'number' },
+    message: { type: 'string', example: message },
+    error: { type: 'string' },
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 @ApiTags('clips')
 @ApiBearerAuth('access-token')
-@ApiUnauthorizedResponse({ description: 'Unauthorized' })
-@ApiInternalServerErrorResponse({ description: 'Internal server error' })
+@ApiUnauthorizedResponse({
+  description: 'Missing or invalid JWT token',
+  schema: ErrorSchema('Unauthorized'),
+})
+@ApiInternalServerErrorResponse({
+  description: 'Unexpected server error',
+  schema: ErrorSchema('Internal server error'),
+})
 @UseGuards(LoginGuard)
 @Controller('clips')
 export class ClipsController {
@@ -50,56 +124,156 @@ export class ClipsController {
     private readonly clipPublishService: ClipPublishService,
   ) {}
 
+  // ── POST /clips/generate ───────────────────────────────────────────────────
+
   @Post('generate')
   @UseGuards(QueueRateLimitGuard)
   @QueueRateLimit({ queue: 'clip-generation', maxJobs: 5 })
   @ApiOperation({
-    summary: 'Generate a clip',
+    summary: 'Generate clips from a video',
     description:
-      'Enqueue a clip-generation job with automatic retry + exponential backoff. Returns the BullMQ job ID immediately; processing happens asynchronously.',
+      'Enqueues a clip-generation job. The job runs FFmpeg + AI virality analysis asynchronously. ' +
+      'Returns immediately with the BullMQ job ID. Poll the job-status endpoint to track progress. ' +
+      'Each user is limited to 5 active generation jobs; excess requests are delayed or rejected (429).',
+  })
+  @ApiBody({
+    description: 'Clip generation parameters',
+    schema: {
+      type: 'object',
+      required: ['videoId', 'inputPath', 'outputPath', 'startTime', 'endTime', 'positionRatio'],
+      properties: {
+        videoId: { type: 'string', example: '7', description: 'Source video ID' },
+        inputPath: {
+          type: 'string',
+          example: '/tmp/uploads/video-7.mp4',
+          description: 'Local path or CDN URL of the source video',
+        },
+        outputPath: {
+          type: 'string',
+          example: '/tmp/clips/clip-101.mp4',
+          description: 'Destination path for the generated clip',
+        },
+        startTime: { type: 'number', example: 45.2, description: 'Start offset in seconds (≥ 0)' },
+        endTime: {
+          type: 'number',
+          example: 75.6,
+          description: 'End offset in seconds (> startTime; duration must be 5–300 s)',
+        },
+        positionRatio: {
+          type: 'number',
+          example: 0.3,
+          description: 'startTime / totalDuration — used for AI virality scoring',
+        },
+        title: { type: 'string', example: 'Epic montage moment', description: 'Optional clip title' },
+        transcript: {
+          type: 'string',
+          example: 'And here is where everything changes…',
+          description: 'Optional transcript for AI caption generation',
+        },
+        royaltyBps: {
+          type: 'number',
+          example: 1000,
+          description: 'NFT royalty BPS (0–1500). Defaults to 1000 (10%) when omitted.',
+        },
+      },
+    },
   })
   @ApiResponse({
     status: 201,
-    description: 'Clip generation job queued successfully',
+    description: 'Job enqueued. Processing is asynchronous.',
+    schema: {
+      type: 'object',
+      properties: {
+        jobId: { type: 'string', example: 'bfb23d4c-1a2b-4c3d-8e9f-000111222333' },
+        delayed: { type: 'boolean', example: false },
+        delayMs: { type: 'number', example: 0, nullable: true },
+      },
+    },
   })
-  @ApiResponse({ status: 400, description: 'Invalid request data' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 429, description: 'Too many active jobs' })
+  @ApiBadRequestResponse({
+    description: 'Validation error (e.g. endTime ≤ startTime, duration out of range)',
+    schema: ErrorSchema('endTime must be greater than startTime'),
+  })
+  @ApiTooManyRequestsResponse({
+    description: 'User has reached the 5-job limit for clip-generation',
+    schema: ErrorSchema('Too many active clip-generation jobs'),
+  })
   generate(@Body() dto: ClipGenerationJob) {
     return this.clipsService.enqueueClip(dto);
   }
+
+  // ── GET /clips ─────────────────────────────────────────────────────────────
 
   @Get()
   @ApiOperation({
     summary: 'List clips',
     description:
-      'List clips sorted by viralityScore descending by default. Supports filtering by videoId and custom sorting.',
+      'Returns a paginated list of clips. Default sort is `viralityScore:desc`. ' +
+      'Use `videoId` to scope the list to one video. ' +
+      'Combine `page` + `limit` for pagination (limit 1–100, default page=1 limit=20).',
   })
-  @ApiResponse({
-    status: 200,
-    description: 'List of clips returned successfully',
-  })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiQuery({
     name: 'videoId',
     required: false,
-    description: 'Filter to a specific source video',
+    type: 'string',
+    description: 'Filter clips to a specific video ID',
+    example: '7',
   })
   @ApiQuery({
     name: 'sort',
     required: false,
-    description:
-      'Sort format: field:order (e.g., viralityScore:desc, createdAt:asc)',
+    type: 'string',
+    description: 'Compound sort: `field:order` — e.g. `viralityScore:desc`, `createdAt:asc`',
+    example: 'viralityScore:desc',
   })
   @ApiQuery({
     name: 'sortBy',
     required: false,
-    description: 'Legacy: viralityScore | createdAt | duration',
+    enum: ['viralityScore', 'createdAt', 'duration'],
+    description: '(Legacy) Sort field',
   })
   @ApiQuery({
     name: 'order',
     required: false,
-    description: 'Legacy: asc | desc',
+    enum: ['asc', 'desc'],
+    description: '(Legacy) Sort direction',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: 'number',
+    description: 'Page number (1-based, default: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: 'number',
+    description: 'Items per page (1–100, default: 20)',
+    example: 20,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of clips',
+    schema: {
+      type: 'object',
+      properties: {
+        data: { type: 'array', items: ClipSchema },
+        meta: {
+          type: 'object',
+          properties: {
+            total: { type: 'number', example: 250 },
+            page: { type: 'number', example: 1 },
+            limit: { type: 'number', example: 20 },
+            totalPages: { type: 'number', example: 13 },
+          },
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Non-integer page or limit values',
+    schema: ErrorSchema('page and limit must be integers'),
   })
   list(
     @Query('videoId') videoId?: string,
@@ -134,27 +308,99 @@ export class ClipsController {
     });
   }
 
+  // ── GET /clips/:id ─────────────────────────────────────────────────────────
+
   @Get(':id')
-  @ApiOperation({ summary: 'Get clip by ID' })
-  @ApiParam({ name: 'id', description: 'Clip ID' })
-  @ApiResponse({ status: 200, description: 'Clip found and returned' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 404, description: 'Clip not found' })
+  @ApiOperation({
+    summary: 'Get a clip by ID',
+    description: 'Returns full clip details including metadata, URLs, virality score, and NFT status.',
+  })
+  @ApiParam({ name: 'id', description: 'Clip ID', type: 'string', example: '101' })
+  @ApiResponse({
+    status: 200,
+    description: 'Clip found',
+    schema: ClipSchema,
+  })
+  @ApiNotFoundResponse({
+    description: 'No clip with the given ID',
+    schema: ErrorSchema('Clip 101 not found'),
+  })
   async findOne(@Param('id') id: string) {
     const clip = await this.clipsService.findById(id);
     if (!clip) throw new NotFoundException(`Clip ${id} not found`);
     return clip;
   }
 
+  // ── POST /clips/bulk-update ────────────────────────────────────────────────
+
   @Post('bulk-update')
   @ApiOperation({
     summary: 'Bulk update clips',
     description:
-      'Bulk update selected and/or postStatus for multiple clips in one transaction. Returns update statistics including notFoundIds for invalid clip IDs.',
+      'Atomically update `selected`, `postStatus`, `caption`, or `royaltyBps` across multiple clips in a single database transaction. ' +
+      'Only clips owned by the authenticated user are updated. ' +
+      'Returns `notFoundIds` for any clip IDs that did not match.',
   })
-  @ApiResponse({ status: 200, description: 'Clips updated successfully' })
-  @ApiResponse({ status: 400, description: 'Invalid request data' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiBody({
+    description: 'Clip IDs and the fields to update',
+    schema: {
+      type: 'object',
+      required: ['clipIds', 'updates'],
+      properties: {
+        clipIds: {
+          type: 'array',
+          items: { type: 'number' },
+          example: [101, 102, 103],
+          description: 'IDs of clips to update',
+        },
+        updates: {
+          type: 'object',
+          description: 'At least one field is required',
+          properties: {
+            selected: { type: 'boolean', example: true },
+            postStatus: {
+              oneOf: [{ type: 'string', example: 'posted' }, { type: 'object' }],
+              description: 'New post status value',
+            },
+            caption: { type: 'string', example: 'New caption text #viral' },
+            royaltyBps: {
+              type: 'number',
+              example: 500,
+              description: 'NFT royalty BPS (0–1500)',
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Update statistics',
+    schema: {
+      type: 'object',
+      properties: {
+        updatedCount: { type: 'number', example: 3 },
+        updates: {
+          type: 'object',
+          example: { selected: true },
+        },
+        notFoundIds: {
+          type: 'array',
+          items: { type: 'number' },
+          example: [],
+        },
+        allClipsProcessed: { type: 'boolean', example: false },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'No update fields provided',
+    schema: ErrorSchema('At least one of selected, postStatus, royaltyBps, or caption must be provided'),
+  })
+  @ApiForbiddenResponse({
+    description: 'None of the clip IDs belong to this user',
+    schema: ErrorSchema('None of the provided clipIds belong to this user or exist'),
+  })
   bulkUpdate(@Body() dto: BulkUpdateClipsDto, @Req() req: Request) {
     const userId: number = Number(
       (req as any).user?.id ?? (req.headers['x-user-id'] as string) ?? 0,
@@ -162,11 +408,49 @@ export class ClipsController {
     return this.clipsService.bulkUpdate(userId, dto);
   }
 
+  // ── POST /clips/bulk-delete ────────────────────────────────────────────────
+
   @Post('bulk-delete')
-  @ApiOperation({ summary: 'Bulk delete rejected clips' })
-  @ApiResponse({ status: 200, description: 'Clips deleted successfully' })
-  @ApiResponse({ status: 400, description: 'Invalid request data' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiOperation({
+    summary: 'Bulk delete clips',
+    description:
+      'Permanently deletes the specified clips and removes their assets from Cloudinary. ' +
+      'Only clips owned by the authenticated user may be deleted. ' +
+      'Returns count of deleted clips and any IDs that were not found.',
+  })
+  @ApiBody({
+    description: 'Array of clip IDs to delete',
+    schema: {
+      type: 'object',
+      required: ['clipIds'],
+      properties: {
+        clipIds: {
+          type: 'array',
+          items: { type: 'number' },
+          example: [104, 105],
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Deletion results',
+    schema: {
+      type: 'object',
+      properties: {
+        deletedCount: { type: 'number', example: 2 },
+        notFoundIds: { type: 'array', items: { type: 'number' }, example: [] },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'clipIds is missing or not an array',
+    schema: ErrorSchema('clipIds must be an array of numbers'),
+  })
+  @ApiForbiddenResponse({
+    description: 'Clip belongs to another user',
+    schema: ErrorSchema('You do not have permission to delete clip 104'),
+  })
   bulkDelete(@Body() dto: BulkDeleteClipsDto, @Req() req: Request) {
     const userId: number = Number(
       (req as any).user?.id ?? (req.headers['x-user-id'] as string) ?? 0,
@@ -174,19 +458,40 @@ export class ClipsController {
     return this.clipsService.bulkDeleteRejected(userId, dto.clipIds);
   }
 
+  // ── POST /clips/:id/regenerate ─────────────────────────────────────────────
+
   @Post(':id/regenerate')
   @UseGuards(QueueRateLimitGuard)
   @QueueRateLimit({ queue: 'clip-generation', maxJobs: 5 })
   @ApiOperation({
     summary: 'Regenerate a clip',
     description:
-      'Re-run FFmpeg cut for a single clip using original timestamps.',
+      'Re-queues an FFmpeg cut job for an existing clip using its original start/end timestamps. ' +
+      'Useful when the original generation failed or produced a poor result.',
   })
-  @ApiParam({ name: 'id', description: 'Clip ID' })
-  @ApiResponse({ status: 200, description: 'Clip regeneration started' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 404, description: 'Clip not found' })
-  @ApiResponse({ status: 429, description: 'Too many active jobs' })
+  @ApiParam({ name: 'id', description: 'Clip ID to regenerate', type: 'string', example: '101' })
+  @ApiResponse({
+    status: 200,
+    description: 'Regeneration job enqueued',
+    schema: {
+      type: 'object',
+      properties: {
+        jobId: { type: 'string', example: 'bfb23d4c-aaaa-bbbb-cccc-000111222333' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'Clip not found',
+    schema: ErrorSchema('Clip 101 not found'),
+  })
+  @ApiForbiddenResponse({
+    description: 'Clip belongs to another user',
+    schema: ErrorSchema('You do not have permission to regenerate this clip'),
+  })
+  @ApiTooManyRequestsResponse({
+    description: 'User has reached the clip-generation rate limit',
+    schema: ErrorSchema('Too many active clip-generation jobs'),
+  })
   regenerate(@Param('id') id: string, @Req() req: Request) {
     const userId: number = Number(
       (req as any).user?.id ?? (req.headers['x-user-id'] as string) ?? 0,
@@ -194,17 +499,56 @@ export class ClipsController {
     return this.clipsService.regenerate(userId, Number(id));
   }
 
+  // ── PATCH /clips/:id/caption ───────────────────────────────────────────────
+
   @Patch(':id/caption')
   @ApiOperation({
     summary: 'Update clip caption',
     description:
-      'Update the auto-generated caption for a clip. Useful for customizing social media posts.',
+      'Replaces the clip caption used when publishing to social platforms. ' +
+      'The caption is also stored in NFT metadata if the clip is later minted.',
   })
-  @ApiParam({ name: 'id', description: 'Clip ID' })
-  @ApiResponse({ status: 200, description: 'Caption updated' })
-  @ApiResponse({ status: 400, description: 'Invalid request' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 404, description: 'Clip not found' })
+  @ApiParam({ name: 'id', description: 'Clip ID', type: 'string', example: '101' })
+  @ApiBody({
+    description: 'New caption string',
+    schema: {
+      type: 'object',
+      required: ['caption'],
+      properties: {
+        caption: {
+          type: 'string',
+          example: 'This moment changed everything 🔥 #viral #trending',
+          description: 'Updated caption for social posting and NFT metadata',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Caption updated',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 101 },
+        caption: {
+          type: 'string',
+          example: 'This moment changed everything 🔥 #viral #trending',
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Caption is missing or not a string',
+    schema: ErrorSchema('caption is required and must be a string'),
+  })
+  @ApiNotFoundResponse({
+    description: 'Clip not found',
+    schema: ErrorSchema('Clip 101 not found'),
+  })
+  @ApiForbiddenResponse({
+    description: 'Clip belongs to another user',
+    schema: ErrorSchema('You do not have permission to update this clip'),
+  })
   async updateCaption(
     @Param('id') id: string,
     @Body('caption') caption: string,
@@ -219,21 +563,58 @@ export class ClipsController {
     return this.clipsService.updateCaption(Number(id), userId, caption);
   }
 
+  // ── PATCH /clips/:id/royalty ───────────────────────────────────────────────
+
   @Patch(':id/royalty')
   @ApiOperation({
     summary: 'Update clip NFT royalty BPS',
     description:
-      'Configure creator royalty (0–1500 BPS) for a clip before minting. Defaults to 1000 (10%) when omitted.',
+      'Sets the creator royalty (in Basis Points) that will be embedded in the Soroban NFT contract on mint. ' +
+      '1 BPS = 0.01%; allowed range 0–1500 (0–15%). ' +
+      'This field becomes immutable once minting starts or completes.',
   })
-  @ApiParam({ name: 'id', description: 'Clip ID' })
-  @ApiResponse({ status: 200, description: 'Royalty updated' })
+  @ApiParam({ name: 'id', description: 'Clip ID', type: 'string', example: '101' })
+  @ApiBody({
+    description: 'Royalty BPS value',
+    type: UpdateClipRoyaltyDto,
+    examples: {
+      ten_percent: {
+        summary: '10% royalty (default)',
+        value: { royaltyBps: 1000 },
+      },
+      five_percent: {
+        summary: '5% royalty',
+        value: { royaltyBps: 500 },
+      },
+      zero: {
+        summary: 'No royalty',
+        value: { royaltyBps: 0 },
+      },
+    },
+  })
   @ApiResponse({
-    status: 400,
-    description: 'Invalid royaltyBps (must be 0–1500)',
+    status: 200,
+    description: 'Royalty updated',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 101 },
+        royaltyBps: { type: 'number', example: 1000 },
+      },
+    },
   })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden' })
-  @ApiResponse({ status: 404, description: 'Clip not found' })
+  @ApiBadRequestResponse({
+    description: 'royaltyBps out of range (0–1500), or minting already started',
+    schema: ErrorSchema('Cannot change royalty after minting has started or completed'),
+  })
+  @ApiNotFoundResponse({
+    description: 'Clip not found',
+    schema: ErrorSchema('Clip 101 not found'),
+  })
+  @ApiForbiddenResponse({
+    description: 'Clip belongs to another user',
+    schema: ErrorSchema('You do not have permission to update this clip'),
+  })
   async updateRoyalty(
     @Param('id') id: string,
     @Body() dto: UpdateClipRoyaltyDto,

--- a/src/clips/nft-mint.service.spec.ts
+++ b/src/clips/nft-mint.service.spec.ts
@@ -399,6 +399,28 @@ describe('NftMintService.prepareMintTx', () => {
     await expect(service.prepareMintTx(5, VALID_WALLET)).rejects.toBeInstanceOf(BadRequestException);
   });
 
+  it('throws BadRequestException when clip postStatus is "posted"', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      ...baseClip,
+      postStatus: 'posted',
+      clipPosts: [],
+    });
+    await expect(service.prepareMintTx(5, VALID_WALLET)).rejects.toThrow(
+      'Posted clips cannot be minted.',
+    );
+  });
+
+  it('throws BadRequestException when clip has a published clipPost', async () => {
+    prismaMock.clip.findUnique.mockResolvedValue({
+      ...baseClip,
+      postStatus: null,
+      clipPosts: [{ status: 'published' }],
+    });
+    await expect(service.prepareMintTx(5, VALID_WALLET)).rejects.toThrow(
+      'Posted clips cannot be minted.',
+    );
+  });
+
   it('returns xdr and metadata when clip is ready', async () => {
     prismaMock.clip.findUnique.mockResolvedValue({ ...baseClip, metadataUri: 'ipfs://abc123' });
     prismaMock.clip.update.mockResolvedValue({});

--- a/src/stellar/stellar.service.spec.ts
+++ b/src/stellar/stellar.service.spec.ts
@@ -256,3 +256,63 @@ describe('StellarService', () => {
   });
 });
 
+
+describe('StellarService network configuration (STELLAR_NETWORK env var)', () => {
+  const originalEnv = process.env.STELLAR_NETWORK;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.STELLAR_NETWORK;
+    } else {
+      process.env.STELLAR_NETWORK = originalEnv;
+    }
+  });
+
+  async function buildService(network?: string): Promise<StellarService> {
+    if (network === undefined) {
+      delete process.env.STELLAR_NETWORK;
+    } else {
+      process.env.STELLAR_NETWORK = network;
+    }
+    const module = await Test.createTestingModule({
+      providers: [StellarService, CircuitBreakerService],
+    }).compile();
+    return module.get<StellarService>(StellarService);
+  }
+
+  it('defaults to testnet when STELLAR_NETWORK is not set', async () => {
+    const svc = await buildService(undefined);
+    expect(svc.network).toBe('testnet');
+    expect(svc.rpcUrl).toBe('https://soroban-testnet.stellar.org');
+    expect(svc.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    expect(svc.networkPassphrase).toBe('Test SDF Network ; September 2015');
+    expect(svc.isTestnet()).toBe(true);
+    expect(svc.isMainnet()).toBe(false);
+  });
+
+  it('configures testnet when STELLAR_NETWORK=testnet', async () => {
+    const svc = await buildService('testnet');
+    expect(svc.network).toBe('testnet');
+    expect(svc.rpcUrl).toBe('https://soroban-testnet.stellar.org');
+    expect(svc.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    expect(svc.networkPassphrase).toBe('Test SDF Network ; September 2015');
+    expect(svc.isTestnet()).toBe(true);
+    expect(svc.isMainnet()).toBe(false);
+  });
+
+  it('configures public (mainnet) when STELLAR_NETWORK=public', async () => {
+    const svc = await buildService('public');
+    expect(svc.network).toBe('public');
+    expect(svc.rpcUrl).toBe('https://soroban-rpc.stellar.org');
+    expect(svc.horizonUrl).toBe('https://horizon.stellar.org');
+    expect(svc.networkPassphrase).toBe('Public Global Stellar Network ; September 2015');
+    expect(svc.isTestnet()).toBe(false);
+    expect(svc.isMainnet()).toBe(true);
+  });
+
+  it('falls back to testnet for unrecognised STELLAR_NETWORK values', async () => {
+    const svc = await buildService('unknown-network');
+    expect(svc.network).toBe('testnet');
+    expect(svc.isTestnet()).toBe(true);
+  });
+});

--- a/src/wallets/wallet-management.service.spec.ts
+++ b/src/wallets/wallet-management.service.spec.ts
@@ -16,6 +16,7 @@ jest.mock('../prisma/prisma.service', () => ({
 const mockPrisma = {
   wallet: {
     findUnique: jest.fn(),
+    findMany: jest.fn(),
     update: jest.fn(),
     upsert: jest.fn(),
   },
@@ -242,5 +243,116 @@ describe('WalletManagementService.connect', () => {
 
     expect(result.address).not.toBe(fullAddress);
     expect(result.address).toContain('****');
+  });
+});
+
+describe('WalletManagementService.listWallets', () => {
+  let service: WalletManagementService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockWalletValidationService.validateAddressForChain.mockImplementation(() => undefined);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WalletManagementService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: WalletValidationService, useValue: mockWalletValidationService },
+      ],
+    }).compile();
+    service = module.get<WalletManagementService>(WalletManagementService);
+  });
+
+  it('returns all active wallets for the user with masked addresses', async () => {
+    const fullAddress1 = 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3';
+    const fullAddress2 = 'GABCDE12345FGHIJ67890KLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKL';
+    mockPrisma.wallet.findMany.mockResolvedValue([
+      { id: 1, userId: 42, address: fullAddress1, chain: 'stellar', type: 'freighter', deletedAt: null, connectedAt: new Date(), updatedAt: new Date() },
+      { id: 2, userId: 42, address: fullAddress2, chain: 'stellar', type: 'lobstr', deletedAt: null, connectedAt: new Date(), updatedAt: new Date() },
+    ]);
+
+    const result = await service.listWallets(42);
+
+    expect(mockPrisma.wallet.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 42, deletedAt: null } }),
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].address).not.toBe(fullAddress1);
+    expect(result[0].address).toContain('****');
+    expect(result[1].address).not.toBe(fullAddress2);
+    expect(result[1].address).toContain('****');
+  });
+
+  it('returns empty array when user has no wallets', async () => {
+    mockPrisma.wallet.findMany.mockResolvedValue([]);
+    const result = await service.listWallets(42);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('WalletManagementService.findWallet', () => {
+  let service: WalletManagementService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockWalletValidationService.validateAddressForChain.mockImplementation(() => undefined);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WalletManagementService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: WalletValidationService, useValue: mockWalletValidationService },
+      ],
+    }).compile();
+    service = module.get<WalletManagementService>(WalletManagementService);
+  });
+
+  it('returns wallet with masked address when found', async () => {
+    const fullAddress = 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3';
+    mockPrisma.wallet.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 42,
+      address: fullAddress,
+      chain: 'stellar',
+      type: 'freighter',
+      deletedAt: null,
+    });
+
+    const result = await service.findWallet(1, 42);
+
+    expect(result.id).toBe(1);
+    expect(result.address).not.toBe(fullAddress);
+    expect(result.address).toContain('****');
+    // First 4 chars preserved
+    expect(result.address.startsWith('GC6X')).toBe(true);
+    // Last 6 chars preserved
+    expect(result.address.endsWith('UHTZF3')).toBe(true);
+  });
+
+  it('throws NotFoundException when wallet does not exist', async () => {
+    mockPrisma.wallet.findUnique.mockResolvedValue(null);
+    await expect(service.findWallet(99, 42)).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws NotFoundException when wallet belongs to another user', async () => {
+    mockPrisma.wallet.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 99,
+      address: 'GABC',
+      chain: 'stellar',
+      type: 'freighter',
+      deletedAt: null,
+    });
+    await expect(service.findWallet(1, 42)).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws NotFoundException when wallet is soft-deleted', async () => {
+    mockPrisma.wallet.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 42,
+      address: 'GABC',
+      chain: 'stellar',
+      type: 'freighter',
+      deletedAt: new Date(),
+    });
+    await expect(service.findWallet(1, 42)).rejects.toThrow(NotFoundException);
   });
 });

--- a/src/wallets/wallet-management.service.ts
+++ b/src/wallets/wallet-management.service.ts
@@ -120,4 +120,31 @@ export class WalletManagementService {
 
     return this.maskWallet(wallet);
   }
+
+  /**
+   * List all active (non-deleted) wallets for a user with masked addresses.
+   */
+  async listWallets(userId: number): Promise<any[]> {
+    const wallets = await this.prisma.wallet.findMany({
+      where: { userId, deletedAt: null },
+      orderBy: { connectedAt: 'desc' },
+    });
+    return wallets.map((w) => this.maskWallet(w));
+  }
+
+  /**
+   * Get a single wallet by ID for a user with masked address.
+   * Throws NotFoundException if not found or owned by another user.
+   */
+  async findWallet(walletId: number, userId: number): Promise<any> {
+    const wallet = await this.prisma.wallet.findUnique({
+      where: { id: walletId },
+    });
+
+    if (!wallet || wallet.userId !== userId || wallet.deletedAt !== null) {
+      throw new NotFoundException(`Wallet ${walletId} not found`);
+    }
+
+    return this.maskWallet(wallet);
+  }
 }

--- a/src/wallets/wallets.controller.ts
+++ b/src/wallets/wallets.controller.ts
@@ -46,6 +46,80 @@ export class WalletsController {
     private readonly walletBalanceService: WalletBalanceService,
   ) {}
 
+  @Get()
+  @ApiOperation({
+    summary: 'List wallets',
+    description:
+      'Returns all active (non-deleted) wallets for the authenticated user. Wallet addresses are partially masked for security (e.g., GABF********KJ93XD).',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of wallets retrieved successfully',
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', example: 1 },
+          userId: { type: 'number', example: 42 },
+          address: {
+            type: 'string',
+            example: 'GABF********KJ93XD',
+            description: 'Masked wallet address',
+          },
+          chain: { type: 'string', example: 'stellar' },
+          type: { type: 'string', example: 'freighter' },
+          connectedAt: { type: 'string', format: 'date-time' },
+          updatedAt: { type: 'string', format: 'date-time' },
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @HttpCode(HttpStatus.OK)
+  async list(@Req() req: AuthRequest) {
+    return this.walletsService.listWallets(req.user.userId);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get wallet by ID',
+    description:
+      'Returns a single wallet by ID for the authenticated user. Wallet address is partially masked.',
+  })
+  @ApiParam({ name: 'id', description: 'Wallet ID', type: 'number' })
+  @ApiResponse({
+    status: 200,
+    description: 'Wallet retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 1 },
+        userId: { type: 'number', example: 42 },
+        address: {
+          type: 'string',
+          example: 'GABF********KJ93XD',
+          description: 'Masked wallet address',
+        },
+        chain: { type: 'string', example: 'stellar' },
+        type: { type: 'string', example: 'freighter' },
+        connectedAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'Wallet not found or belongs to another user',
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @HttpCode(HttpStatus.OK)
+  async findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthRequest,
+  ) {
+    return this.walletsService.findWallet(id, req.user.userId);
+  }
+
   @Get(':id/balance')
   @Throttle({ default: { limit: 30, ttl: 60000 } })
   @UseGuards(WalletOwnershipGuard)

--- a/src/wallets/wallets.service.spec.ts
+++ b/src/wallets/wallets.service.spec.ts
@@ -5,6 +5,8 @@ import { WalletManagementService } from './wallet-management.service';
 const mockWalletManagementService = {
   disconnect: jest.fn(),
   connect: jest.fn(),
+  listWallets: jest.fn(),
+  findWallet: jest.fn(),
 };
 
 describe('WalletsService', () => {
@@ -46,5 +48,36 @@ describe('WalletsService', () => {
 
     expect(mockWalletManagementService.connect).toHaveBeenCalledWith(42, dto);
     expect(result.id).toBe(1);
+  });
+
+  it('delegates listWallets to WalletManagementService with masked addresses', async () => {
+    const maskedWallets = [
+      { id: 1, userId: 42, address: 'GC6X********TF3', chain: 'stellar', type: 'freighter' },
+      { id: 2, userId: 42, address: 'GABC********XYZ', chain: 'stellar', type: 'lobstr' },
+    ];
+    mockWalletManagementService.listWallets.mockResolvedValue(maskedWallets);
+
+    const result = await service.listWallets(42);
+
+    expect(mockWalletManagementService.listWallets).toHaveBeenCalledWith(42);
+    expect(result).toEqual(maskedWallets);
+    expect(result).toHaveLength(2);
+  });
+
+  it('delegates findWallet to WalletManagementService with masked address', async () => {
+    const maskedWallet = {
+      id: 1,
+      userId: 42,
+      address: 'GC6X********TF3',
+      chain: 'stellar',
+      type: 'freighter',
+    };
+    mockWalletManagementService.findWallet.mockResolvedValue(maskedWallet);
+
+    const result = await service.findWallet(1, 42);
+
+    expect(mockWalletManagementService.findWallet).toHaveBeenCalledWith(1, 42);
+    expect(result).toEqual(maskedWallet);
+    expect(result.address).toContain('****');
   });
 });

--- a/src/wallets/wallets.service.ts
+++ b/src/wallets/wallets.service.ts
@@ -20,4 +20,12 @@ export class WalletsService {
   connect(userId: number, dto: ConnectWalletDto) {
     return this.walletManagementService.connect(userId, dto);
   }
+
+  listWallets(userId: number) {
+    return this.walletManagementService.listWallets(userId);
+  }
+
+  findWallet(walletId: number, userId: number) {
+    return this.walletManagementService.findWallet(walletId, userId);
+  }
 }

--- a/test/testers/PR_DESCRIPTION.md
+++ b/test/testers/PR_DESCRIPTION.md
@@ -1,0 +1,110 @@
+# Pull Request: Username Leaf Circuit - Standalone Testing
+
+## Summary
+Implements comprehensive standalone testing for the `username_leaf.circom` component, ensuring it can be independently verified as the bridge between raw username arrays and Poseidon-hashed Merkle leaves.
+
+## Issue Addressed
+Closes #68: [ZK] Username Leaf Circuit — extract and test username_leaf.circom as standalone component
+
+## Changes Made
+
+### ✅ New Components
+- **`username_leaf_main.circom`** - Standalone circuit with main component for independent compilation
+- **`username_leaf_test.ts`** - Comprehensive TypeScript test suite with multiple test cases
+- **`input.json`** - Test input for "amar" username in correct 32-byte zero-padded format
+- **`username_encoding.md`** - Complete documentation of username encoding specification
+
+### 🔧 Infrastructure Updates
+- **`package.json`** - Added `compile:username_leaf` and `test:username_leaf` scripts
+- **`compile.sh`** - Integrated username_leaf_main into build process
+- **`zk_circuits.yml`** - Updated CI workflow to verify new circuit compilation
+
+### 📚 Documentation
+- **`README_username_leaf.md`** - Usage guide and troubleshooting documentation
+- **`IMPLEMENTATION_SUMMARY.md`** - Complete implementation overview
+- **`verify_implementation.js`** - Pre-flight verification script
+
+## Verification
+
+### Test Results Expected
+For username "amar":
+```
+Input:  [97, 109, 97, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+Output: 20874380368079837438632997674874984863391487284332644052898098881644791571788
+```
+
+### Test Cases Covered
+- "amar" - Primary test case from requirements
+- "test" - Different character set
+- "user123" - Alphanumeric validation
+- "alice" - Common username pattern
+- "" (empty) - Edge case handling
+
+## Acceptance Criteria Met
+
+- [x] `username_leaf.circom` compiles standalone with circom 2.x
+- [x] Witness generated for "amar" input matches expected leaf hash
+- [x] TypeScript-side Poseidon matches circuit output exactly
+- [x] ZK CI workflow updated and passes
+- [x] Username encoding format documented (32-byte zero-padded array)
+
+## Usage
+
+```bash
+# Compile the standalone circuit
+npm run compile:username_leaf
+
+# Run the comprehensive test suite
+npm run test:username_leaf
+
+# Verify implementation completeness
+node verify_implementation.js
+```
+
+## Security Benefits
+
+- **Independent Verification**: Username hashing can be tested without full Merkle tree context
+- **Encoding Validation**: Ensures consistent 32-byte zero-padded format across implementations
+- **Hash Consistency**: TypeScript and circuit implementations produce identical results
+- **Regression Prevention**: Standalone tests catch changes to username processing logic
+
+## Integration Points
+
+This enhancement strengthens the Alien Gateway ZK infrastructure by:
+- Providing isolated testing of username → leaf conversion
+- Ensuring Merkle proof integrity through verified leaf generation
+- Documenting and standardizing username encoding format
+- Adding comprehensive test coverage for critical component
+
+## Files Changed
+
+### New Files (7)
+- `zk/circuits/merkle/username_leaf_main.circom`
+- `zk/input.json`
+- `zk/tests/username_leaf_test.ts`
+- `zk/docs/username_encoding.md`
+- `zk/tests/README_username_leaf.md`
+- `zk/IMPLEMENTATION_SUMMARY.md`
+- `zk/verify_implementation.js`
+
+### Modified Files (3)
+- `zk/package.json`
+- `zk/scripts/compile.sh`
+- `.github/workflows/zk_circuits.yml`
+
+## Testing
+
+The implementation includes comprehensive testing that verifies:
+1. Circuit compilation succeeds independently
+2. Witness generation produces correct leaf hash
+3. TypeScript Poseidon computation matches circuit exactly
+4. Multiple username variations produce expected results
+5. Encoding format consistency across test cases
+
+## Impact
+
+This implementation provides:
+- **Reliability**: Independent verification prevents silent failures
+- **Maintainability**: Clear separation of concerns for username processing
+- **Security**: Validated encoding prevents format-based vulnerabilities
+- **Developer Experience**: Well-documented, easily testable component

--- a/test/testers/README.md
+++ b/test/testers/README.md
@@ -1,0 +1,69 @@
+
+# 🌉 Alien Gateway
+
+[![Smart Contracts CI](https://github.com/Alien-Protocol/Alien-Gateway/actions/workflows/build_test.yml/badge.svg)](https://github.com/Alien-Protocol/Alien-Gateway/actions/workflows/build_test.yml)
+[![Checks](https://github.com/Alien-Protocol/Alien-Gateway/actions/workflows/checks.yml/badge.svg)](https://github.com/Alien-Protocol/Alien-Gateway/actions/workflows/checks.yml)
+[![ZK Circuits CI](https://github.com/Alien-Protocol/Alien-Gateway/actions/workflows/zk_circuits.yml/badge.svg)](https://github.com/Alien-Protocol/Alien-Gateway/actions/workflows/zk_circuits.yml)
+
+<p align="center">
+  <img 
+    src="alien_protocol_optiz.gif" 
+    alt="Alien Protocol"
+    width="100%"
+    style="max-width:900px; border-radius:20px; box-shadow:0 0 40px rgba(0,255,170,.35);"
+  />
+</p>
+
+> Send crypto to `@username` instead of a long wallet address — built for Stellar.
+
+Alien Gateway is a **privacy-preserving username system for the Stellar network**.  
+It allows users to send and receive payments using **human-readable identities** like `@username` instead of long Stellar wallet addresses.
+
+Unlike traditional naming systems, usernames are **never stored on-chain in plaintext**.  
+They are stored as **zero-knowledge commitments**, protecting user identity and wallet associations.
+
+---
+
+## ✨ Features
+
+- Send payments using `@username`
+- Human-readable Stellar identities
+- Privacy-preserving wallet linking
+- Optional private payment routing
+- Developer-friendly SDK for integration
+
+---
+
+## 🧠 How It Works
+
+1. User registers a `@username`
+2. Username is stored as a **ZK commitment**
+3. The system verifies uniqueness using **zero-knowledge proofs**
+4. The username resolves to a linked **Stellar wallet**
+5. Payments can be sent directly using `@username`
+
+---
+
+## ⚙️ Tech Stack
+
+- **Smart Contracts:** Rust + Soroban  
+- **ZK Circuits:** Circom  
+- **Proof System:** Groth16  
+- **Hash Function:** Poseidon  
+- **SDK:** TypeScript  
+
+---
+
+## 🚀 Vision
+
+**One username. One identity. Built for Stellar.**
+
+Alien Gateway aims to become the **identity and payment resolution layer for the Stellar ecosystem**.
+
+## 🌐 Connect with us
+
+<p align="center">
+  <a href="https://t.me/alien_protocol_xyz">
+    <img src="https://img.shields.io/badge/Telegram-Join%20Alien%20Protocol-2CA5E0?logo=telegram&logoColor=white&style=for-the-badge"/>
+  </a>
+</p>

--- a/test/testers/SECURITY.md
+++ b/test/testers/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Alien Gateway, please **do not open a public GitHub issue**.
+
+Report it privately via one of the following channels:
+
+- **GitHub Security Advisories**: [Report a vulnerability](https://github.com/Alien-Protocol/Alien-Gateway/security/advisories/new)
+- **Email**: security@alien-protocol.io *(replace with actual contact before publishing)*
+
+Please include:
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Affected component (circuit, contract, or off-chain tooling)
+
+We aim to acknowledge reports within **48 hours** and provide a resolution timeline within **7 days**.
+
+## Scope
+
+In scope:
+- ZK circuits (`zk/circuits/`)
+- Soroban smart contracts (`gateway-contract/contracts/`)
+- Trusted setup artifacts and verification keys
+
+Out of scope:
+- Third-party dependencies (circomlib, soroban-sdk) — report upstream
+- Issues requiring physical access or social engineering
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Please allow us reasonable time to patch before public disclosure. We will credit researchers in release notes unless anonymity is requested.
+
+## Known Limitations (Pre-Audit)
+
+See [`docs/threat-model.md`](docs/threat-model.md) for the current threat model and known findings being addressed before the audit handoff.

--- a/test/testers/package-lock.json
+++ b/test/testers/package-lock.json
@@ -1,0 +1,1630 @@
+{
+  "name": "Alien-Gateway",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@commitlint/cli": "^20.4.4",
+        "@commitlint/config-conventional": "^20.4.4",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.3.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.4.tgz",
+      "integrity": "sha512-GLMNQHYGcn0ohL2HMlAnXcD1PS2vqBBGbYKlhrRPOYsWiRoLWtrewsR3uKRb9v/IdS+qOS0vqJQ64n1g8VPKFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^20.4.4",
+        "@commitlint/lint": "^20.4.4",
+        "@commitlint/load": "^20.4.4",
+        "@commitlint/read": "^20.4.4",
+        "@commitlint/types": "^20.4.4",
+        "tinyexec": "^1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.4.tgz",
+      "integrity": "sha512-Usg+XXbPNG2GtFWTgRURNWCge1iH1y6jQIvvklOdAbyn2t8ajfVwZCnf5t5X4gUsy17BOiY+myszGsSMIvhOVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.4.4",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.4.tgz",
+      "integrity": "sha512-K8hMS9PTLl7EYe5vWtSFQ/sgsV2PHUOtEnosg8k3ZQxCyfKD34I4C7FxWEfRTR54rFKeUYmM3pmRQqBNQeLdlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.4.4",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.4.tgz",
+      "integrity": "sha512-QivV0M1MGL867XCaF+jJkbVXEPKBALhUUXdjae66hes95aY1p3vBJdrcl3x8jDv2pdKWvIYIz+7DFRV/v0dRkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.4.4",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
+      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.4.tgz",
+      "integrity": "sha512-jLi/JBA4GEQxc5135VYCnkShcm1/rarbXMn2Tlt3Si7DHiiNKHm4TaiJCLnGbZ1r8UfwDRk+qrzZ80kwh08Aow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.4.4",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.4.tgz",
+      "integrity": "sha512-y76rT8yq02x+pMDBI2vY4y/ByAwmJTkta/pASbgo8tldBiKLduX8/2NCRTSCjb3SumE5FBeopERKx3oMIm8RTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.4.4",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.4.tgz",
+      "integrity": "sha512-svOEW+RptcNpXKE7UllcAsV0HDIdOck9reC2TP1QA6K5Fo0xxQV+QPjV8Zqx9g6X/hQBkF2S9ZQZ78Xrv1Eiog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^20.4.4",
+        "@commitlint/parse": "^20.4.4",
+        "@commitlint/rules": "^20.4.4",
+        "@commitlint/types": "^20.4.4"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.4.tgz",
+      "integrity": "sha512-kvFrzvoIACa/fMjXEP0LNEJB1joaH3q3oeMJsLajXE5IXjYrNGVcW1ZFojXUruVJ7odTZbC3LdE/6+ONW4f2Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.4.4",
+        "@commitlint/execute-rule": "^20.0.0",
+        "@commitlint/resolve-extends": "^20.4.4",
+        "@commitlint/types": "^20.4.4",
+        "cosmiconfig": "^9.0.1",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "is-plain-obj": "^4.1.0",
+        "lodash.mergewith": "^4.6.2",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "20.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
+      "integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.4.tgz",
+      "integrity": "sha512-AjfgOgrjEozeQNzhFu1KL5N0nDx4JZmswVJKNfOTLTUGp6xODhZHCHqb//QUHKOzx36If5DQ7tci2o7szYxu1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.4.4",
+        "conventional-changelog-angular": "^8.2.0",
+        "conventional-commits-parser": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.4.tgz",
+      "integrity": "sha512-jvgdAQDdEY6L8kCxOo21IWoiAyNFzvrZb121wU2eBxI1DzWAUZgAq+a8LlJRbT0Qsj9INhIPVWgdaBbEzlF0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^20.4.3",
+        "@commitlint/types": "^20.4.4",
+        "git-raw-commits": "^5.0.0",
+        "minimist": "^1.2.8",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.4.tgz",
+      "integrity": "sha512-pyOf+yX3c3m/IWAn2Jop+7s0YGKPQ8YvQaxt9IQxnLIM3yZAlBdkKiQCT14TnrmZTkVGTXiLtckcnFTXYwlY0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.4.4",
+        "@commitlint/types": "^20.4.4",
+        "global-directory": "^4.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.4.tgz",
+      "integrity": "sha512-PmUp8QPLICn9w05dAx5r1rdOYoTk7SkfusJJh5tP3TqHwo2mlQ9jsOm8F0HSXU9kuLfgTEGNrunAx/dlK/RyPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^20.4.4",
+        "@commitlint/message": "^20.4.3",
+        "@commitlint/to-lines": "^20.0.0",
+        "@commitlint/types": "^20.4.4"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
+      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "20.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
+      "integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.4.tgz",
+      "integrity": "sha512-dwTGzyAblFXHJNBOgrTuO5Ee48ioXpS5XPRLLatxhQu149DFAHUcB3f0Q5eea3RM4USSsP1+WVT2dBtLVod4fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-parser": "^6.3.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.6.0.tgz",
+      "integrity": "sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.3.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
+      "integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.0.tgz",
+      "integrity": "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
+      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
+      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lint-staged": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.3.tgz",
+      "integrity": "sha512-RLq2koZ5fGWrx7tcqx2tSTMQj4lRkfNJaebO/li/uunhCJbtZqwTuwPHpgIimAHHi/2nZIiGrkCHDCOeR1onxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.2",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/test/testers/package.json
+++ b/test/testers/package.json
@@ -1,0 +1,12 @@
+{
+  "devDependencies": {
+    "@commitlint/cli": "^20.4.4",
+    "@commitlint/config-conventional": "^20.4.4",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.3.3"
+  },
+  "scripts": {
+    "prepare": "husky",
+    "test:poseidon": "mocha tests/poseidon.test.js"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #548, closes #549, closes #550, closes #555

---

### #548 — [Security] Mask Wallet Addresses
- Added `GET /wallets` — lists all active wallets for the authenticated user; addresses are partially masked (e.g. `GABF********KJ93XD`)
- Added `GET /wallets/:id` — returns a single wallet by ID with masked address
- Implemented `listWallets(userId)` and `findWallet(walletId, userId)` in `WalletManagementService` and `WalletsService`
- Full address is never exposed in API responses; full value is preserved internally in the database
- Added unit tests covering masking, empty list, `NotFoundException` for missing/other-user/deleted wallets

### #549 — [NFT] Prevent Minting Posted Clips
- The guard was already implemented in `NftMintService.prepareMintTx`
- Added missing unit tests:
  - Rejects when `clip.postStatus === 'posted'`
  - Rejects when any `clipPost.status === 'published'`

### #550 — [Web3] Configure Stellar Network
- `STELLAR_NETWORK` env var was already wired into `StellarService`
- Added spec tests verifying:
  - `STELLAR_NETWORK=testnet` → testnet RPC/Horizon URLs + correct passphrase
  - `STELLAR_NETWORK=public` → mainnet RPC/Horizon URLs + correct passphrase
  - Unrecognised values fall back to `testnet`
  - `isTestnet()` / `isMainnet()` helpers return correct booleans

### #555 — [Swagger] Document Clip Management APIs
- Replaced sparse Swagger annotations with full documentation on every endpoint:
  - `POST /clips/generate` — request body schema with all fields + examples
  - `GET /clips` — paginated response schema, all query params documented
  - `GET /clips/:id` — full clip schema response
  - `POST /clips/bulk-update` — request/response schemas + error responses
  - `POST /clips/bulk-delete` — request/response schemas + error responses
  - `POST /clips/:id/regenerate` — response + rate-limit error
  - `PATCH /clips/:id/caption` — request/response schemas
  - `PATCH /clips/:id/royalty` — request examples (0%, 5%, 10%) + error responses
- Every endpoint now has: description, request DTO, response DTO, example payloads, and error responses (400/401/403/404/429)

## Tests

All 4 affected test files pass (80 tests total):
- `wallets.service.spec.ts` ✅
- `wallet-management.service.spec.ts` ✅
- `nft-mint.service.spec.ts` ✅
- `stellar.service.spec.ts` ✅