### PR TITLE
docs(swagger): document password strength, magic link, OAuth, and security headers

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -65,7 +65,10 @@ export class AuthController {
   })
   @ApiResponse({
     status: 400,
-    description: 'Invalid input or user already exists',
+    description:
+      'Invalid input, weak password, or user already exists. Password validation errors ' +
+      'return a JSON-encoded message, e.g. ' +
+      '`{"score":1,"feedback":["Add numbers"],"suggestions":"Password is too weak. Add numbers"}`.',
   })
   @ApiResponse({ status: 429, description: 'Too many requests' })
   @ApiQuery({
@@ -140,9 +143,12 @@ export class AuthController {
   @Get('google')
   @ApiOperation({
     summary: 'Initiate Google OAuth flow',
-    description: 'Redirects to Google for authentication',
+    description:
+      'Redirects the browser to Google\'s consent screen requesting the `profile` and ' +
+      '`email` scopes. On approval, Google redirects back to `GET /auth/google/callback`. ' +
+      'This endpoint is meant to be opened directly in a browser, not called via AJAX/fetch.',
   })
-  @ApiResponse({ status: 302, description: 'Redirects to Google OAuth' })
+  @ApiResponse({ status: 302, description: 'Redirects to Google OAuth consent screen' })
   @UseGuards(AuthGuard('google'))
   googleAuth() {
     return;
@@ -151,14 +157,22 @@ export class AuthController {
   @Get('google/callback')
   @ApiOperation({
     summary: 'Google OAuth callback',
-    description: 'Handles Google OAuth redirect',
+    description:
+      'Google redirects here after the user approves or denies access ' +
+      '(configured via the `GOOGLE_CALLBACK_URL` env var, default ' +
+      '`http://localhost:3000/auth/google/callback`). On success, finds or creates a user ' +
+      'from the Google profile, issues access/refresh tokens, and always sets them as ' +
+      'httpOnly cookies (this redirect-based flow has no JS context to read a JSON body). ' +
+      'A CSRF token is returned in the response body and also set as a cookie. Use the ' +
+      'returned `accessToken` as a `Bearer` token on subsequent authenticated requests ' +
+      '(`Authorization: Bearer <accessToken>`).',
   })
   @ApiResponse({
     status: 200,
-    description: 'Authentication successful',
+    description: 'Authentication successful — sets token cookies and returns the user + csrfToken',
     type: AuthSuccessResponseDto,
   })
-  @ApiResponse({ status: 401, description: 'Authentication failed' })
+  @ApiResponse({ status: 401, description: 'Google authentication failed or was denied' })
   @UseGuards(AuthGuard('google'))
   async googleCallback(
     @Req() req: any,
@@ -185,7 +199,13 @@ export class AuthController {
   }
 
   @Post('magic-link')
-  @ApiOperation({ summary: 'Request magic link for passwordless login' })
+  @ApiOperation({
+    summary: 'Request magic link for passwordless login',
+    description:
+      'Sends a one-time login link to the given email if an account exists. ' +
+      'The link token expires 15 minutes after issuance and can only be used once. ' +
+      'Always responds with 200 (even for unknown emails) to prevent email enumeration.',
+  })
   @ApiBody({ type: MagicLinkRequestDto })
   @ApiResponse({
     status: 200,
@@ -205,14 +225,27 @@ export class AuthController {
   @Get('verify-magic')
   @ApiOperation({
     summary: 'Verify magic link token',
-    description: 'Validates magic link and returns tokens',
+    description:
+      'Validates a magic link token and returns access/refresh tokens. ' +
+      'Tokens expire 15 minutes after the link was requested and are single-use — ' +
+      'reusing an already-consumed token returns 400.',
   })
   @ApiResponse({
     status: 200,
     description: 'Token verified successfully',
     type: AuthSuccessResponseDto,
   })
-  @ApiResponse({ status: 400, description: 'Invalid or expired token' })
+  @ApiResponse({ status: 400, description: 'Token query parameter is missing' })
+  @ApiResponse({
+    status: 401,
+    description:
+      'Token has expired (>15 minutes old) or was already used. ' +
+      'Examples: `"Magic link has expired"`, `"Magic link has already been used"`.',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Token does not exist. Example: `"Invalid or expired magic link"`.',
+  })
   @ApiQuery({ name: 'token', required: true, description: 'Magic link token' })
   @ApiQuery({
     name: 'use_cookies',
@@ -360,7 +393,11 @@ export class AuthController {
   })
   @ApiResponse({
     status: 400,
-    description: 'Invalid token or password requirements not met',
+    description:
+      'Invalid/expired token or password does not meet strength requirements ' +
+      '(min 10 characters, zxcvbn score >= 3). Password validation errors return a ' +
+      'JSON-encoded message, e.g. ' +
+      '`{"score":1,"feedback":["Add numbers"],"suggestions":"Password is too weak. Add numbers"}`.',
   })
   @HttpCode(HttpStatus.OK)
   async resetPassword(

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty, IsString, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsStrongPassword } from '../validators/decorators';
 
 export class ResetPasswordDto {
   @ApiProperty({
@@ -11,11 +12,17 @@ export class ResetPasswordDto {
   token: string;
 
   @ApiProperty({
-    description: 'New password (min 8 characters)',
-    example: 'NewSecurePass123!',
-    minLength: 8,
+    description:
+      'New password. Must be at least 10 characters long and score at least 3 out of 4 ' +
+      'on the zxcvbn strength scale (0 = very weak, 4 = very strong). ' +
+      'Requests that fail this check return 400 with a JSON-encoded message containing ' +
+      '`score`, `feedback`, and `suggestions` fields, e.g. ' +
+      '`{"score":1,"feedback":["Add numbers","Add special characters"],"suggestions":"Password is too weak. Add numbers, Add special characters"}`.',
+    example: 'N3w-C0rrect-Horse-Battery!',
+    minLength: 10,
   })
   @IsString()
-  @MinLength(8, { message: 'Password must be at least 8 characters long' })
+  @MinLength(10, { message: 'Password must be at least 10 characters long' })
+  @IsStrongPassword()
   newPassword: string;
 }

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -1,5 +1,6 @@
 import { IsEmail, IsString, MinLength, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsStrongPassword } from '../validators/decorators';
 
 export class SignupDto {
   @ApiProperty({
@@ -21,13 +22,19 @@ export class SignupDto {
   email: string;
 
   @ApiProperty({
-    description: 'User password (min 8 characters)',
-    example: 'SecurePass123!',
-    minLength: 8,
+    description:
+      'User password. Must be at least 10 characters long and score at least 3 out of 4 ' +
+      'on the zxcvbn strength scale (0 = very weak, 4 = very strong). ' +
+      'Requests that fail this check return 400 with a JSON-encoded message containing ' +
+      '`score`, `feedback`, and `suggestions` fields, e.g. ' +
+      '`{"score":1,"feedback":["Add numbers","Add special characters"],"suggestions":"Password is too weak. Add numbers, Add special characters"}`.',
+    example: 'C0rrect-Horse-Battery-Staple!',
+    minLength: 10,
     maxLength: 32,
   })
   @IsString()
-  @MinLength(8, { message: 'Password is too short (min 8 characters)' })
+  @MinLength(10, { message: 'Password must be at least 10 characters long' })
   @MaxLength(32, { message: 'Password is too long (max 32 characters)' })
+  @IsStrongPassword()
   password: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,43 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const logger = new Logger('Bootstrap');
   const isProduction = process.env.NODE_ENV === 'production';
+  const enableSwaggerUI = !isProduction || process.env.ENABLE_SWAGGER_UI === 'true';
+
+  // Security headers with Helmet. Registered before any route/router (including
+  // Swagger UI below) so every response — docs included — gets these headers;
+  // Express only applies middleware to requests that reach it in registration order.
+  // Swagger UI's bundled HTML injects an inline <script> to boot SwaggerUIBundle, so
+  // scriptSrc needs 'unsafe-inline' whenever the docs UI is exposed; kept locked down
+  // otherwise.
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: [`'self'`],
+          styleSrc: [`'self'`, `'unsafe-inline'`],
+          scriptSrc: enableSwaggerUI ? [`'self'`, `'unsafe-inline'`] : [`'self'`],
+          imgSrc: [`'self'`, 'data:', 'https:'],
+          connectSrc: [`'self'`],
+          fontSrc: [`'self'`],
+          objectSrc: [`'none'`],
+          mediaSrc: [`'self'`],
+          frameSrc: [`'none'`],
+        },
+      },
+      crossOriginEmbedderPolicy: false,
+      hsts: {
+        maxAge: 31536000,
+        includeSubDomains: true,
+        preload: true,
+      },
+      noSniff: true,
+      xssFilter: true,
+      hidePoweredBy: true,
+      frameguard: {
+        action: 'deny',
+      },
+    }),
+  );
 
   // Validate BullMQ Redis connection configuration on startup
   const configService = app.get(ConfigService);
@@ -107,7 +144,21 @@ async function bootstrap() {
       '- Use webhooks instead of polling for real-time updates\n' +
       '- Contact support for higher limits if needed for production use\n\n' +
       '### IP Whitelisting\n\n' +
-      'Trusted IPs can be whitelisted by setting `THROTTLER_WHITELIST` environment variable (comma-separated list).'
+      'Trusted IPs can be whitelisted by setting `THROTTLER_WHITELIST` environment variable (comma-separated list).\n\n' +
+      '## Security Headers\n\n' +
+      'All responses (including this documentation UI) are protected by [Helmet](https://helmetjs.github.io/):\n\n' +
+      '| Header | Value | Purpose |\n' +
+      '|--------|-------|---------|\n' +
+      '| `Content-Security-Policy` | `default-src \'self\'; ...` | Restricts sources for scripts, styles, images, etc. |\n' +
+      '| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` | Forces HTTPS for 1 year |\n' +
+      '| `X-Content-Type-Options` | `nosniff` | Prevents MIME-sniffing |\n' +
+      '| `X-XSS-Protection` | `0` (modern browsers rely on CSP instead) | Legacy XSS filter header |\n' +
+      '| `X-Powered-By` | removed | Hides the underlying framework |\n' +
+      '| `X-Frame-Options` | `DENY` | Blocks the API/docs from being framed (clickjacking protection) |\n\n' +
+      'The `Content-Security-Policy` directives (`scriptSrc`, `styleSrc`, ...) only relax to allow ' +
+      '`\'unsafe-inline\'` scripts when the Swagger UI is enabled (non-production, or ' +
+      '`ENABLE_SWAGGER_UI=true`), since the docs page needs an inline script to boot. ' +
+      'API JSON responses are never affected by this relaxation.'
     )
     .setVersion('1.0')
     .addBearerAuth(
@@ -153,7 +204,6 @@ async function bootstrap() {
   logger.log(`OpenAPI spec exported to ${openapiPath}`);
 
   // Setup Swagger UI (only in non-production or if explicitly enabled)
-  const enableSwaggerUI = !isProduction || process.env.ENABLE_SWAGGER_UI === 'true';
   if (enableSwaggerUI) {
     SwaggerModule.setup('api/docs', app, document, {
       swaggerOptions: {
@@ -183,37 +233,6 @@ async function bootstrap() {
   // Raw body parser for webhook signature verification (must be before JSON parser for specific routes)
   // This preserves the raw body for HMAC signature verification
   app.use('/webhooks/stellar', bodyParser.raw({ type: 'application/json' }));
-
-  // Security headers with Helmet
-  app.use(
-    helmet({
-      contentSecurityPolicy: {
-        directives: {
-          defaultSrc: [`'self'`],
-          styleSrc: [`'self'`, `'unsafe-inline'`],
-          scriptSrc: [`'self'`],
-          imgSrc: [`'self'`, 'data:', 'https:'],
-          connectSrc: [`'self'`],
-          fontSrc: [`'self'`],
-          objectSrc: [`'none'`],
-          mediaSrc: [`'self'`],
-          frameSrc: [`'none'`],
-        },
-      },
-      crossOriginEmbedderPolicy: false,
-      hsts: {
-        maxAge: 31536000,
-        includeSubDomains: true,
-        preload: true,
-      },
-      noSniff: true,
-      xssFilter: true,
-      hidePoweredBy: true,
-      frameguard: {
-        action: 'deny',
-      },
-    }),
-  );
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
## Summary
- **Password Strength Validation (#608)**: wired the existing zxcvbn-based `IsStrongPassword` validator into the signup/reset-password DTOs and documented the real requirements (min 10 chars, zxcvbn score >= 3) plus example JSON validation error messages in Swagger.
- **Passwordless Login (#609)**: documented `POST /auth/magic-link` and `GET /auth/verify-magic` — 15-minute token expiration, single-use tokens, and corrected/added the 401 (expired/used) and 404 (invalid) response docs that were previously mislabeled as a single 400.
- **Helmet Middleware (#610)**: moved Helmet registration before the Swagger UI mount so security headers (CSP, HSTS, etc.) actually apply to `/api/docs` responses — previously Helmet was registered after the Swagger router and never ran for docs requests. CSP `scriptSrc` now only relaxes to allow the inline bootstrap script Swagger UI needs, and only when the docs UI is enabled. Added a "Security Headers" section to the Swagger description documenting all applied headers.
- **Google OAuth (#611)**: documented the full `GET /auth/google` → `GET /auth/google/callback` redirect flow, cookie-based token issuance, and how to use the returned access token as a `Bearer` token on subsequent requests.

Closes #608
Closes #609
Closes #610
Closes #611

## Test plan
- [ ] `npm run build` / `tsc --noEmit` on touched files (pre-existing unrelated TS errors in `payouts.controller.ts` / `wallets.controller.ts` verified present on `main` before this change)
- [ ] Boot the app and confirm `/api/docs` still loads correctly with Helmet enabled
- [ ] Spot-check `/auth/signup` and `/auth/reset-password` reject short/weak passwords with the documented error shape