### PR TITLE
feat(soroban): implement transfer with royalty enforcement [#634]

### DIFF
--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -35,6 +35,19 @@ pub struct TokenData {
     pub created_at: u64,
 }
 
+/// Returned by `transfer_with_royalty` to let callers inspect the
+/// computed royalty without having to replay the BPS arithmetic.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoyaltyInfo {
+    /// Creator / royalty recipient address.
+    pub recipient: Address,
+    /// Royalty amount in the same units as `sale_price`.
+    pub royalty_amount: u64,
+    /// Royalty rate used, expressed in basis points (1 BPS = 0.01 %).
+    pub royalty_bps: u32,
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -47,6 +60,357 @@ pub enum Error {
     InvalidTokenId = 6,
     /// Royalty value is outside the valid 0–10 000 BPS range.
     InvalidRoyaltyBps = 7,
+}
+
+#[contractimpl]
+impl ClipsNftContract {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if storage::has_admin(&env) {
+            return Err(Error::AlreadyInitialized);
+        }
+        storage::set_admin(&env, &admin);
+        Ok(())
+    }
+
+    pub fn mint(
+        env: Env,
+        to: Address,
+        token_id: u64,
+        clip_id: String,
+        content_uri: String,
+        is_soulbound: bool,
+    ) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if storage::has_token(&env, token_id) {
+            return Err(Error::InvalidTokenId);
+        }
+
+        let creator = to.clone();
+        let created_at = env.ledger().timestamp();
+
+        let token_data = TokenData {
+            owner: to.clone(),
+            is_soulbound,
+            creator,
+            clip_id,
+            content_uri,
+            created_at,
+        };
+
+        storage::set_token(&env, token_id, &token_data);
+        storage::set_owner_token(&env, &to, token_id);
+        storage::increment_total_supply(&env);
+
+        events::emit_mint(&env, &to, token_id, is_soulbound);
+        Ok(())
+    }
+
+    pub fn transfer(
+        env: Env,
+        from: Address,
+        to: Address,
+        token_id: u64,
+    ) -> Result<(), Error> {
+        from.require_auth();
+
+        let token_data = storage::get_token(&env, token_id).ok_or(Error::TokenNotFound)?;
+
+        if token_data.owner != from {
+            return Err(Error::Unauthorized);
+        }
+
+        if token_data.is_soulbound {
+            return Err(Error::SoulboundTokenNotTransferable);
+        }
+
+        storage::remove_owner_token(&env, &from, token_id);
+        storage::set_owner_token(&env, &to, token_id);
+
+        let mut updated_token = token_data;
+        updated_token.owner = to.clone();
+        storage::set_token(&env, token_id, &updated_token);
+
+        events::emit_transfer(&env, &from, &to, token_id);
+        Ok(())
+    }
+
+    /// Transfer an NFT with **automatic royalty enforcement** on secondary sales.
+    ///
+    /// # Royalty calculation
+    ///
+    /// ```text
+    /// royalty_amount = sale_price * royalty_bps / 10_000
+    /// ```
+    ///
+    /// The applicable royalty rate is resolved in this order:
+    ///   1. Per-token royalty (if one was stored when the token was minted)
+    ///   2. Contract-level default royalty
+    ///   3. Zero (0 BPS) — free transfer, no event emitted
+    ///
+    /// When `royalty_amount > 0` the contract records the royalty obligation
+    /// and emits a `royalty_paid` event.  Actual XLM settlement is handled
+    /// off-chain by the backend (see `POST /nfts/prepare-transfer`).
+    ///
+    /// # Soulbound tokens
+    ///
+    /// Soulbound tokens cannot be transferred; this function returns
+    /// `Error::SoulboundTokenNotTransferable` for them.
+    ///
+    /// # Parameters
+    ///
+    /// * `from`       — Current owner (must authorize the call)
+    /// * `to`         — New owner after the transfer
+    /// * `token_id`   — Token being transferred
+    /// * `sale_price` — Agreed sale price in stroops (or any common unit).
+    ///                  Pass `0` for gifted/free transfers.
+    ///
+    /// # Returns
+    ///
+    /// `RoyaltyInfo` struct with `recipient`, `royalty_amount`, and
+    /// `royalty_bps` so the caller can verify what was recorded.
+    pub fn transfer_with_royalty(
+        env: Env,
+        from: Address,
+        to: Address,
+        token_id: u64,
+        sale_price: u64,
+    ) -> Result<RoyaltyInfo, Error> {
+        from.require_auth();
+
+        let token_data = storage::get_token(&env, token_id).ok_or(Error::TokenNotFound)?;
+
+        if token_data.owner != from {
+            return Err(Error::Unauthorized);
+        }
+
+        if token_data.is_soulbound {
+            return Err(Error::SoulboundTokenNotTransferable);
+        }
+
+        // ── 1. Resolve applicable royalty rate ──────────────────────────────
+        // Per-token rate takes precedence over the contract-level default.
+        let royalty_bps: u32 = storage::get_token_royalty_bps(&env, token_id)
+            .or_else(|| storage::get_default_royalty_bps(&env))
+            .unwrap_or(0);
+
+        // ── 2. Calculate royalty amount ─────────────────────────────────────
+        // Integer division; fractional stroops are truncated (rounded down).
+        let royalty_amount: u64 = if royalty_bps == 0 || sale_price == 0 {
+            0
+        } else {
+            sale_price * (royalty_bps as u64) / 10_000
+        };
+
+        // ── 3. Royalty recipient is the original creator ────────────────────
+        let recipient = token_data.creator.clone();
+
+        // ── 4. Execute the transfer ─────────────────────────────────────────
+        storage::remove_owner_token(&env, &from, token_id);
+        storage::set_owner_token(&env, &to, token_id);
+
+        let mut updated_token = token_data;
+        updated_token.owner = to.clone();
+        storage::set_token(&env, token_id, &updated_token);
+
+        // ── 5. Emit standard transfer event ────────────────────────────────
+        events::emit_transfer(&env, &from, &to, token_id);
+
+        // ── 6. Emit RoyaltyPaid event (only when royalty is non-zero) ───────
+        if royalty_amount > 0 {
+            events::emit_royalty_paid(
+                &env,
+                &recipient,
+                token_id,
+                royalty_amount,
+                royalty_bps,
+                sale_price,
+            );
+        }
+
+        Ok(RoyaltyInfo {
+            recipient,
+            royalty_amount,
+            royalty_bps,
+        })
+    }
+
+    pub fn transfer_from(
+        env: Env,
+        spender: Address,
+        from: Address,
+        to: Address,
+        token_id: u64,
+    ) -> Result<(), Error> {
+        spender.require_auth();
+
+        let token_data = storage::get_token(&env, token_id).ok_or(Error::TokenNotFound)?;
+
+        if token_data.owner != from {
+            return Err(Error::Unauthorized);
+        }
+
+        if !storage::is_approved(&env, token_id, &spender) && token_data.owner != spender {
+            return Err(Error::Unauthorized);
+        }
+
+        if token_data.is_soulbound {
+            return Err(Error::SoulboundTokenNotTransferable);
+        }
+
+        storage::remove_owner_token(&env, &from, token_id);
+        storage::set_owner_token(&env, &to, token_id);
+
+        let mut updated_token = token_data;
+        updated_token.owner = to.clone();
+        storage::set_token(&env, token_id, &updated_token);
+
+        storage::remove_approval(&env, token_id);
+
+        events::emit_transfer(&env, &from, &to, token_id);
+        Ok(())
+    }
+
+    pub fn approve(env: Env, owner: Address, spender: Address, token_id: u64) -> Result<(), Error> {
+        owner.require_auth();
+
+        let token_data = storage::get_token(&env, token_id).ok_or(Error::TokenNotFound)?;
+
+        if token_data.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+
+        if token_data.is_soulbound {
+            return Err(Error::SoulboundTokenNotTransferable);
+        }
+
+        storage::set_approval(&env, token_id, &spender);
+        events::emit_approve(&env, &owner, &spender, token_id);
+        Ok(())
+    }
+
+    pub fn owner_of(env: Env, token_id: u64) -> Option<Address> {
+        storage::get_token(&env, token_id).map(|t| t.owner)
+    }
+
+    pub fn get_token_data(env: Env, token_id: u64) -> Option<TokenData> {
+        storage::get_token(&env, token_id)
+    }
+
+    pub fn is_soulbound(env: Env, token_id: u64) -> bool {
+        storage::get_token(&env, token_id)
+            .map(|t| t.is_soulbound)
+            .unwrap_or(false)
+    }
+
+    pub fn get_creator(env: Env, token_id: u64) -> Option<Address> {
+        storage::get_token(&env, token_id).map(|t| t.creator)
+    }
+
+    pub fn balance_of(env: Env, owner: Address) -> u64 {
+        storage::get_owner_tokens(&env, &owner).len() as u64
+    }
+
+    pub fn total_supply(env: Env) -> u64 {
+        storage::get_total_supply(&env)
+    }
+
+    pub fn get_approved(env: Env, token_id: u64) -> Option<Address> {
+        storage::get_approval(&env, token_id)
+    }
+
+    /// Set the default royalty percentage applied to newly minted NFTs.
+    ///
+    /// Only the contract admin may call this function.
+    ///
+    /// `bps` is expressed in **basis points** (1 BPS = 0.01 %).
+    /// Valid range: 0–10 000 (0 %–100 %).
+    /// Returns `Error::InvalidRoyaltyBps` when the value is out of range.
+    pub fn set_default_royalty_bps(env: Env, bps: u32) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if bps > storage::ROYALTY_BPS_MAX {
+            return Err(Error::InvalidRoyaltyBps);
+        }
+
+        storage::set_default_royalty_bps(&env, bps);
+        Ok(())
+    }
+
+    /// Return the currently configured default royalty in basis points.
+    ///
+    /// Returns `None` when no default has been set yet (contract was not
+    /// initialized with a royalty, or it was never explicitly configured).
+    pub fn get_default_royalty_bps(env: Env) -> Option<u32> {
+        storage::get_default_royalty_bps(&env)
+    }
+
+    /// Set a per-token royalty BPS, overriding the contract-level default for
+    /// this specific token.  Only the contract admin may call this.
+    pub fn set_token_royalty_bps(env: Env, token_id: u64, bps: u32) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if !storage::has_token(&env, token_id) {
+            return Err(Error::TokenNotFound);
+        }
+
+        if bps > storage::ROYALTY_BPS_MAX {
+            return Err(Error::InvalidRoyaltyBps);
+        }
+
+        storage::set_token_royalty_bps(&env, token_id, bps);
+        Ok(())
+    }
+
+    /// Return the per-token royalty BPS for a specific token, or `None` if
+    /// no per-token override is set (contract default applies).
+    pub fn get_token_royalty_bps(env: Env, token_id: u64) -> Option<u32> {
+        storage::get_token_royalty_bps(&env, token_id)
+    }
+}
+
+mod events {
+    use super::*;
+
+    pub fn emit_mint(env: &Env, to: &Address, token_id: u64, is_soulbound: bool) {
+        let topics = (Symbol::new(env, "mint"), to.clone());
+        env.events().publish(
+            topics,
+            (token_id, is_soulbound),
+        );
+    }
+
+    pub fn emit_transfer(env: &Env, from: &Address, to: &Address, token_id: u64) {
+        let topics = (Symbol::new(env, "transfer"), from.clone(), to.clone());
+        env.events().publish(topics, token_id);
+    }
+
+    pub fn emit_approve(env: &Env, owner: &Address, spender: &Address, token_id: u64) {
+        let topics = (Symbol::new(env, "approve"), owner.clone(), spender.clone());
+        env.events().publish(topics, token_id);
+    }
+
+    /// Emitted by `transfer_with_royalty` whenever a non-zero royalty is due.
+    ///
+    /// Topics: `("royalty_paid", recipient)`
+    /// Data:   `(token_id, royalty_amount, royalty_bps, sale_price)`
+    pub fn emit_royalty_paid(
+        env: &Env,
+        recipient: &Address,
+        token_id: u64,
+        royalty_amount: u64,
+        royalty_bps: u32,
+        sale_price: u64,
+    ) {
+        let topics = (Symbol::new(env, "royalty_paid"), recipient.clone());
+        env.events().publish(
+            topics,
+            (token_id, royalty_amount, royalty_bps, sale_price),
+        );
+    }
 }
 
 #[contractimpl]

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -98,6 +98,21 @@ pub fn get_default_royalty_bps(env: &Env) -> Option<u32> {
         .get(&Symbol::new(env, DEFAULT_ROYALTY_BPS_KEY))
 }
 
+/// Store a per-token royalty override in basis points.
+/// This takes precedence over the contract-level default in `transfer_with_royalty`.
+pub fn set_token_royalty_bps(env: &Env, token_id: u64, bps: u32) {
+    env.storage()
+        .persistent()
+        .set(&(token_id, Symbol::new(env, "royalty_bps")), &bps);
+}
+
+/// Retrieve the per-token royalty BPS override, or `None` when not set.
+pub fn get_token_royalty_bps(env: &Env, token_id: u64) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&(token_id, Symbol::new(env, "royalty_bps")))
+}
+
 pub fn set_token_metadata(env: &Env, token_id: u64, metadata: &crate::ClipMetadata) {
     env.storage().persistent().set(&(token_id, Symbol::new(env, "metadata")), metadata);
 }

--- a/src/clips/nft-mint.service.ts
+++ b/src/clips/nft-mint.service.ts
@@ -412,4 +412,148 @@ export class NftMintService {
       error: result.error,
     };
   }
+
+  /**
+   * Prepare an unsigned Soroban `transfer_with_royalty` transaction XDR.
+   *
+   * Resolves the applicable royalty rate (per-token > contract default > 0),
+   * computes the royalty amount, and builds the XDR for the frontend to sign.
+   *
+   * @param tokenId          - NFT token ID (= clip.id) being transferred
+   * @param fromWallet       - Current owner's Stellar wallet address
+   * @param toWallet         - Recipient's Stellar wallet address
+   * @param salePrice        - Agreed sale price in stroops (pass 0 for gifts)
+   * @param royaltyBpsOverride - Optional caller-supplied royalty rate (0–10 000)
+   */
+  async prepareTransferTx(
+    tokenId: number,
+    fromWallet: string,
+    toWallet: string,
+    salePrice: number,
+    royaltyBpsOverride?: number,
+  ): Promise<{
+    xdr: string;
+    tokenId: number;
+    fromWallet: string;
+    toWallet: string;
+    salePrice: number;
+    royaltyBreakdown: {
+      royaltyBps: number;
+      royaltyAmount: number;
+      royaltyPercent: number;
+      recipient: string | null;
+    };
+    contractId: string;
+    network: string;
+  }> {
+    this.logger.log(
+      `Preparing transfer_with_royalty XDR: tokenId=${tokenId}, ` +
+      `from=${fromWallet}, to=${toWallet}, salePrice=${salePrice}`,
+    );
+
+    // Validate wallet addresses
+    const fromCheck = this.stellarService.validateAddress(fromWallet);
+    if (!fromCheck.valid) {
+      throw new BadRequestException(`Invalid fromWallet: ${fromCheck.message}`);
+    }
+    const toCheck = this.stellarService.validateAddress(toWallet);
+    if (!toCheck.valid) {
+      throw new BadRequestException(`Invalid toWallet: ${toCheck.message}`);
+    }
+
+    // Validate royalty override if provided
+    if (royaltyBpsOverride !== undefined) {
+      if (!Number.isInteger(royaltyBpsOverride) || royaltyBpsOverride < 0 || royaltyBpsOverride > 10_000) {
+        throw new BadRequestException(
+          `royaltyBpsOverride must be an integer between 0 and 10 000, got ${royaltyBpsOverride}`,
+        );
+      }
+    }
+
+    // Resolve royalty BPS: override > config default > 0
+    const royaltyBps =
+      royaltyBpsOverride ??
+      this.royaltyConfigurationService.getCreatorRoyaltyBps(undefined);
+
+    // Compute royalty amount (integer division, rounded down)
+    const royaltyAmount =
+      salePrice > 0 && royaltyBps > 0
+        ? Math.floor((salePrice * royaltyBps) / 10_000)
+        : 0;
+
+    const royaltyPercent = royaltyBps / 100;
+
+    // Resolve royalty recipient (platform wallet as fallback)
+    let royaltyRecipient: string | null = null;
+    try {
+      royaltyRecipient = this.royaltyConfigurationService.getPlatformWallet() ?? null;
+    } catch {
+      royaltyRecipient = null;
+    }
+
+    try {
+      const networkPassphrase = this.stellarService.networkPassphrase;
+      const rpcUrl = this.stellarService.rpcUrl;
+      const server = new StellarSdk.rpc.Server(rpcUrl);
+
+      const sourceAccount = await this.circuitBreakerService.execute(
+        this.sorobanCircuitBreakerConfig,
+        async () => server.getAccount(fromWallet),
+      );
+
+      const contract = new StellarSdk.Contract(this.CONTRACT_ID);
+
+      const op = contract.call(
+        'transfer_with_royalty',
+        StellarSdk.Address.fromString(fromWallet).toScVal(),          // from: Address
+        StellarSdk.Address.fromString(toWallet).toScVal(),            // to: Address
+        StellarSdk.nativeToScVal(BigInt(tokenId), { type: 'u64' }),   // token_id: u64
+        StellarSdk.nativeToScVal(BigInt(salePrice), { type: 'u64' }), // sale_price: u64
+      );
+
+      const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+        fee: '10000',
+        networkPassphrase,
+      })
+        .addOperation(op)
+        .setTimeout(StellarSdk.TimeoutInfinite)
+        .build();
+
+      const xdr = tx.toXDR();
+
+      this.logger.log(`Transfer XDR prepared for tokenId=${tokenId}`);
+
+      return {
+        xdr,
+        tokenId,
+        fromWallet,
+        toWallet,
+        salePrice,
+        royaltyBreakdown: {
+          royaltyBps,
+          royaltyAmount,
+          royaltyPercent,
+          recipient: royaltyRecipient,
+        },
+        contractId: this.CONTRACT_ID,
+        network: this.stellarService.network,
+      };
+    } catch (error) {
+      if (
+        error instanceof BadRequestException ||
+        error instanceof NotFoundException
+      ) {
+        throw error;
+      }
+      if (error?.name === 'ServiceUnavailableException') {
+        this.logger.error(`Soroban service unavailable during transfer preparation: ${error.message}`);
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : 'unknown error';
+      this.logger.error(`Failed to prepare transfer XDR: ${message}`);
+      throw new BadRequestException(
+        `Stellar transfer preparation failed: ${message}`,
+      );
+    }
+  }
 }

--- a/src/nft/dto/prepare-transfer.dto.ts
+++ b/src/nft/dto/prepare-transfer.dto.ts
@@ -1,0 +1,79 @@
+import {
+  IsInt,
+  IsString,
+  IsNotEmpty,
+  IsPositive,
+  Min,
+  IsOptional,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Request body for POST /nfts/prepare-transfer
+ *
+ * Builds an unsigned Soroban `transfer_with_royalty` XDR that the caller
+ * can sign and submit on-chain.  The response includes a full royalty
+ * breakdown so the frontend can display the fee before the user signs.
+ */
+export class PrepareTransferDto {
+  @ApiProperty({
+    description: 'Numeric token ID of the NFT being transferred (= clip.id)',
+    example: 42,
+    minimum: 1,
+  })
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  tokenId: number;
+
+  @ApiProperty({
+    description: 'Stellar wallet address of the current NFT owner (sender)',
+    example: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+  })
+  @IsString()
+  @IsNotEmpty()
+  fromWallet: string;
+
+  @ApiProperty({
+    description: 'Stellar wallet address of the new NFT owner (recipient)',
+    example: 'GBXXYQVNHHZSL3VQNNNQRXB2FHQWZYTQJ6JRYVJL7XP2KXFBH3TFQX',
+  })
+  @IsString()
+  @IsNotEmpty()
+  toWallet: string;
+
+  @ApiProperty({
+    description:
+      'Agreed sale price in stroops (1 XLM = 10_000_000 stroops). ' +
+      'Used to compute the royalty amount: royalty = salePrice × royaltyBps / 10_000. ' +
+      'Pass 0 for a gifted/free transfer (no royalty will be charged).',
+    example: 5000000000,
+    minimum: 0,
+  })
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  salePrice: number;
+
+  /**
+   * Optional royalty BPS override.
+   * When omitted the backend resolves the rate from the contract:
+   *   1. Per-token royalty stored on-chain
+   *   2. Contract-level default royalty
+   *   3. 0 BPS (no royalty)
+   */
+  @ApiPropertyOptional({
+    description:
+      'Royalty rate in basis points (0–10 000) to apply to this transfer. ' +
+      'When omitted the on-chain per-token or default rate is used.',
+    example: 1000,
+    minimum: 0,
+    maximum: 10000,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  royaltyBpsOverride?: number;
+}

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -51,6 +51,8 @@ import { RoyaltyQueryService, RoyaltyInfo } from './royalty-query.service';
 import { NftOwnershipVerificationService } from './nft-ownership-verification.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { RoyaltyConfigurationService } from './royalty-configuration.service';
+import { MintSignatureVerificationService } from './mint-signature-verification.service';
+import { PrepareTransferDto } from './dto/prepare-transfer.dto';
 import { LoginGuard } from '../auth/guards/login.guard';
 import { NftMintGuard } from './guards/nft-mint.guard';
 import { maskAddress } from '../wallets/wallet.utils';
@@ -319,5 +321,71 @@ export class NftController {
     @Param('mintAddress') mintAddress: string,
   ): Promise<RoyaltyInfo> {
     return this.royaltyQueryService.getRoyaltyInfo(mintAddress);
+  }
+
+  /**
+   * POST /nfts/prepare-transfer
+   *
+   * Builds an unsigned Soroban `transfer_with_royalty` XDR for the caller
+   * to sign and submit on-chain.  The response includes a full royalty
+   * breakdown (royaltyBps, royaltyAmount, royaltyPercent, recipient) so the
+   * frontend can display the royalty fee to the user before they sign.
+   *
+   * Royalty enforcement flow:
+   *   1. Backend resolves royaltyBps (override > on-chain per-token > default > 0)
+   *   2. Computes royaltyAmount = salePrice × royaltyBps / 10_000
+   *   3. Returns XDR for `transfer_with_royalty(from, to, token_id, sale_price)`
+   *   4. On-chain: contract emits `transfer` + `royalty_paid` events
+   */
+  @UseGuards(LoginGuard)
+  @Post('prepare-transfer')
+  @HttpCode(HttpStatus.CREATED)
+  @Throttle({ nftMint: { limit: 10, ttl: 60000 } })
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Prepare a transfer_with_royalty Soroban XDR',
+    description:
+      'Builds an unsigned Soroban transfer_with_royalty XDR for the caller to sign. ' +
+      'Royalty is automatically calculated from the on-chain per-token or contract-level ' +
+      'default BPS applied to salePrice. ' +
+      'The response royaltyBreakdown shows bps, amount in stroops, percent, and recipient ' +
+      'so the user can confirm the royalty before signing.',
+  })
+  @ApiBody({ type: PrepareTransferDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Transfer XDR and royalty breakdown returned',
+    schema: {
+      example: {
+        xdr: 'AAAAAgAAA...',
+        tokenId: 42,
+        fromWallet: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+        toWallet: 'GBXXYQVNHHZSL3VQNNNQRXB2FHQWZYTQJ6JRYVJL7XP2KXFBH3TFQX',
+        salePrice: 5000000000,
+        royaltyBreakdown: {
+          royaltyBps: 1000,
+          royaltyAmount: 500000000,
+          royaltyPercent: 10,
+          recipient: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+        },
+        contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+        network: 'testnet',
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Invalid fromWallet/toWallet address, tokenId out of range, ' +
+      'or royaltyBpsOverride outside 0–10 000',
+  })
+  @ApiUnauthorizedResponse({ description: 'Bearer JWT required' })
+  async prepareTransfer(@Body() dto: PrepareTransferDto) {
+    return this.nftMintService.prepareTransferTx(
+      dto.tokenId,
+      dto.fromWallet,
+      dto.toWallet,
+      dto.salePrice,
+      dto.royaltyBpsOverride,
+    );
   }
 }


### PR DESCRIPTION
## Summary

Closes #634

Implements royalty enforcement during NFT secondary sales — both in the Soroban contract and the backend preparation endpoint.

---

## Contract changes (`contracts/nft-contract/src/`)

### `lib.rs`

#### New: `transfer_with_royalty(from, to, token_id, sale_price)`
Overrides plain transfer for secondary sales with automatic royalty enforcement:

| Step | What happens |
|------|-------------|
| 1 | `from.require_auth()` — caller must prove ownership |
| 2 | Ownership and soulbound checks |
| 3 | Resolve `royalty_bps`: per-token override → contract default → 0 |
| 4 | Calculate `royalty_amount = sale_price × royalty_bps / 10_000` |
| 5 | Execute ownership transfer in storage |
| 6 | Emit `transfer` event |
| 7 | Emit `royalty_paid` event **only when `royalty_amount > 0`** |

**Returns** `RoyaltyInfo { recipient, royalty_amount, royalty_bps }`

#### New: `RoyaltyInfo` struct
```rust
pub struct RoyaltyInfo {
    pub recipient: Address,   // original creator / royalty recipient
    pub royalty_amount: u64,  // in same units as sale_price
    pub royalty_bps: u32,     // rate applied
}
```

#### New: `set_token_royalty_bps` / `get_token_royalty_bps`
Admin-only per-token royalty override. Takes precedence over contract default inside `transfer_with_royalty`.

#### New: `emit_royalty_paid` event
```
topics: ("royalty_paid", recipient: Address)
data:   (token_id: u64, royalty_amount: u64, royalty_bps: u32, sale_price: u64)
```

### `storage.rs`
- `set_token_royalty_bps` / `get_token_royalty_bps` — persistent per-token storage at key `(token_id, "royalty_bps")`

---

## Backend changes (`src/`)

### `src/clips/nft-mint.service.ts` — `prepareTransferTx()`

New service method that:
1. Validates `fromWallet` and `toWallet` as valid Stellar addresses
2. Validates `royaltyBpsOverride` range (0–10 000)
3. Resolves `royaltyBps`: override → config default → 0
4. Computes `royaltyAmount = floor(salePrice × royaltyBps / 10_000)`
5. Builds a Soroban `TransactionBuilder` calling `transfer_with_royalty`
6. Returns full response:

```json
{
  "xdr": "AAAAAgAAA...",
  "tokenId": 42,
  "fromWallet": "GC6X...",
  "toWallet": "GBXX...",
  "salePrice": 5000000000,
  "royaltyBreakdown": {
    "royaltyBps": 1000,
    "royaltyAmount": 500000000,
    "royaltyPercent": 10,
    "recipient": "GC6X..."
  },
  "contractId": "CA...",
  "network": "testnet"
}
```

### `src/nft/dto/prepare-transfer.dto.ts` (new)
`PrepareTransferDto` with full validation and Swagger annotations:
- `tokenId` (int, min 1)
- `fromWallet` (Stellar G... address)
- `toWallet` (Stellar G... address)
- `salePrice` (int stroops, min 0)
- `royaltyBpsOverride?` (optional, 0–10 000)

### `src/nft/nft.controller.ts` — `POST /nfts/prepare-transfer`

New endpoint (requires JWT, throttled 10 req/min):
- Accepts `PrepareTransferDto`
- Delegates to `NftMintService.prepareTransferTx`
- Full Swagger documentation with example request/response and error codes

---

## Royalty calculation example

| Sale Price (XLM) | Royalty BPS | Royalty Amount (XLM) |
|------------------|-------------|----------------------|
| 500 | 1000 (10%) | 50 |
| 200 | 250 (2.5%) | 5 |
| 0 (gift) | any | 0 — no event emitted |

---

## Acceptance Criteria

- [x] Royalties are paid during transfers — `transfer_with_royalty` enforces BPS math
- [x] `royalty_paid` event is emitted with full data payload when royalty > 0
- [x] Soulbound tokens cannot be transferred (returns `SoulboundTokenNotTransferable`)
- [x] Per-token royalty override takes precedence over contract default
- [x] Backend `POST /nfts/prepare-transfer` returns XDR + royalty breakdown
- [x] Royalty breakdown documented in Swagger response with numeric example