### PR TITLE
feat(wallets): add GET /wallets/:address/nfts with pagination (closes…

### DIFF
--- a/src/wallets/dto/wallet-nfts-query.dto.ts
+++ b/src/wallets/dto/wallet-nfts-query.dto.ts
@@ -1,0 +1,35 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Query parameters for GET /wallets/:address/nfts (Issue #673).
+ * Supports cursor-style pagination via `page` and `limit`.
+ */
+export class WalletNftsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-based)',
+    example: 1,
+    minimum: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Number of token IDs to return per page (max 100)',
+    example: 20,
+    minimum: 1,
+    maximum: 100,
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/wallets/wallet-nfts.spec.ts
+++ b/src/wallets/wallet-nfts.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { WalletsController } from './wallets.controller';
+import { WalletsService } from './wallets.service';
+import { WalletBalanceService } from './wallet-balance.service';
+import { NftOwnershipService } from '../nft/nft-ownership.service';
+import { WalletOwnershipGuard } from './guards/wallet-ownership.guard';
+import { PrismaService } from '../prisma/prisma.service';
+
+const VALID_ADDRESS = 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3';
+
+describe('WalletsController – GET /wallets/:address/nfts (Issue #673)', () => {
+  let controller: WalletsController;
+  let nftOwnershipService: jest.Mocked<NftOwnershipService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WalletsController],
+      providers: [
+        {
+          provide: WalletsService,
+          useValue: {},
+        },
+        {
+          provide: WalletBalanceService,
+          useValue: {},
+        },
+        {
+          provide: NftOwnershipService,
+          useValue: {
+            getWalletTokenIds: jest.fn(),
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
+      ],
+    })
+      .overrideGuard(WalletOwnershipGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<WalletsController>(WalletsController);
+    nftOwnershipService = module.get(NftOwnershipService);
+  });
+
+  describe('getWalletNfts', () => {
+    it('returns paginated token IDs for a valid address', async () => {
+      nftOwnershipService.getWalletTokenIds.mockResolvedValue([1, 2, 3, 4, 5]);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {
+        page: 1,
+        limit: 3,
+      });
+
+      expect(result).toEqual({
+        address: VALID_ADDRESS,
+        tokenIds: [1, 2, 3],
+        total: 5,
+        page: 1,
+        limit: 3,
+        hasNextPage: true,
+      });
+    });
+
+    it('returns correct second page', async () => {
+      nftOwnershipService.getWalletTokenIds.mockResolvedValue([1, 2, 3, 4, 5]);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {
+        page: 2,
+        limit: 3,
+      });
+
+      expect(result).toEqual({
+        address: VALID_ADDRESS,
+        tokenIds: [4, 5],
+        total: 5,
+        page: 2,
+        limit: 3,
+        hasNextPage: false,
+      });
+    });
+
+    it('sets hasNextPage=false when on the last page', async () => {
+      nftOwnershipService.getWalletTokenIds.mockResolvedValue([10, 20]);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.hasNextPage).toBe(false);
+      expect(result.total).toBe(2);
+    });
+
+    it('returns empty tokenIds and total=0 for wallet with no NFTs', async () => {
+      nftOwnershipService.getWalletTokenIds.mockResolvedValue([]);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {});
+
+      expect(result.tokenIds).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.hasNextPage).toBe(false);
+    });
+
+    it('throws BadRequestException for an address that is too short', async () => {
+      await expect(
+        controller.getWalletNfts('GSHORT', {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException for an address that does not start with G', async () => {
+      const invalidAddress = 'X' + VALID_ADDRESS.slice(1);
+      await expect(
+        controller.getWalletNfts(invalidAddress, {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('uses default page=1 and limit=20 when query params are omitted', async () => {
+      const tokens = Array.from({ length: 25 }, (_, i) => i + 1);
+      nftOwnershipService.getWalletTokenIds.mockResolvedValue(tokens);
+
+      const result = await controller.getWalletNfts(VALID_ADDRESS, {});
+
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.tokenIds).toHaveLength(20);
+      expect(result.hasNextPage).toBe(true);
+    });
+  });
+});

--- a/src/wallets/wallets.controller.ts
+++ b/src/wallets/wallets.controller.ts
@@ -1,9 +1,11 @@
 import {
+  BadRequestException,
   Controller,
   Delete,
   Get,
   Param,
   ParseIntPipe,
+  Query,
   Req,
   UseGuards,
   HttpCode,
@@ -17,19 +19,23 @@ import {
   ApiResponse,
   ApiBearerAuth,
   ApiParam,
+  ApiQuery,
   ApiBadRequestResponse,
   ApiUnauthorizedResponse,
   ApiNotFoundResponse,
   ApiInternalServerErrorResponse,
   ApiConflictResponse,
+  ApiOkResponse,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { WalletsService, DisconnectResult } from './wallets.service';
 import { WalletBalanceService } from './wallet-balance.service';
 import { CreateWalletConnectionDto } from './dto/connect-wallet.dto';
+import { WalletNftsQueryDto } from './dto/wallet-nfts-query.dto';
 import { WalletOwnershipGuard } from './guards/wallet-ownership.guard';
 import { WalletBalanceResult } from '../stellar/stellar.service';
+import { NftOwnershipService } from '../nft/nft-ownership.service';
 
 interface AuthRequest extends Request {
   user: { userId: number; email: string | null };
@@ -45,6 +51,7 @@ export class WalletsController {
   constructor(
     private readonly walletsService: WalletsService,
     private readonly walletBalanceService: WalletBalanceService,
+    private readonly nftOwnershipService: NftOwnershipService,
   ) {}
 
   @Get()
@@ -230,5 +237,101 @@ export class WalletsController {
     @Body() dto: CreateWalletConnectionDto,
   ) {
     return this.walletsService.connect(req.user.userId, dto);
+  }
+
+  /**
+   * GET /wallets/:address/nfts
+   * Returns all token IDs owned by the given Stellar wallet address,
+   * with optional pagination (Issue #673).
+   */
+  @Get(':address/nfts')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List NFT token IDs owned by a Stellar wallet address (Issue #673)',
+    description:
+      'Returns all token IDs currently owned by the specified Stellar wallet address. ' +
+      'Supports pagination via `page` and `limit` query parameters. ' +
+      'Large collections are handled safely via result-size limits (max 100 per page). ' +
+      'Authentication is not required — the address is the lookup key.',
+  })
+  @ApiParam({
+    name: 'address',
+    description: 'Stellar wallet address (56-character G... address)',
+    example: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (1-based, default: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Results per page (max 100, default: 20)',
+    example: 20,
+  })
+  @ApiOkResponse({
+    description: 'Paginated list of NFT token IDs owned by the wallet',
+    schema: {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'string',
+          example: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+        },
+        tokenIds: {
+          type: 'array',
+          items: { type: 'number' },
+          example: [42, 51, 99],
+        },
+        total: {
+          type: 'number',
+          description: 'Total number of tokens owned by this wallet',
+          example: 3,
+        },
+        page: { type: 'number', example: 1 },
+        limit: { type: 'number', example: 20 },
+        hasNextPage: {
+          type: 'boolean',
+          description: 'True when there are more pages available',
+          example: false,
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: 'Invalid Stellar wallet address format' })
+  async getWalletNfts(
+    @Param('address') address: string,
+    @Query() query: WalletNftsQueryDto,
+  ) {
+    if (!address || address.length !== 56 || !address.startsWith('G')) {
+      throw new BadRequestException(
+        'Invalid Stellar wallet address: must be a 56-character G... address',
+      );
+    }
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+
+    const allTokenIds = await this.nftOwnershipService.getWalletTokenIds(address);
+    const total = allTokenIds.length;
+
+    // Apply pagination
+    const start = (page - 1) * limit;
+    const end = start + limit;
+    const tokenIds = allTokenIds.slice(start, end);
+    const hasNextPage = end < total;
+
+    return {
+      address,
+      tokenIds,
+      total,
+      page,
+      limit,
+      hasNextPage,
+    };
   }
 }

--- a/src/wallets/wallets.module.ts
+++ b/src/wallets/wallets.module.ts
@@ -7,9 +7,10 @@ import { WalletBalanceService } from './wallet-balance.service';
 import { WalletsController } from './wallets.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { NftOwnershipModule } from '../nft/nft-ownership.module';
 
 @Module({
-  imports: [AuthModule, PrismaModule, StellarModule],
+  imports: [AuthModule, PrismaModule, StellarModule, NftOwnershipModule],
   providers: [
     WalletValidationService,
     WalletManagementService,


### PR DESCRIPTION
Closes #673
Closes #693
Closes #687 

- Add GET /wallets/:address/nfts endpoint to WalletsController
- Support page/limit query params (max 100 per page)
- Return total count, hasNextPage flag for safe large-collection handling
- Import NftOwnershipModule into WalletsModule
- Add WalletNftsQueryDto with validation
- Add unit tests (7 passing)