### PR TITLE
feat: Paginated User Token Query (Issue #704)

### DIFF
--- a/contracts/nft-contract/bindings/clips-nft-contract.ts
+++ b/contracts/nft-contract/bindings/clips-nft-contract.ts
@@ -148,6 +148,18 @@ export class ClipsNftContractClient {
   async totalSupply(): Promise<bigint> {
     return 0n;
   }
+
+  /**
+   * Return a paginated slice of token IDs owned by `owner`.
+   *
+   * @param owner   - Stellar address of the token holder
+   * @param limit   - Maximum number of token IDs to return (capped at 100)
+   * @param cursor  - Offset into the owner's token list (0-based index)
+   * @returns Array of token IDs in the requested page
+   */
+  async getUserTokens(owner: string, limit: number, cursor: number): Promise<number[]> {
+    return [];
+  }
 }
 
 export function createClipsNftContractClient(config: ContractConfig): ClipsNftContractClient {

--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -835,6 +835,27 @@ impl ClipsNftContract {
     pub fn get_nonce(env: Env, caller: Address) -> u64 {
         storage::get_nonce(&env, &caller)
     }
+
+    /// Return a paginated slice of token IDs owned by `owner`.
+    ///
+    /// `limit`  – maximum number of token IDs to return (capped at 100).
+    /// `cursor` – offset into the owner's token list (0-based index).
+    ///
+    /// Returns an empty Vec when `cursor` >= total tokens or `limit` is 0.
+    pub fn get_user_tokens(env: Env, owner: Address, limit: u32, cursor: u32) -> Vec<u64> {
+        let tokens = storage::get_owner_tokens(&env, &owner);
+        let total = tokens.len();
+        let start = cursor.min(total);
+        let effective_limit = limit.min(100);
+        let end = (start + effective_limit).min(total);
+        let mut result = Vec::new(&env);
+        let mut i = start;
+        while i < end {
+            result.push_back(tokens.get(i).unwrap());
+            i += 1;
+        }
+        result
+    }
 }
 
 mod events {

--- a/contracts/nft-contract/src/test.rs
+++ b/contracts/nft-contract/src/test.rs
@@ -1253,3 +1253,243 @@ fn test_update_metadata_one_time_enforcement() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────
+// Issue #704: Paginated User Token Query
+// ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_user_tokens_empty_owner() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let result = client.get_user_tokens(&owner, &10, &0);
+    assert_eq!(result.len(), 0, "empty owner should return empty Vec");
+}
+
+#[test]
+fn test_get_user_tokens_basic() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.mint(&owner, &1, &s(&env, "clip_001"), &s(&env, "uri_001"), &false);
+    client.mint(&owner, &2, &s(&env, "clip_002"), &s(&env, "uri_002"), &false);
+    client.mint(&owner, &3, &s(&env, "clip_003"), &s(&env, "uri_003"), &false);
+
+    let result = client.get_user_tokens(&owner, &10, &0);
+    assert_eq!(result.len(), 3, "should return all 3 tokens");
+    assert_eq!(result.get(0).unwrap(), 1);
+    assert_eq!(result.get(1).unwrap(), 2);
+    assert_eq!(result.get(2).unwrap(), 3);
+}
+
+#[test]
+fn test_get_user_tokens_pagination_first_page() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    for i in 1..=5 {
+        let token_id = i;
+        let clip_id = format!("clip_{}", i);
+        let uri = format!("uri_{}", i);
+        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+    }
+
+    let page1 = client.get_user_tokens(&owner, &2, &0);
+    assert_eq!(page1.len(), 2, "first page should have 2 tokens");
+    assert_eq!(page1.get(0).unwrap(), 1);
+    assert_eq!(page1.get(1).unwrap(), 2);
+}
+
+#[test]
+fn test_get_user_tokens_pagination_second_page() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    for i in 1..=5 {
+        let token_id = i;
+        let clip_id = format!("clip_{}", i);
+        let uri = format!("uri_{}", i);
+        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+    }
+
+    let page2 = client.get_user_tokens(&owner, &2, &2);
+    assert_eq!(page2.len(), 2, "second page should have 2 tokens");
+    assert_eq!(page2.get(0).unwrap(), 3);
+    assert_eq!(page2.get(1).unwrap(), 4);
+}
+
+#[test]
+fn test_get_user_tokens_pagination_last_page_partial() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    for i in 1..=5 {
+        let token_id = i;
+        let clip_id = format!("clip_{}", i);
+        let uri = format!("uri_{}", i);
+        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+    }
+
+    let last_page = client.get_user_tokens(&owner, &2, &4);
+    assert_eq!(last_page.len(), 1, "last page should have 1 remaining token");
+    assert_eq!(last_page.get(0).unwrap(), 5);
+}
+
+#[test]
+fn test_get_user_tokens_cursor_beyond_total() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.mint(&owner, &1, &s(&env, "clip_001"), &s(&env, "uri_001"), &false);
+
+    let result = client.get_user_tokens(&owner, &10, &100);
+    assert_eq!(result.len(), 0, "cursor beyond total should return empty Vec");
+}
+
+#[test]
+fn test_get_user_tokens_limit_exceeds_total() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    for i in 1..=3 {
+        let token_id = i;
+        let clip_id = format!("clip_{}", i);
+        let uri = format!("uri_{}", i);
+        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+    }
+
+    let result = client.get_user_tokens(&owner, &100, &0);
+    assert_eq!(result.len(), 3, "limit exceeding total should return all tokens");
+}
+
+#[test]
+fn test_get_user_tokens_zero_limit() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.mint(&owner, &1, &s(&env, "clip_001"), &s(&env, "uri_001"), &false);
+
+    let result = client.get_user_tokens(&owner, &0, &0);
+    assert_eq!(result.len(), 0, "zero limit should return empty Vec");
+}
+
+#[test]
+fn test_get_user_tokens_limit_capped_at_100() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Mint 50 tokens (batch limit is 50)
+    let token_ids: Vec<u64> = (1..=50).collect();
+    let clip_ids: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("clip_{}", i))).collect();
+    let uris: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("uri_{}", i))).collect();
+    let soulbound: Vec<bool> = (1..=50).map(|_| false).collect();
+    client.batch_mint(&owner, &token_ids, &clip_ids, &uris, &soulbound);
+
+    // Request 200 (should be capped to 100, but only 50 exist)
+    let result = client.get_user_tokens(&owner, &200, &0);
+    assert_eq!(result.len(), 50, "limit capped to available tokens");
+}
+
+#[test]
+fn test_get_user_tokens_large_collection_multi_page() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Mint 50 tokens via batch
+    let token_ids: Vec<u64> = (1..=50).collect();
+    let clip_ids: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("clip_{}", i))).collect();
+    let uris: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("uri_{}", i))).collect();
+    let soulbound: Vec<bool> = (1..=50).map(|_| false).collect();
+    client.batch_mint(&owner, &token_ids, &clip_ids, &uris, &soulbound);
+
+    // Page 1
+    let page1 = client.get_user_tokens(&owner, &20, &0);
+    assert_eq!(page1.len(), 20);
+    assert_eq!(page1.get(0).unwrap(), 1);
+    assert_eq!(page1.get(19).unwrap(), 20);
+
+    // Page 2
+    let page2 = client.get_user_tokens(&owner, &20, &20);
+    assert_eq!(page2.len(), 20);
+    assert_eq!(page2.get(0).unwrap(), 21);
+    assert_eq!(page2.get(19).unwrap(), 40);
+
+    // Page 3 (partial)
+    let page3 = client.get_user_tokens(&owner, &20, &40);
+    assert_eq!(page3.len(), 10);
+    assert_eq!(page3.get(0).unwrap(), 41);
+    assert_eq!(page3.get(9).unwrap(), 50);
+
+    // Page 4 (empty)
+    let page4 = client.get_user_tokens(&owner, &20, &60);
+    assert_eq!(page4.len(), 0, "page beyond end should be empty");
+}
+
+#[test]
+fn test_get_user_tokens_only_returns_owner_tokens() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+    let owner1 = Address::generate(&env);
+    let owner2 = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.mint(&owner1, &1, &s(&env, "clip_001"), &s(&env, "uri_001"), &false);
+    client.mint(&owner1, &2, &s(&env, "clip_002"), &s(&env, "uri_002"), &false);
+    client.mint(&owner2, &3, &s(&env, "clip_003"), &s(&env, "uri_003"), &false);
+    client.mint(&owner2, &4, &s(&env, "clip_004"), &s(&env, "uri_004"), &false);
+    client.mint(&owner2, &5, &s(&env, "clip_005"), &s(&env, "uri_005"), &false);
+
+    let owner1_tokens = client.get_user_tokens(&owner1, &10, &0);
+    assert_eq!(owner1_tokens.len(), 2, "owner1 should have 2 tokens");
+    assert_eq!(owner1_tokens.get(0).unwrap(), 1);
+    assert_eq!(owner1_tokens.get(1).unwrap(), 2);
+
+    let owner2_tokens = client.get_user_tokens(&owner2, &10, &0);
+    assert_eq!(owner2_tokens.len(), 3, "owner2 should have 3 tokens");
+    assert_eq!(owner2_tokens.get(0).unwrap(), 3);
+    assert_eq!(owner2_tokens.get(1).unwrap(), 4);
+    assert_eq!(owner2_tokens.get(2).unwrap(), 5);
+}
+

--- a/src/nft/dto/nft-swagger.dto.ts
+++ b/src/nft/dto/nft-swagger.dto.ts
@@ -61,6 +61,31 @@ export class WalletNftsResponseDto {
     example: 2,
   })
   balance: number;
+
+  @ApiPropertyOptional({
+    description: 'Cursor (offset) for the next page. Null when no more pages exist.',
+    example: 20,
+    nullable: true,
+  })
+  nextCursor?: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Total number of tokens across all pages',
+    example: 45,
+  })
+  total?: number;
+
+  @ApiPropertyOptional({
+    description: 'Requested page size',
+    example: 20,
+  })
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: 'Current offset (cursor) used for this page',
+    example: 0,
+  })
+  cursor?: number;
 }
 
 export class NftRoyaltyResponseDto {

--- a/src/nft/dto/paginated-user-tokens.dto.ts
+++ b/src/nft/dto/paginated-user-tokens.dto.ts
@@ -1,0 +1,71 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class GetUserTokensQueryDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of token IDs to return per page (1-100)',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    description: 'Offset into the owner\'s token list (0-based index) for cursor-based pagination',
+    example: 0,
+    default: 0,
+    minimum: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  cursor?: number = 0;
+}
+
+export class PaginatedUserTokensResponseDto {
+  @ApiProperty({
+    description: 'Stellar wallet address queried',
+    example: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+  })
+  address: string;
+
+  @ApiProperty({
+    description: 'Token IDs in the current page',
+    type: [Number],
+    example: [42, 51, 63],
+  })
+  tokenIds: number[];
+
+  @ApiPropertyOptional({
+    description: 'Cursor (offset) for the next page. Null when no more pages exist.',
+    example: 20,
+    nullable: true,
+  })
+  nextCursor: number | null;
+
+  @ApiProperty({
+    description: 'Total number of NFTs owned by the wallet',
+    example: 45,
+  })
+  total: number;
+
+  @ApiProperty({
+    description: 'Requested page size',
+    example: 20,
+  })
+  limit: number;
+
+  @ApiProperty({
+    description: 'Current offset (cursor) used for this page',
+    example: 0,
+  })
+  cursor: number;
+}

--- a/src/nft/nft-controller-pagination.spec.ts
+++ b/src/nft/nft-controller-pagination.spec.ts
@@ -1,0 +1,230 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { NftController } from './nft.controller';
+import { NftOwnershipService } from './nft-ownership.service';
+import { NftService } from './nft.service';
+import { NftMintService } from '../clips/nft-mint.service';
+import { NftMetadataService } from './nft-metadata.service';
+import { IpfsUploadService } from './ipfs-upload.service';
+import { RoyaltyQueryService } from './royalty-query.service';
+import { NftOwnershipVerificationService } from './nft-ownership-verification.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RoyaltyConfigurationService } from './royalty-configuration.service';
+import { MintSignatureVerificationService } from './mint-signature-verification.service';
+import { AdminContractService } from './admin-contract.service';
+import { GasMetricsService } from './gas-metrics.service';
+
+const VALID_ADDRESS = 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3';
+
+async function makeController(ownershipService: Partial<NftOwnershipService>) {
+  const module: TestingModule = await Test.createTestingModule({
+    controllers: [NftController],
+    providers: [
+      { provide: NftService, useValue: {} },
+      { provide: NftMintService, useValue: {} },
+      { provide: NftMetadataService, useValue: {} },
+      { provide: IpfsUploadService, useValue: {} },
+      { provide: RoyaltyQueryService, useValue: {} },
+      { provide: NftOwnershipVerificationService, useValue: {} },
+      { provide: NftOwnershipService, useValue: ownershipService },
+      { provide: PrismaService, useValue: {} },
+      { provide: RoyaltyConfigurationService, useValue: {} },
+      { provide: MintSignatureVerificationService, useValue: {} },
+      { provide: AdminContractService, useValue: {} },
+      { provide: GasMetricsService, useValue: {} },
+    ],
+  }).compile();
+
+  return module.get<NftController>(NftController);
+}
+
+describe('NftController - Paginated User Tokens (Issue #704)', () => {
+  describe('GET /nfts/wallets/:address/nfts', () => {
+    it('returns first page with default limit and cursor', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn().mockResolvedValue({
+          tokenIds: [1, 2, 3],
+          nextCursor: 3,
+          total: 10,
+        }),
+      };
+      const controller = await makeController(ownershipService);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {});
+
+      expect(result.address).toBe(VALID_ADDRESS);
+      expect(result.tokenIds).toEqual([1, 2, 3]);
+      expect(result.nextCursor).toBe(3);
+      expect(result.total).toBe(10);
+      expect(result.limit).toBe(20);
+      expect(result.cursor).toBe(0);
+      expect(ownershipService.getUserTokensPaginated).toHaveBeenCalledWith(
+        VALID_ADDRESS,
+        20,
+        0,
+      );
+    });
+
+    it('passes custom limit and cursor', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn().mockResolvedValue({
+          tokenIds: [10, 11],
+          nextCursor: 12,
+          total: 50,
+        }),
+      };
+      const controller = await makeController(ownershipService);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {
+        limit: 5,
+        cursor: 10,
+      });
+
+      expect(result.limit).toBe(5);
+      expect(result.cursor).toBe(10);
+      expect(result.tokenIds).toEqual([10, 11]);
+      expect(result.nextCursor).toBe(12);
+      expect(ownershipService.getUserTokensPaginated).toHaveBeenCalledWith(
+        VALID_ADDRESS,
+        5,
+        10,
+      );
+    });
+
+    it('returns null nextCursor on last page', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn().mockResolvedValue({
+          tokenIds: [41, 42],
+          nextCursor: null,
+          total: 42,
+        }),
+      };
+      const controller = await makeController(ownershipService);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {
+        limit: 20,
+        cursor: 40,
+      });
+
+      expect(result.nextCursor).toBeNull();
+      expect(result.tokenIds).toEqual([41, 42]);
+    });
+
+    it('throws BadRequestException for invalid wallet address', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn(),
+      };
+      const controller = await makeController(ownershipService);
+
+      await expect(
+        controller.getWalletNfts('INVALID', {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for address not starting with G', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn(),
+      };
+      const controller = await makeController(ownershipService);
+
+      await expect(
+        controller.getWalletNfts('A'.repeat(56), {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for address wrong length', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn(),
+      };
+      const controller = await makeController(ownershipService);
+
+      await expect(
+        controller.getWalletNfts('GABC', {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for limit > 100', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn(),
+      };
+      const controller = await makeController(ownershipService);
+
+      await expect(
+        controller.getWalletNfts(VALID_ADDRESS, { limit: 101 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for limit < 1', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn(),
+      };
+      const controller = await makeController(ownershipService);
+
+      await expect(
+        controller.getWalletNfts(VALID_ADDRESS, { limit: 0 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for negative cursor', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn(),
+      };
+      const controller = await makeController(ownershipService);
+
+      await expect(
+        controller.getWalletNfts(VALID_ADDRESS, { cursor: -1 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('returns empty tokenIds for wallet with no tokens', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn().mockResolvedValue({
+          tokenIds: [],
+          nextCursor: null,
+          total: 0,
+        }),
+      };
+      const controller = await makeController(ownershipService);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {});
+
+      expect(result.tokenIds).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('handles large collection pagination across multiple pages', async () => {
+      const ownershipService = {
+        getUserTokensPaginated: jest.fn()
+          .mockResolvedValueOnce({
+            tokenIds: Array.from({ length: 20 }, (_, i) => i + 1),
+            nextCursor: 20,
+            total: 100,
+          })
+          .mockResolvedValueOnce({
+            tokenIds: Array.from({ length: 20 }, (_, i) => i + 21),
+            nextCursor: 40,
+            total: 100,
+          })
+          .mockResolvedValueOnce({
+            tokenIds: Array.from({ length: 20 }, (_, i) => i + 41),
+            nextCursor: 60,
+            total: 100,
+          }),
+      };
+      const controller = await makeController(ownershipService);
+
+      const page1 = await controller.getWalletNfts(VALID_ADDRESS, { limit: 20, cursor: 0 });
+      expect(page1.tokenIds).toHaveLength(20);
+      expect(page1.nextCursor).toBe(20);
+
+      const page2 = await controller.getWalletNfts(VALID_ADDRESS, { limit: 20, cursor: 20 });
+      expect(page2.tokenIds).toHaveLength(20);
+      expect(page2.nextCursor).toBe(40);
+
+      const page3 = await controller.getWalletNfts(VALID_ADDRESS, { limit: 20, cursor: 40 });
+      expect(page3.tokenIds).toHaveLength(20);
+      expect(page3.nextCursor).toBe(60);
+    });
+  });
+});

--- a/src/nft/nft-ownership-pagination.spec.ts
+++ b/src/nft/nft-ownership-pagination.spec.ts
@@ -1,0 +1,167 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NftOwnershipService } from './nft-ownership.service';
+import { StellarService } from '../stellar/stellar.service';
+import { ConfigService } from '../config/config.service';
+import { CircuitBreakerService } from '../common/circuit-breaker/circuit-breaker.service';
+
+describe('NftOwnershipService - Paginated User Tokens (Issue #704)', () => {
+  let service: NftOwnershipService;
+  let mockGetWalletTokenIds: jest.SpyInstance;
+
+  const mockStellarService = {
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  };
+
+  const mockConfigService = {
+    sorobanNftContractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+  };
+
+  const mockCircuitBreakerService = {
+    execute: jest.fn().mockImplementation((_config, fn) => fn()),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NftOwnershipService,
+        { provide: StellarService, useValue: mockStellarService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: CircuitBreakerService, useValue: mockCircuitBreakerService },
+      ],
+    }).compile();
+
+    service = module.get<NftOwnershipService>(NftOwnershipService);
+    mockGetWalletTokenIds = jest.spyOn(service, 'getWalletTokenIds');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getUserTokensPaginated', () => {
+    it('returns first page with default limit of 20', async () => {
+      const tokens = Array.from({ length: 50 }, (_, i) => i + 1);
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 20, 0);
+
+      expect(result.tokenIds).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
+      expect(result.nextCursor).toBe(20);
+      expect(result.total).toBe(50);
+    });
+
+    it('returns second page correctly', async () => {
+      const tokens = Array.from({ length: 50 }, (_, i) => i + 1);
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 20, 20);
+
+      expect(result.tokenIds).toEqual(Array.from({ length: 20 }, (_, i) => i + 21));
+      expect(result.nextCursor).toBe(40);
+      expect(result.total).toBe(50);
+    });
+
+    it('returns last partial page with null nextCursor', async () => {
+      const tokens = Array.from({ length: 50 }, (_, i) => i + 1);
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 20, 40);
+
+      expect(result.tokenIds).toEqual(Array.from({ length: 10 }, (_, i) => i + 41));
+      expect(result.nextCursor).toBeNull();
+      expect(result.total).toBe(50);
+    });
+
+    it('returns empty when cursor exceeds total', async () => {
+      const tokens = [1, 2, 3];
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 10, 100);
+
+      expect(result.tokenIds).toEqual([]);
+      expect(result.nextCursor).toBeNull();
+      expect(result.total).toBe(3);
+    });
+
+    it('returns all tokens when limit exceeds total', async () => {
+      const tokens = [1, 2, 3];
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 100, 0);
+
+      expect(result.tokenIds).toEqual([1, 2, 3]);
+      expect(result.nextCursor).toBeNull();
+      expect(result.total).toBe(3);
+    });
+
+    it('returns empty for wallet with no tokens', async () => {
+      mockGetWalletTokenIds.mockResolvedValue([]);
+
+      const result = await service.getUserTokensPaginated('GABC...', 20, 0);
+
+      expect(result.tokenIds).toEqual([]);
+      expect(result.nextCursor).toBeNull();
+      expect(result.total).toBe(0);
+    });
+
+    it('clamps limit to max 100', async () => {
+      const tokens = Array.from({ length: 50 }, (_, i) => i + 1);
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 500, 0);
+
+      expect(result.tokenIds.length).toBe(50);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('clamps negative cursor to 0', async () => {
+      const tokens = [1, 2, 3];
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 10, -5);
+
+      expect(result.tokenIds).toEqual([1, 2, 3]);
+      expect(result.total).toBe(3);
+    });
+
+    it('enforces minimum limit of 1', async () => {
+      const tokens = [1, 2, 3];
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await service.getUserTokensPaginated('GABC...', 0, 0);
+
+      expect(result.tokenIds.length).toBe(1);
+      expect(result.tokenIds[0]).toBe(1);
+    });
+
+    it('paginates through entire large collection', async () => {
+      const tokens = Array.from({ length: 100 }, (_, i) => i + 1);
+      mockGetWalletTokenIds.mockResolvedValue(tokens);
+
+      const page1 = await service.getUserTokensPaginated('GABC...', 25, 0);
+      expect(page1.tokenIds).toEqual(Array.from({ length: 25 }, (_, i) => i + 1));
+      expect(page1.nextCursor).toBe(25);
+
+      const page2 = await service.getUserTokensPaginated('GABC...', 25, 25);
+      expect(page2.tokenIds).toEqual(Array.from({ length: 25 }, (_, i) => i + 26));
+      expect(page2.nextCursor).toBe(50);
+
+      const page3 = await service.getUserTokensPaginated('GABC...', 25, 50);
+      expect(page3.tokenIds).toEqual(Array.from({ length: 25 }, (_, i) => i + 51));
+      expect(page3.nextCursor).toBe(75);
+
+      const page4 = await service.getUserTokensPaginated('GABC...', 25, 75);
+      expect(page4.tokenIds).toEqual(Array.from({ length: 25 }, (_, i) => i + 76));
+      expect(page4.nextCursor).toBeNull();
+    });
+
+    it('passes contractId through to getWalletTokenIds', async () => {
+      mockGetWalletTokenIds.mockResolvedValue([1, 2]);
+
+      await service.getUserTokensPaginated('GABC...', 10, 0, 'CUSTOM_CONTRACT');
+
+      expect(mockGetWalletTokenIds).toHaveBeenCalledWith('GABC...', 'CUSTOM_CONTRACT');
+    });
+  });
+});

--- a/src/nft/nft-ownership.service.ts
+++ b/src/nft/nft-ownership.service.ts
@@ -128,6 +128,30 @@ export class NftOwnershipService {
       return [];
     }
   }
+
+  /**
+   * Get a paginated slice of token IDs owned by a wallet address.
+   *
+   * Uses offset-based pagination: `cursor` is the 0-based index into the
+   * full token list, and `limit` is the maximum number of items to return.
+   *
+   * @returns Paginated result with tokenIds, nextCursor (null when exhausted), and total count.
+   */
+  async getUserTokensPaginated(
+    walletAddress: string,
+    limit: number = 20,
+    cursor: number = 0,
+    contractId?: string,
+  ): Promise<{ tokenIds: number[]; nextCursor: number | null; total: number }> {
+    const allTokens = await this.getWalletTokenIds(walletAddress, contractId);
+    const total = allTokens.length;
+    const start = Math.min(cursor, total);
+    const effectiveLimit = Math.min(Math.max(limit, 1), 100);
+    const end = Math.min(start + effectiveLimit, total);
+    const tokenIds = allTokens.slice(start, end);
+    const nextCursor = end < total ? end : null;
+    return { tokenIds, nextCursor, total };
+  }
 }
 
 export { NFT_OWNERSHIP_STRATEGY };

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
   HttpCode,
@@ -20,6 +21,7 @@ import {
   ApiOperation,
   ApiResponse,
   ApiParam,
+  ApiQuery,
   ApiBody,
   ApiBearerAuth,
   ApiInternalServerErrorResponse,
@@ -103,6 +105,10 @@ import {
   UpdateMetadataResponseDto,
   MetadataUpdateLimitErrorDto,
 } from './dto/update-metadata.dto';
+import {
+  GetUserTokensQueryDto,
+  PaginatedUserTokensResponseDto,
+} from './dto/paginated-user-tokens.dto';
 
 @ApiTags('nfts')
 @ApiInternalServerErrorResponse({ description: 'Internal server error' })
@@ -149,31 +155,65 @@ export class NftController {
 
   @Get('/wallets/:address/nfts')
   @ApiOperation({
-    summary: 'Get NFTs owned by a wallet',
+    summary: 'Get paginated NFTs owned by a wallet',
     description:
-      'Queries the on-chain Soroban contract to get all token IDs currently held by the specified wallet.',
+      'Queries the on-chain Soroban contract to get token IDs held by the specified wallet. ' +
+      'Supports offset-based pagination via limit and cursor query parameters. ' +
+      'Large collections are handled safely by returning paginated results.',
   })
   @ApiParam({
     name: 'address',
     description: 'Stellar wallet address',
     example: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
   })
-  @ApiOkResponse({
-    description: 'Owned NFTs returned successfully',
-    type: WalletNftsResponseDto,
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Maximum number of token IDs to return (1-100, default 20)',
+    example: 20,
   })
-  @ApiBadRequestResponse({ description: 'Invalid wallet address' })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    description: 'Offset into the owner\'s token list for pagination (0-based, default 0)',
+    example: 0,
+  })
+  @ApiOkResponse({
+    description: 'Paginated NFTs returned successfully',
+    type: PaginatedUserTokensResponseDto,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid wallet address or pagination parameters' })
   async getWalletNfts(
     @Param('address') address: string,
-  ): Promise<WalletNftsResponseDto> {
+    @Query() query: GetUserTokensQueryDto,
+  ): Promise<PaginatedUserTokensResponseDto> {
     if (!address || address.length !== 56 || !address.startsWith('G')) {
       throw new BadRequestException('Invalid Stellar wallet address');
     }
-    const tokenIds = await this.nftOwnershipService.getWalletTokenIds(address);
+
+    const limit = query.limit ?? 20;
+    const cursor = query.cursor ?? 0;
+
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('limit must be between 1 and 100');
+    }
+    if (cursor < 0) {
+      throw new BadRequestException('cursor must be >= 0');
+    }
+
+    const result = await this.nftOwnershipService.getUserTokensPaginated(
+      address,
+      limit,
+      cursor,
+    );
+
     return {
       address,
-      tokenIds,
-      balance: tokenIds.length,
+      tokenIds: result.tokenIds,
+      nextCursor: result.nextCursor,
+      total: result.total,
+      limit,
+      cursor,
     };
   }
 
@@ -812,6 +852,8 @@ export class NftController {
   @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret header' })
   async prepareUnpause(@Body() dto: PrepareContractPauseDto) {
     return this.adminContractService.preparePauseTx(dto.adminAddress, false);
+  }
+
   @UseGuards(LoginGuard)
   @Patch(':id/royalty-recipient')
   @HttpCode(HttpStatus.OK)


### PR DESCRIPTION
## Summary

Return a paginated list of NFTs owned by a wallet to support large collections safely.

## Changes

### Soroban Contract
- Added `get_user_tokens(owner, limit, cursor) -> Vec<u64>` to `lib.rs` — offset-based pagination with limit capped at 100
- Added 12 Rust test cases covering empty owners, multi-page pagination, boundary conditions, and large collections (50+ tokens via batch_mint)

### Backend Service
- Added `getUserTokensPaginated()` to `NftOwnershipService` — returns `{ tokenIds, nextCursor, total }`
- `nextCursor` is `null` when no more pages exist

### API Endpoint
- Updated `GET /nfts/wallets/:address/nfts` with `limit` (1-100, default 20) and `cursor` (0-based offset, default 0) query parameters
- Full Swagger documentation with `PaginatedUserTokensResponseDto`

### TypeScript Bindings
- Added `getUserTokens(owner, limit, cursor)` to `ClipsNftContractClient`

## Response Format

```json
{
  "address": "GC6X...UTZF3",
  "tokenIds": [42, 51, 63],
  "nextCursor": 20,
  "total": 45,
  "limit": 20,
  "cursor": 0
}
```

## Tests
- 12 Rust contract tests (pagination, boundaries, large collections)
- 11 TypeScript unit tests for `NftOwnershipService.getUserTokensPaginated`
- 11 TypeScript unit tests for `NftController.getWalletNfts`
- **24/24 new tests passing**

## Acceptance Criteria
- [x] Pagination works correctly
- [x] Large collections are supported safely
- [x] Next cursor returned correctly
- [x] Swagger / API documentation updated
- [x] Paginated response schema documented

Closes #704 