### PR TITLE
[Security] Rate limiting, headers, and audit logging hardening

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,8 @@
 import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_GUARD, APP_FILTER } from '@nestjs/core';
+import { SecurityAuditFilter } from './common/filters/security-audit.filter';
 import { ThrottlerRedisModule } from './common/throttler/throttler-redis.module';
 import { ThrottlerStorageRedisService } from './common/throttler/throttler-storage-redis.service';
 import { AppController } from './app.controller';
@@ -60,6 +61,13 @@ import { GracefulShutdownModule } from './common/shutdown/graceful-shutdown.modu
             name: 'auth',
             ttl: 60000,
             limit: 10,
+          },
+          // Stricter tier for high-value auth actions (login, signup, refresh,
+          // password reset, OTP verification) per security hardening requirements.
+          {
+            name: 'authStrict',
+            ttl: 60000,
+            limit: 5,
           },
           {
             name: 'sensitive',
@@ -136,6 +144,10 @@ import { GracefulShutdownModule } from './common/shutdown/graceful-shutdown.modu
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: SecurityAuditFilter,
     },
   ],
 })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -73,7 +73,7 @@ export class AuthController {
     required: false,
     description: 'Return tokens in cookies instead of body',
   })
-  @Throttle({ auth: { limit: 10, ttl: 60000 } })
+  @Throttle({ auth: { limit: 10, ttl: 60000 }, authStrict: { limit: 5, ttl: 60000 } })
   async signup(
     @Body(new ValidationPipe({ transform: true })) signupDto: SignupDto,
     @Res({ passthrough: true }) res: Response,
@@ -114,7 +114,7 @@ export class AuthController {
     description: 'Return tokens in cookies instead of body',
   })
   @UseGuards(BruteForceGuard)
-  @Throttle({ auth: { limit: 10, ttl: 60000 } })
+  @Throttle({ auth: { limit: 10, ttl: 60000 }, authStrict: { limit: 5, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   async login(
     @Body(new ValidationPipe({ transform: true })) dto: LoginDto,
@@ -276,11 +276,13 @@ export class AuthController {
   })
   @ApiResponse({ status: 400, description: 'Invalid or expired refresh token' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
   @ApiQuery({
     name: 'use_cookies',
     required: false,
     description: 'Return tokens in cookies instead of body',
   })
+  @Throttle({ authStrict: { limit: 5, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   async refresh(
     @Body(new ValidationPipe({ transform: true })) dto: RefreshTokenDto,
@@ -339,7 +341,7 @@ export class AuthController {
   @ApiResponse({ status: 400, description: 'Invalid email format' })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   @HttpCode(HttpStatus.OK)
-  @Throttle({ sensitive: { limit: 3, ttl: 900000 } })
+  @Throttle({ sensitive: { limit: 3, ttl: 900000 }, authStrict: { limit: 5, ttl: 60000 } })
   async forgotPassword(
     @Body(new ValidationPipe({ transform: true })) dto: ForgotPasswordDto,
   ) {
@@ -362,7 +364,9 @@ export class AuthController {
     status: 400,
     description: 'Invalid token or password requirements not met',
   })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
   @HttpCode(HttpStatus.OK)
+  @Throttle({ authStrict: { limit: 5, ttl: 60000 } })
   async resetPassword(
     @Body(new ValidationPipe({ transform: true })) dto: ResetPasswordDto,
   ) {
@@ -402,7 +406,9 @@ export class AuthController {
   })
   @ApiResponse({ status: 400, description: 'Invalid verification code' })
   @ApiResponse({ status: 401, description: 'Unauthorized — Bearer JWT required' })
+  @ApiResponse({ status: 429, description: 'Too many requests' })
   @HttpCode(HttpStatus.OK)
+  @Throttle({ authStrict: { limit: 5, ttl: 60000 } })
   async enableMfa(@Req() req: any, @Body('code') code: string) {
     const userId = Number(req.user?.id ?? req.headers['x-user-id']);
     await this.authService.enableMfa(userId, code);

--- a/src/common/filters/security-audit.filter.ts
+++ b/src/common/filters/security-audit.filter.ts
@@ -1,0 +1,56 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
+import { AppLoggerService } from '../../logger/logger.service';
+
+const SECURITY_EVENTS: Record<number, string> = {
+  401: 'AUTH_FAILURE',
+  403: 'PERMISSION_DENIED',
+  429: 'RATE_LIMIT_EXCEEDED',
+};
+
+/**
+ * Logs security-relevant HTTP exceptions (auth failures, permission denials,
+ * rate-limit violations, account lockouts) for auditing, then forwards the
+ * original response unchanged. Never logs request bodies/headers, so
+ * credentials and tokens can't leak into logs.
+ */
+@Catch(HttpException)
+export class SecurityAuditFilter implements ExceptionFilter {
+  constructor(private readonly logger: AppLoggerService) {}
+
+  catch(exception: HttpException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+    const status = exception.getStatus();
+
+    const exceptionResponse = exception.getResponse();
+    const errorCode =
+      typeof exceptionResponse === 'object' && exceptionResponse !== null
+        ? (exceptionResponse as Record<string, unknown>).error
+        : undefined;
+
+    const event =
+      errorCode === 'ACCOUNT_LOCKED'
+        ? 'ACCOUNT_LOCKOUT'
+        : SECURITY_EVENTS[status];
+
+    if (event) {
+      this.logger.warn(`Security event: ${event}`, {
+        context: 'SecurityAudit',
+        event,
+        statusCode: status,
+        method: request.method,
+        path: request.originalUrl ?? request.url,
+        ip: request.ip,
+        requestId: request.id,
+      });
+    }
+
+    response.status(status).json(exceptionResponse);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -177,6 +177,10 @@ async function bootstrap() {
     credentials: true, // required for cross-origin cookie support
   });
 
+  // Redundant with helmet's hidePoweredBy(), but explicit about disabling
+  // Express defaults that leak framework identity.
+  app.getHttpAdapter().getInstance().disable('x-powered-by');
+
   // Parse cookies (required for httpOnly cookie-based JWT support)
   app.use(cookieParser());
 
@@ -214,6 +218,15 @@ async function bootstrap() {
       },
     }),
   );
+
+  // API responses may contain user-specific or sensitive data — prevent
+  // shared/browser caches from storing them. Swagger UI is left cacheable.
+  app.use((req, res, next) => {
+    if (!req.path.startsWith('/api/docs')) {
+      res.set('Cache-Control', 'no-store');
+    }
+    next();
+  });
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
## Summary
- Adds a stricter `authStrict` (5 req/min per IP) throttle tier applied to login, signup, refresh, forgot-password, reset-password, and OTP verification (mfa/enable), on top of the existing global/auth throttling — documents `429` responses for these routes in Swagger.
- Adds `SecurityAuditFilter`, a global exception filter that logs auth failures (401), permission-denied (403), rate-limit violations and account lockouts (429) via the existing structured `AppLoggerService`, without ever logging credentials/tokens (redaction already built into the logger).
- Hardens HTTP responses: explicitly disables Express's `x-powered-by` (in addition to helmet's `hidePoweredBy`), and sets `Cache-Control: no-store` on API responses (Swagger UI excluded) to avoid caching sensitive data.
- Global rate limiting (`@nestjs/throttler`, 100 req/min default, IP whitelist via `THROTTLER_WHITELIST`, `429` handling, rate-limit headers) was already in place from prior work and verified as satisfying the acceptance criteria.

Closes #600
Closes #601
Closes #602
Closes #603

## Test plan
- [ ] `npm run build`
- [ ] `npm run lint`
- [ ] Manual: hit `/auth/login` >5x/min and confirm `429` + audit log line
- [ ] Manual: confirm `X-Powered-By` header absent and `Cache-Control: no-store` present on API responses
- [ ] Manual: confirm Swagger UI at `/api/docs` still loads