### PR TITLE
feat(#676): emergency withdraw for stuck XLM with 24h timelock

### DIFF
--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -82,6 +82,14 @@ pub enum Error {
     InvalidBatchSize = 13,
     /// One-time metadata update limit reached for token ID.
     MetadataAlreadyUpdated = 14,
+    /// withdraw_xlm called before initiate_withdraw (Issue #676).
+    WithdrawNotInitiated = 15,
+    /// withdraw_xlm called before the 24-hour timelock has elapsed (Issue #676).
+    WithdrawTimelockActive = 16,
+    /// withdraw_xlm amount must be greater than zero (Issue #676).
+    InvalidWithdrawAmount = 17,
+    /// XLM token SAC address has not been configured (Issue #676).
+    XlmTokenNotConfigured = 18,
 }
 
 #[contractimpl]
@@ -835,6 +843,86 @@ impl ClipsNftContract {
     pub fn get_nonce(env: Env, caller: Address) -> u64 {
         storage::get_nonce(&env, &caller)
     }
+
+    // ── Issue #676: Emergency withdraw for stuck XLM ────────────────────────
+
+    /// Initiate a 24-hour timelock before XLM can be withdrawn (Issue #676).
+    ///
+    /// The admin calls this first to start the clock. After 24 hours have
+    /// passed, `withdraw_xlm` can be executed. This two-step design prevents
+    /// accidental or malicious instant drains.
+    ///
+    /// Only the contract admin may call this function.
+    pub fn initiate_withdraw(env: Env) -> Result<u64, Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        let unlock_time = env.ledger().timestamp() + storage::WITHDRAW_TIMELOCK_SECS;
+        storage::set_withdraw_unlock_time(&env, unlock_time);
+
+        events::emit_withdraw_initiated(&env, &admin, unlock_time);
+        Ok(unlock_time)
+    }
+
+    /// Return the timestamp (Unix seconds) when a pending withdraw becomes
+    /// executable, or `None` when no initiation is pending (Issue #676).
+    pub fn get_withdraw_unlock_time(env: Env) -> Option<u64> {
+        storage::get_withdraw_unlock_time(&env)
+    }
+
+    /// Withdraw accidentally-stuck XLM to `recipient` (Issue #676).
+    ///
+    /// Requirements:
+    ///   - Caller must be the contract admin.
+    ///   - `initiate_withdraw()` must have been called at least 24 hours ago.
+    ///   - `amount_stroops` must be > 0.
+    ///
+    /// On success the timelock is cleared and a `withdraw_xlm` event is
+    /// emitted so the transaction is auditable on-chain.
+    pub fn withdraw_xlm(
+        env: Env,
+        recipient: Address,
+        amount_stroops: i128,
+    ) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if amount_stroops <= 0 {
+            return Err(Error::InvalidWithdrawAmount);
+        }
+
+        let unlock_time = storage::get_withdraw_unlock_time(&env)
+            .ok_or(Error::WithdrawNotInitiated)?;
+
+        if env.ledger().timestamp() < unlock_time {
+            return Err(Error::WithdrawTimelockActive);
+        }
+
+        // Clear timelock before transferring (checks-effects-interactions).
+        storage::clear_withdraw_unlock_time(&env);
+
+        // Transfer native XLM from the contract's own balance to recipient.
+        let xlm_token_address = storage::get_xlm_token_address(&env)
+            .ok_or(Error::XlmTokenNotConfigured)?;
+        let token_client = token::Client::new(&env, &xlm_token_address);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &amount_stroops,
+        );
+
+        events::emit_withdraw_xlm(&env, &admin, &recipient, amount_stroops);
+        Ok(())
+    }
+
+    /// Set the XLM Stellar Asset Contract (SAC) address used by
+    /// `withdraw_xlm`. Only the admin may call this (Issue #676).
+    pub fn set_xlm_token_address(env: Env, xlm_token: Address) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        storage::set_xlm_token_address(&env, &xlm_token);
+        Ok(())
+    }
 }
 
 mod events {
@@ -912,6 +1000,28 @@ mod events {
     pub fn emit_upgrade(env: &Env, new_wasm_hash: &BytesN<32>) {
         let topics = (Symbol::new(env, "upgrade"),);
         env.events().publish(topics, (new_wasm_hash.clone(),));
+    }
+
+    /// Emitted when the admin calls `initiate_withdraw()` (Issue #676).
+    /// `unlock_time` is the Unix timestamp after which `withdraw_xlm` may run.
+    pub fn emit_withdraw_initiated(env: &Env, admin: &Address, unlock_time: u64) {
+        let topics = (Symbol::new(env, "withdraw_init"), admin.clone());
+        env.events().publish(topics, unlock_time);
+    }
+
+    /// Emitted on a successful `withdraw_xlm()` execution (Issue #676).
+    pub fn emit_withdraw_xlm(
+        env: &Env,
+        admin: &Address,
+        recipient: &Address,
+        amount_stroops: i128,
+    ) {
+        let topics = (
+            Symbol::new(env, "withdraw_xlm"),
+            admin.clone(),
+            recipient.clone(),
+        );
+        env.events().publish(topics, amount_stroops);
     }
 
     pub fn emit_royalty_recipient_updated(

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -330,3 +330,47 @@ pub fn is_verified_clip(env: &Env, clip_hash: &BytesN<32>) -> bool {
         .get(&(Symbol::new(env, "vclip"), clip_hash.clone()))
         .unwrap_or(false)
 }
+
+// ── Issue #676: Emergency withdraw timelock ─────────────────────────────────
+
+/// 24 hours expressed in seconds.
+pub const WITHDRAW_TIMELOCK_SECS: u64 = 86_400;
+
+const WITHDRAW_UNLOCK_KEY: &str = "wdraw_unlock";
+const XLM_TOKEN_KEY: &str = "xlm_token";
+
+/// Persist the timestamp after which `withdraw_xlm` may execute.
+pub fn set_withdraw_unlock_time(env: &Env, unlock_time: u64) {
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, WITHDRAW_UNLOCK_KEY), &unlock_time);
+}
+
+/// Retrieve the pending unlock timestamp, or `None` when not initiated.
+pub fn get_withdraw_unlock_time(env: &Env) -> Option<u64> {
+    env.storage()
+        .instance()
+        .get(&Symbol::new(env, WITHDRAW_UNLOCK_KEY))
+}
+
+/// Clear the timelock after a successful withdrawal so it cannot be
+/// re-used without a fresh `initiate_withdraw` call.
+pub fn clear_withdraw_unlock_time(env: &Env) {
+    env.storage()
+        .instance()
+        .remove(&Symbol::new(env, WITHDRAW_UNLOCK_KEY));
+}
+
+/// Persist the XLM Stellar Asset Contract (SAC) address.
+pub fn set_xlm_token_address(env: &Env, address: &Address) {
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, XLM_TOKEN_KEY), address);
+}
+
+/// Retrieve the configured XLM SAC address.
+pub fn get_xlm_token_address(env: &Env) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get(&Symbol::new(env, XLM_TOKEN_KEY))
+}

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -844,6 +844,247 @@ export class NftController {
     );
   }
 
+  // ── Issue #676: Emergency withdraw for stuck XLM ────────────────────────
+
+  /**
+   * POST /nfts/admin/withdraw/initiate
+   *
+   * Starts the 24-hour timelock before XLM can be withdrawn. Admin must
+   * call this first; `withdraw_xlm` only executes after the lock expires.
+   */
+  @UseGuards(AdminGuard)
+  @Post('admin/withdraw/initiate')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Initiate the 24-hour emergency-withdraw timelock (Issue #676)',
+    description:
+      'Calls `initiate_withdraw()` on the Soroban contract. The contract ' +
+      'records `now + 86400s` as the earliest time `withdraw_xlm` may run. ' +
+      'Requires the x-admin-secret header. Returns an unsigned XDR for signing.',
+  })
+  @ApiBody({
+    schema: { example: { adminAddress: 'GC6X...UTZF3' } },
+  })
+  @ApiOkResponse({
+    description: 'Timelock initiation XDR returned',
+    schema: {
+      example: {
+        xdr: 'AAAA...',
+        action: 'initiate_withdraw',
+        unlockAfterSeconds: 86400,
+        contractId: 'CAA...',
+        network: 'testnet',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret' })
+  async prepareInitiateWithdraw(@Body() body: { adminAddress: string }) {
+    const StellarSdk = (await import('@stellar/stellar-sdk')).default;
+    const contractId =
+      process.env.SOROBAN_NFT_CONTRACT_ID ??
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
+    const rpcUrl =
+      (this as any).stellarService?.rpcUrl ??
+      process.env.SOROBAN_RPC_URL ??
+      'https://soroban-testnet.stellar.org';
+    const networkPassphrase =
+      (this as any).stellarService?.networkPassphrase ??
+      'Test SDF Network ; September 2015';
+
+    const server = new StellarSdk.rpc.Server(rpcUrl);
+    const contract = new StellarSdk.Contract(contractId);
+    const sourceAccount = await server.getAccount(body.adminAddress);
+
+    const op = contract.call('initiate_withdraw');
+
+    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: '10000',
+      networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    return {
+      xdr: tx.toXDR(),
+      action: 'initiate_withdraw',
+      unlockAfterSeconds: 86400,
+      contractId,
+      network: (this as any).stellarService?.network ?? process.env.STELLAR_NETWORK ?? 'testnet',
+    };
+  }
+
+  /**
+   * GET /nfts/admin/withdraw/timelock-status
+   *
+   * Queries the on-chain unlock timestamp so admins can see how long
+   * remains before the withdraw is executable (Issue #676).
+   */
+  @UseGuards(AdminGuard)
+  @Get('admin/withdraw/timelock-status')
+  @ApiOperation({
+    summary: 'Get emergency-withdraw timelock status (Issue #676)',
+    description:
+      'Queries `get_withdraw_unlock_time()` on the Soroban contract. ' +
+      'Returns the Unix timestamp after which withdrawal is allowed, ' +
+      'or null when no initiation is pending.',
+  })
+  @ApiOkResponse({
+    description: 'Timelock status returned',
+    schema: {
+      example: {
+        unlockTime: 1754042400,
+        unlockTimeIso: '2026-08-01T18:00:00.000Z',
+        secondsRemaining: 82345,
+        ready: false,
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret' })
+  async getWithdrawTimelockStatus(): Promise<{
+    unlockTime: number | null;
+    unlockTimeIso: string | null;
+    secondsRemaining: number;
+    ready: boolean;
+  }> {
+    const StellarSdk = (await import('@stellar/stellar-sdk')).default;
+    const contractId =
+      process.env.SOROBAN_NFT_CONTRACT_ID ??
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
+    const rpcUrl =
+      (this as any).stellarService?.rpcUrl ??
+      'https://soroban-testnet.stellar.org';
+    const networkPassphrase =
+      (this as any).stellarService?.networkPassphrase ??
+      'Test SDF Network ; September 2015';
+
+    const server = new StellarSdk.rpc.Server(rpcUrl);
+    const contract = new StellarSdk.Contract(contractId);
+    const dummyAccount = new StellarSdk.Account(
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      '0',
+    );
+
+    const op = contract.call('get_withdraw_unlock_time');
+    const tx = new StellarSdk.TransactionBuilder(dummyAccount, {
+      fee: '100',
+      networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    const simulation = await server.simulateTransaction(tx);
+    const results = (simulation as { results?: Array<{ xdr: string }> }).results;
+
+    if (!results?.[0]?.xdr) {
+      return { unlockTime: null, unlockTimeIso: null, secondsRemaining: 0, ready: false };
+    }
+
+    const returnValue = StellarSdk.xdr.ScVal.fromXDR(results[0].xdr, 'base64');
+    const native = StellarSdk.scValToNative(returnValue);
+    // Option<u64> returns null or a bigint/number
+    if (native == null) {
+      return { unlockTime: null, unlockTimeIso: null, secondsRemaining: 0, ready: false };
+    }
+
+    const unlockTime = Number(native);
+    const nowSecs = Math.floor(Date.now() / 1000);
+    const secondsRemaining = Math.max(0, unlockTime - nowSecs);
+
+    return {
+      unlockTime,
+      unlockTimeIso: new Date(unlockTime * 1000).toISOString(),
+      secondsRemaining,
+      ready: secondsRemaining === 0,
+    };
+  }
+
+  /**
+   * POST /nfts/admin/withdraw/execute
+   *
+   * Executes the emergency XLM withdrawal after the 24h timelock has passed.
+   * Prepares an unsigned Soroban `withdraw_xlm` XDR (Issue #676).
+   */
+  @UseGuards(AdminGuard)
+  @Post('admin/withdraw/execute')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Prepare emergency withdraw_xlm XDR (admin-only, Issue #676)',
+    description:
+      'Builds an unsigned Soroban `withdraw_xlm(recipient, amount_stroops)` ' +
+      'transaction. Can only succeed after the 24-hour timelock set by ' +
+      '`initiate_withdraw` has elapsed. Returns XDR for the admin wallet to sign.',
+  })
+  @ApiBody({
+    schema: {
+      example: {
+        adminAddress: 'GC6X...UTZF3',
+        recipientAddress: 'GDEST...ABC',
+        amountStroops: '10000000',
+      },
+    },
+  })
+  @ApiOkResponse({
+    description: 'Unsigned withdraw_xlm XDR returned',
+    schema: {
+      example: {
+        xdr: 'AAAA...',
+        recipient: 'GDEST...',
+        amountStroops: '10000000',
+        contractId: 'CAA...',
+        network: 'testnet',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret' })
+  @ApiBadRequestResponse({ description: 'Amount must be > 0' })
+  async prepareWithdrawXlm(
+    @Body() body: { adminAddress: string; recipientAddress: string; amountStroops: string },
+  ) {
+    const amountStroops = BigInt(body.amountStroops ?? '0');
+    if (amountStroops <= 0n) {
+      throw new BadRequestException('amountStroops must be greater than 0');
+    }
+
+    const StellarSdk = (await import('@stellar/stellar-sdk')).default;
+    const contractId =
+      process.env.SOROBAN_NFT_CONTRACT_ID ??
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
+    const rpcUrl =
+      (this as any).stellarService?.rpcUrl ??
+      'https://soroban-testnet.stellar.org';
+    const networkPassphrase =
+      (this as any).stellarService?.networkPassphrase ??
+      'Test SDF Network ; September 2015';
+
+    const server = new StellarSdk.rpc.Server(rpcUrl);
+    const contract = new StellarSdk.Contract(contractId);
+    const sourceAccount = await server.getAccount(body.adminAddress);
+
+    const op = contract.call(
+      'withdraw_xlm',
+      StellarSdk.Address.fromString(body.recipientAddress).toScVal(),
+      StellarSdk.nativeToScVal(amountStroops, { type: 'i128' }),
+    );
+
+    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: '10000',
+      networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    return {
+      xdr: tx.toXDR(),
+      recipient: body.recipientAddress,
+      amountStroops: body.amountStroops,
+      contractId,
+      network: (this as any).stellarService?.network ?? process.env.STELLAR_NETWORK ?? 'testnet',
+    };
+  }
+
   @Get('deployment-status')
   @ApiOperation({
     summary: 'Verify contract deployment status (Issue #686)',


### PR DESCRIPTION
## Summary

Closes #676

Contracts may receive unintended XLM transfers that need recovery. This PR adds a two-step admin-only emergency withdrawal mechanism: the admin must first call `initiate_withdraw()` to start a 24-hour timelock, then after it expires call `withdraw_xlm()` to recover the funds.

## Changes

### Soroban contract (`contracts/nft-contract/src/`)

**storage.rs**
- `WITHDRAW_TIMELOCK_SECS = 86_400` (24 hours)
- `set/get/clear_withdraw_unlock_time` — persists the unlock timestamp in instance storage
- `set/get_xlm_token_address` — configures the XLM SAC address used for transfers

**lib.rs**
- `initiate_withdraw()` — admin-only; stores `now + 86400s` as unlock time; emits `withdraw_init` event
- `withdraw_xlm(recipient, amount_stroops)` — admin-only; checks timelock, clears it before transfer (checks-effects-interactions pattern), transfers XLM via token SAC, emits `withdraw_xlm` event
- `get_withdraw_unlock_time()` — read-only view returning the pending unlock timestamp
- `set_xlm_token_address()` — admin setter for the XLM SAC address
- New error codes: `WithdrawNotInitiated` (15), `WithdrawTimelockActive` (16), `InvalidWithdrawAmount` (17), `XlmTokenNotConfigured` (18)

### NestJS backend (`src/nft/nft.controller.ts`)
- `POST /nfts/admin/withdraw/initiate` — prepare unsigned `initiate_withdraw` XDR (x-admin-secret required)
- `GET  /nfts/admin/withdraw/timelock-status` — query unlock time, seconds remaining, and ready flag
- `POST /nfts/admin/withdraw/execute` — prepare unsigned `withdraw_xlm` XDR

## Acceptance Criteria
- [x] Only admin can withdraw
- [x] Timelock is enforced (24h between initiate and execute)
- [x] `withdraw_init` and `withdraw_xlm` events are emitted
- [x] Admin-only endpoints documented with Swagger
- [x] Timelock status response includes `secondsRemaining` and `ready` flag