### PR TITLE
feat(soroban): add deployment scripts and contract info endpoint [#636]

### DIFF
--- a/contracts/nft-contract/deploy-mainnet.sh
+++ b/contracts/nft-contract/deploy-mainnet.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# ============================================================
+# deploy-mainnet.sh — Deploy ClipCash NFT contract to Stellar Mainnet
+#
+# Usage:
+#   chmod +x deploy-mainnet.sh
+#   ./deploy-mainnet.sh
+#
+# Prerequisites:
+#   - Rust toolchain with wasm32-unknown-unknown target
+#   - stellar CLI (https://developers.stellar.org/docs/tools/developer-tools/cli/install)
+#   - STELLAR_SECRET_KEY env var set to the deployer's secret key
+#   - Sufficient XLM in the deployer account to cover contract deployment fees
+#
+# WARNING:
+#   This deploys to STELLAR MAINNET (public network).
+#   Real XLM will be consumed. Confirm before proceeding.
+#
+# Outputs:
+#   CONTRACT_ID printed to stdout and saved to .contract-id-mainnet
+# ============================================================
+
+set -euo pipefail
+
+# ── Network configuration ────────────────────────────────────
+NETWORK="public"
+RPC_URL="https://soroban-rpc.stellar.org"
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+HORIZON_URL="https://horizon.stellar.org"
+
+# ── Safety gate ──────────────────────────────────────────────
+MAINNET_CONFIRMED="${MAINNET_DEPLOY_CONFIRMED:-}"
+if [[ "$MAINNET_CONFIRMED" != "yes" ]]; then
+  echo "╔══════════════════════════════════════════════════════╗"
+  echo "║  ⚠   MAINNET DEPLOYMENT — REAL XLM REQUIRED  ⚠     ║"
+  echo "╚══════════════════════════════════════════════════════╝"
+  echo ""
+  echo "  This script deploys to the Stellar PUBLIC network."
+  echo "  Real XLM will be consumed. This action is irreversible."
+  echo ""
+  echo "  To proceed, set the confirmation variable:"
+  echo "    export MAINNET_DEPLOY_CONFIRMED=yes"
+  echo "  then re-run this script."
+  echo ""
+  exit 1
+fi
+
+# ── Resolve deployer identity ────────────────────────────────
+DEPLOYER_SECRET="${STELLAR_SECRET_KEY:-}"
+if [[ -z "$DEPLOYER_SECRET" ]]; then
+  echo "❌  ERROR: STELLAR_SECRET_KEY environment variable is required." >&2
+  echo "    Export it before running this script:" >&2
+  echo "    export STELLAR_SECRET_KEY=S..." >&2
+  exit 1
+fi
+
+# ── Resolve optional admin address ──────────────────────────
+ADMIN_ADDRESS="${STELLAR_ADMIN_ADDRESS:-}"
+
+# ── Paths ────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WASM_PATH="$SCRIPT_DIR/../../target/wasm32-unknown-unknown/release/clips_nft_contract.wasm"
+CONTRACT_ID_FILE="$SCRIPT_DIR/.contract-id-mainnet"
+
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  ClipCash NFT — Soroban MAINNET Deployment           ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+echo "  Network    : $NETWORK (PUBLIC)"
+echo "  RPC URL    : $RPC_URL"
+echo "  WASM path  : $WASM_PATH"
+echo ""
+
+# ── Step 1: Build the contract ───────────────────────────────
+echo "▶  Building contract (release)..."
+pushd "$SCRIPT_DIR" > /dev/null
+cargo build --target wasm32-unknown-unknown --release 2>&1 | grep -E "(Compiling|Finished|error)" || true
+popd > /dev/null
+
+if [[ ! -f "$WASM_PATH" ]]; then
+  echo "❌  Build failed — WASM not found at: $WASM_PATH" >&2
+  exit 1
+fi
+
+WASM_SIZE=$(du -h "$WASM_PATH" | cut -f1)
+echo "   WASM built successfully (size: $WASM_SIZE)"
+echo ""
+
+# ── Step 2: Resolve deployer public key ──────────────────────
+DEPLOYER_PUBLIC=$(stellar keys address "$DEPLOYER_SECRET" 2>/dev/null || \
+  node -e "
+    const StellarSdk = require('@stellar/stellar-sdk');
+    const kp = StellarSdk.Keypair.fromSecret('$DEPLOYER_SECRET');
+    console.log(kp.publicKey());
+  " 2>/dev/null || echo "")
+
+if [[ -n "$DEPLOYER_PUBLIC" ]]; then
+  echo "   Deployer account : $DEPLOYER_PUBLIC"
+
+  # Check account balance via Horizon
+  BALANCE=$(curl -sf "$HORIZON_URL/accounts/$DEPLOYER_PUBLIC" | \
+    python3 -c "import sys, json; balances=json.load(sys.stdin)['balances']; print(next((b['balance'] for b in balances if b['asset_type']=='native'), '0'))" 2>/dev/null || echo "unknown")
+  echo "   Account XLM balance: $BALANCE XLM"
+fi
+echo ""
+
+# ── Step 3: Deploy (upload + create) ────────────────────────
+echo "▶  Deploying contract to Stellar MAINNET..."
+echo "   (This will consume real XLM for ledger entry fees)"
+echo ""
+
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_PATH" \
+  --source-account "$DEPLOYER_SECRET" \
+  --network "$NETWORK" \
+  --rpc-url "$RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  2>&1 | tail -n 1)
+
+if [[ -z "$CONTRACT_ID" ]]; then
+  echo "❌  Deployment failed — no contract ID returned." >&2
+  exit 1
+fi
+
+echo "   ✅  Contract deployed!"
+echo ""
+
+# ── Step 4: Initialize contract ──────────────────────────────
+INIT_ADMIN="${ADMIN_ADDRESS:-$DEPLOYER_PUBLIC}"
+if [[ -n "$INIT_ADMIN" ]]; then
+  echo "▶  Initializing contract with admin: $INIT_ADMIN..."
+  stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source-account "$DEPLOYER_SECRET" \
+    --network "$NETWORK" \
+    --rpc-url "$RPC_URL" \
+    --network-passphrase "$NETWORK_PASSPHRASE" \
+    -- initialize \
+    --admin "$INIT_ADMIN" && echo "   ✅  Contract initialized." || \
+    echo "   ⚠  Initialization failed (contract may already be initialized)."
+  echo ""
+fi
+
+# ── Step 5: Output ────────────────────────────────────────────
+echo "════════════════════════════════════════════════════════"
+echo "  CONTRACT_ID : $CONTRACT_ID"
+echo "  NETWORK     : Stellar Mainnet (public)"
+echo "════════════════════════════════════════════════════════"
+echo ""
+
+# Save contract ID to file
+echo "$CONTRACT_ID" > "$CONTRACT_ID_FILE"
+echo "   Contract ID saved to: $CONTRACT_ID_FILE"
+echo ""
+echo "  Update your production .env with:"
+echo "    SOROBAN_NFT_CONTRACT_ID=$CONTRACT_ID"
+echo "    STELLAR_NETWORK=public"
+echo ""
+echo "  Explorer: https://stellar.expert/explorer/public/contract/$CONTRACT_ID"

--- a/contracts/nft-contract/deploy-testnet.sh
+++ b/contracts/nft-contract/deploy-testnet.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# ============================================================
+# deploy-testnet.sh — Deploy ClipCash NFT contract to Stellar Testnet
+#
+# Usage:
+#   chmod +x deploy-testnet.sh
+#   ./deploy-testnet.sh
+#
+# Prerequisites:
+#   - Rust toolchain with wasm32-unknown-unknown target
+#   - stellar CLI (https://developers.stellar.org/docs/tools/developer-tools/cli/install)
+#   - STELLAR_SECRET_KEY env var set to the deployer's secret key
+#
+# Outputs:
+#   CONTRACT_ID printed to stdout and saved to .contract-id-testnet
+# ============================================================
+
+set -euo pipefail
+
+# ── Network configuration ────────────────────────────────────
+NETWORK="testnet"
+RPC_URL="https://soroban-testnet.stellar.org"
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+HORIZON_URL="https://horizon-testnet.stellar.org"
+
+# ── Resolve deployer identity ────────────────────────────────
+DEPLOYER_SECRET="${STELLAR_SECRET_KEY:-}"
+if [[ -z "$DEPLOYER_SECRET" ]]; then
+  echo "❌  ERROR: STELLAR_SECRET_KEY environment variable is required." >&2
+  echo "    Export it before running this script:" >&2
+  echo "    export STELLAR_SECRET_KEY=S..." >&2
+  exit 1
+fi
+
+# ── Resolve optional admin address ──────────────────────────
+ADMIN_ADDRESS="${STELLAR_ADMIN_ADDRESS:-}"
+
+# ── Paths ────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WASM_PATH="$SCRIPT_DIR/../../target/wasm32-unknown-unknown/release/clips_nft_contract.wasm"
+CONTRACT_ID_FILE="$SCRIPT_DIR/.contract-id-testnet"
+
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  ClipCash NFT — Soroban Testnet Deployment           ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+echo "  Network    : $NETWORK"
+echo "  RPC URL    : $RPC_URL"
+echo "  WASM path  : $WASM_PATH"
+echo ""
+
+# ── Step 1: Build the contract ───────────────────────────────
+echo "▶  Building contract (release)..."
+pushd "$SCRIPT_DIR" > /dev/null
+cargo build --target wasm32-unknown-unknown --release 2>&1 | grep -E "(Compiling|Finished|error)" || true
+popd > /dev/null
+
+if [[ ! -f "$WASM_PATH" ]]; then
+  echo "❌  Build failed — WASM not found at: $WASM_PATH" >&2
+  exit 1
+fi
+
+WASM_SIZE=$(du -h "$WASM_PATH" | cut -f1)
+echo "   WASM built successfully (size: $WASM_SIZE)"
+echo ""
+
+# ── Step 2: Fund deployer account via Friendbot (testnet only) ─
+echo "▶  Requesting testnet XLM from Friendbot..."
+DEPLOYER_PUBLIC=$(stellar keys address "$DEPLOYER_SECRET" 2>/dev/null || \
+  node -e "
+    const StellarSdk = require('@stellar/stellar-sdk');
+    const kp = StellarSdk.Keypair.fromSecret('$DEPLOYER_SECRET');
+    console.log(kp.publicKey());
+  " 2>/dev/null || echo "")
+
+if [[ -n "$DEPLOYER_PUBLIC" ]]; then
+  curl -sf "https://friendbot.stellar.org?addr=${DEPLOYER_PUBLIC}" > /dev/null && \
+    echo "   Friendbot funded: $DEPLOYER_PUBLIC" || \
+    echo "   ⚠  Friendbot request failed (account may already be funded)"
+else
+  echo "   ⚠  Could not resolve public key; skipping Friendbot."
+fi
+echo ""
+
+# ── Step 3: Deploy (upload + create) ────────────────────────
+echo "▶  Deploying contract to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_PATH" \
+  --source-account "$DEPLOYER_SECRET" \
+  --network "$NETWORK" \
+  --rpc-url "$RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  2>&1 | tail -n 1)
+
+if [[ -z "$CONTRACT_ID" ]]; then
+  echo "❌  Deployment failed — no contract ID returned." >&2
+  exit 1
+fi
+
+echo "   ✅  Contract deployed!"
+echo ""
+
+# ── Step 4: Initialize contract ──────────────────────────────
+INIT_ADMIN="${ADMIN_ADDRESS:-$DEPLOYER_PUBLIC}"
+if [[ -n "$INIT_ADMIN" ]]; then
+  echo "▶  Initializing contract with admin: $INIT_ADMIN..."
+  stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source-account "$DEPLOYER_SECRET" \
+    --network "$NETWORK" \
+    --rpc-url "$RPC_URL" \
+    --network-passphrase "$NETWORK_PASSPHRASE" \
+    -- initialize \
+    --admin "$INIT_ADMIN" && echo "   ✅  Contract initialized." || \
+    echo "   ⚠  Initialization failed (contract may already be initialized)."
+  echo ""
+fi
+
+# ── Step 5: Output ────────────────────────────────────────────
+echo "════════════════════════════════════════════════════════"
+echo "  CONTRACT_ID : $CONTRACT_ID"
+echo "════════════════════════════════════════════════════════"
+echo ""
+
+# Save contract ID to file
+echo "$CONTRACT_ID" > "$CONTRACT_ID_FILE"
+echo "   Contract ID saved to: $CONTRACT_ID_FILE"
+echo ""
+echo "  Next steps:"
+echo "    1. Copy the CONTRACT_ID into your .env:"
+echo "       SOROBAN_NFT_CONTRACT_ID=$CONTRACT_ID"
+echo "       STELLAR_NETWORK=testnet"
+echo "    2. Or run ./deploy.sh to auto-select by STELLAR_NETWORK env."
+echo ""
+echo "  Explorer: https://stellar.expert/explorer/testnet/contract/$CONTRACT_ID"

--- a/contracts/nft-contract/deploy.sh
+++ b/contracts/nft-contract/deploy.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ============================================================
+# deploy.sh — Environment-driven Soroban deployment selector
+#
+# Reads STELLAR_NETWORK from the environment (or .env file) and
+# delegates to the appropriate network-specific script.
+#
+# Usage:
+#   export STELLAR_NETWORK=testnet   # or "public" for mainnet
+#   export STELLAR_SECRET_KEY=S...
+#   chmod +x deploy.sh
+#   ./deploy.sh
+#
+# For mainnet you must also set:
+#   export MAINNET_DEPLOY_CONFIRMED=yes
+#
+# Optional:
+#   export STELLAR_ADMIN_ADDRESS=G...   # defaults to deployer public key
+# ============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Load .env if present ─────────────────────────────────────
+if [[ -f "$SCRIPT_DIR/../../.env" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  source "$SCRIPT_DIR/../../.env"
+  set +a
+  echo "   Loaded environment from .env"
+fi
+
+# ── Determine target network ─────────────────────────────────
+NETWORK="${STELLAR_NETWORK:-testnet}"
+
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  ClipCash NFT — Soroban Deployment Router            ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+echo "  STELLAR_NETWORK = $NETWORK"
+echo ""
+
+case "$NETWORK" in
+  testnet)
+    echo "  → Routing to testnet deployment script..."
+    echo ""
+    exec "$SCRIPT_DIR/deploy-testnet.sh"
+    ;;
+  public|mainnet)
+    echo "  → Routing to mainnet deployment script..."
+    echo ""
+    exec "$SCRIPT_DIR/deploy-mainnet.sh"
+    ;;
+  *)
+    echo "❌  ERROR: Unsupported STELLAR_NETWORK value: '$NETWORK'" >&2
+    echo "    Valid values: 'testnet' | 'public'" >&2
+    exit 1
+    ;;
+esac

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -320,4 +320,68 @@ export class NftController {
   ): Promise<RoyaltyInfo> {
     return this.royaltyQueryService.getRoyaltyInfo(mintAddress);
   }
+
+  /**
+   * GET /nfts/contract/info
+   *
+   * Returns the currently deployed Soroban NFT contract details:
+   * contractId, network, rpcUrl, and networkPassphrase.
+   *
+   * This is useful for frontends and tooling that need to know which
+   * contract to interact with on the currently configured network.
+   */
+  @Get('contract/info')
+  @ApiOperation({
+    summary: 'Get deployed Soroban NFT contract info',
+    description:
+      'Returns the contract ID and network details for the currently deployed ' +
+      'ClipCash NFT Soroban contract. Network is driven by the STELLAR_NETWORK ' +
+      'environment variable (testnet | public).',
+  })
+  @ApiOkResponse({
+    description: 'Contract info returned successfully',
+    schema: {
+      example: {
+        contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+        network: 'testnet',
+        rpcUrl: 'https://soroban-testnet.stellar.org',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+        explorerUrl:
+          'https://stellar.expert/explorer/testnet/contract/CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+      },
+    },
+  })
+  getContractInfo(): {
+    contractId: string;
+    network: string;
+    rpcUrl: string;
+    networkPassphrase: string;
+    explorerUrl: string;
+  } {
+    const contractId =
+      process.env.SOROBAN_NFT_CONTRACT_ID ??
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
+    const network = (process.env.STELLAR_NETWORK ?? 'testnet').toLowerCase();
+    const isMainnet = network === 'public';
+
+    const rpcUrl = isMainnet
+      ? 'https://soroban-rpc.stellar.org'
+      : 'https://soroban-testnet.stellar.org';
+
+    const networkPassphrase = isMainnet
+      ? 'Public Global Stellar Network ; September 2015'
+      : 'Test SDF Network ; September 2015';
+
+    const explorerBase = isMainnet
+      ? 'https://stellar.expert/explorer/public/contract'
+      : 'https://stellar.expert/explorer/testnet/contract';
+
+    return {
+      contractId,
+      network,
+      rpcUrl,
+      networkPassphrase,
+      explorerUrl: `${explorerBase}/${contractId}`,
+    };
+  }
 }


### PR DESCRIPTION
## Summary

Closes #636

Provides fully automated, repeatable deployment scripts for the ClipCash NFT Soroban contract on both Stellar testnet and mainnet, plus a backend endpoint exposing the deployed contract info.

---

## Changes

### `contracts/nft-contract/deploy-testnet.sh`
- Builds the `clips_nft_contract` WASM artifact via `cargo build --release`
- Funds the deployer account on testnet via Friendbot
- Deploys the contract using `stellar contract deploy`
- Calls `initialize --admin <address>` on the newly deployed contract
- **Prints the `CONTRACT_ID` to stdout** and writes it to `.contract-id-testnet`
- Outputs the Stellar Explorer URL for immediate verification

### `contracts/nft-contract/deploy-mainnet.sh`
- Same pipeline as testnet but targeting the Stellar public network
- **Safety gate**: requires `MAINNET_DEPLOY_CONFIRMED=yes` to prevent accidental mainnet deployments
- Checks account XLM balance via Horizon before proceeding
- Saves contract ID to `.contract-id-mainnet`

### `contracts/nft-contract/deploy.sh`
- **Env-based network selector**: reads `STELLAR_NETWORK` (from env or `.env` file)
- Routes to `deploy-testnet.sh` when `STELLAR_NETWORK=testnet`
- Routes to `deploy-mainnet.sh` when `STELLAR_NETWORK=public`
- Single entry point for CI/CD pipelines

### `src/nft/nft.controller.ts` — `GET /nfts/contract/info`
New endpoint that returns:
```json
{
  "contractId": "C...",
  "network": "testnet",
  "rpcUrl": "https://soroban-testnet.stellar.org",
  "networkPassphrase": "Test SDF Network ; September 2015",
  "explorerUrl": "https://stellar.expert/explorer/testnet/contract/C..."
}
```
This allows frontends and client tooling to discover the deployed contract without hardcoding values.

---

## Usage

```bash
# Testnet
export STELLAR_SECRET_KEY=S...
./contracts/nft-contract/deploy-testnet.sh

# Mainnet
export STELLAR_SECRET_KEY=S...
export MAINNET_DEPLOY_CONFIRMED=yes
./contracts/nft-contract/deploy-mainnet.sh

# Env-driven (reads STELLAR_NETWORK from .env or shell)
STELLAR_NETWORK=testnet ./contracts/nft-contract/deploy.sh
```

After deployment, set the following in `.env`:
```env
SOROBAN_NFT_CONTRACT_ID=<output CONTRACT_ID>
STELLAR_NETWORK=testnet  # or public
```

---

## Acceptance Criteria

- [x] `deploy-testnet.sh` deploys and outputs the contract ID
- [x] `deploy-mainnet.sh` deploys and outputs the contract ID (with safety gate)
- [x] `deploy.sh` selects the correct script via `STELLAR_NETWORK` env var
- [x] Contract ID is printed to stdout and saved to a file
- [x] Backend `GET /nfts/contract/info` endpoint documents and exposes the deployed contract details