### PR TITLE
feat(nft): add GET /nfts/:id/exists token existence check (closes #688)

### DIFF
--- a/src/nft/nft-ownership.service.ts
+++ b/src/nft/nft-ownership.service.ts
@@ -128,6 +128,26 @@ export class NftOwnershipService {
       return [];
     }
   }
+
+  /**
+   * Lightweight check: returns true when the token has been minted on-chain,
+   * false when it has not (Issue #688). Uses an efficient storage lookup via
+   * owner_of — no ownership transfer is involved.
+   */
+  async tokenExists(
+    tokenId: string,
+    contractId?: string,
+  ): Promise<boolean> {
+    try {
+      return await this.circuitBreakerService.execute(
+        this.circuitBreakerConfig,
+        () => this.strategy.tokenExists(contractId ?? this.contractId, tokenId),
+      );
+    } catch (error) {
+      this.logger.error(`Failed to check token existence for token ${tokenId}`, error);
+      return false;
+    }
+  }
 }
 
 export { NFT_OWNERSHIP_STRATEGY };

--- a/src/nft/nft-token-exists.spec.ts
+++ b/src/nft/nft-token-exists.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { NftController } from './nft.controller';
+import { NftOwnershipService } from './nft-ownership.service';
+import { NftService } from './nft.service';
+import { NftMintService } from '../clips/nft-mint.service';
+import { NftMetadataService } from './nft-metadata.service';
+import { IpfsUploadService } from './ipfs-upload.service';
+import { RoyaltyQueryService } from './royalty-query.service';
+import { NftOwnershipVerificationService } from './nft-ownership-verification.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RoyaltyConfigurationService } from './royalty-configuration.service';
+import { MintSignatureVerificationService } from './mint-signature-verification.service';
+import { AdminContractService } from './admin-contract.service';
+import { GasMetricsService } from './gas-metrics.service';
+import { NftMintGuard } from './guards/nft-mint.guard';
+import { LoginGuard } from '../auth/guards/login.guard';
+
+describe('NftController – GET /nfts/:id/exists (Issue #688)', () => {
+  let controller: NftController;
+  let nftOwnershipService: jest.Mocked<NftOwnershipService>;
+
+  const mockNftOwnershipService = {
+    tokenExists: jest.fn(),
+    getOwner: jest.fn(),
+    getWalletTokenIds: jest.fn(),
+    verifyNFTOwnership: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NftController],
+      providers: [
+        { provide: NftService, useValue: { mintClip: jest.fn(), batchMintClips: jest.fn(), updateRoyaltyRecipient: jest.fn(), updateMetadata: jest.fn(), updateTokenUri: jest.fn() } },
+        { provide: NftMintService, useValue: { validateClipOwner: jest.fn(), uploadMetadataToIPFS: jest.fn(), prepareMintTx: jest.fn(), confirmMint: jest.fn(), prepareBurnTx: jest.fn(), prepareSetRoyaltiesTx: jest.fn() } },
+        { provide: NftMetadataService, useValue: { build: jest.fn() } },
+        { provide: IpfsUploadService, useValue: {} },
+        { provide: RoyaltyQueryService, useValue: { getRoyaltyInfo: jest.fn(), getRoyaltySplits: jest.fn() } },
+        { provide: NftOwnershipVerificationService, useValue: { verifyNFTOwnership: jest.fn() } },
+        { provide: NftOwnershipService, useValue: mockNftOwnershipService },
+        { provide: PrismaService, useValue: { clip: { findUnique: jest.fn() } } },
+        { provide: RoyaltyConfigurationService, useValue: { getCreatorRoyaltyBps: jest.fn(), getPlatformWallet: jest.fn() } },
+        { provide: MintSignatureVerificationService, useValue: { verify: jest.fn() } },
+        { provide: AdminContractService, useValue: { getPauseStatus: jest.fn(), preparePauseTx: jest.fn() } },
+        { provide: GasMetricsService, useValue: { getStats: jest.fn() } },
+      ],
+    })
+      .overrideGuard(LoginGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(NftMintGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<NftController>(NftController);
+    nftOwnershipService = module.get(NftOwnershipService);
+  });
+
+  describe('tokenExists', () => {
+    it('returns { id, exists: true } when the token has been minted', async () => {
+      mockNftOwnershipService.tokenExists.mockResolvedValue(true);
+
+      const result = await controller.tokenExists(42);
+
+      expect(result).toEqual({ id: 42, exists: true });
+      expect(mockNftOwnershipService.tokenExists).toHaveBeenCalledWith('42');
+    });
+
+    it('returns { id, exists: false } when the token has not been minted', async () => {
+      mockNftOwnershipService.tokenExists.mockResolvedValue(false);
+
+      const result = await controller.tokenExists(99);
+
+      expect(result).toEqual({ id: 99, exists: false });
+      expect(mockNftOwnershipService.tokenExists).toHaveBeenCalledWith('99');
+    });
+
+    it('throws BadRequestException when id is 0', async () => {
+      await expect(controller.tokenExists(0)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when id is negative', async () => {
+      await expect(controller.tokenExists(-1)).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -12,7 +12,6 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  BadRequestException,
   ForbiddenException,
 } from '@nestjs/common';
 import {
@@ -145,6 +144,48 @@ export class NftController {
     }
     const owner = await this.nftOwnershipService.getOwner(id.toString());
     return { owner };
+  }
+
+  /**
+   * GET /nfts/:id/exists
+   * Lightweight token existence check (Issue #688).
+   * Returns { exists: true } when the token has been minted, { exists: false } otherwise.
+   * Does not require authentication — the frontend uses this before any wallet interaction.
+   */
+  @Get(':id/exists')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Check whether an NFT token has been minted (Issue #688)',
+    description:
+      'Lightweight query that returns a boolean indicating whether the token with the given ' +
+      'ID exists on-chain. Uses an efficient Soroban storage lookup (owner_of). ' +
+      'Existing tokens return { exists: true }; non-existent tokens return { exists: false }. ' +
+      'No authentication required.',
+  })
+  @ApiParam({ name: 'id', description: 'Numeric token ID', example: 42 })
+  @ApiOkResponse({
+    description: 'Token existence check result',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 42 },
+        exists: {
+          type: 'boolean',
+          description: 'true when the token has been minted, false otherwise',
+          example: true,
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: 'Invalid token ID format' })
+  async tokenExists(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<{ id: number; exists: boolean }> {
+    if (id <= 0) {
+      throw new BadRequestException('Token ID must be a positive integer');
+    }
+    const exists = await this.nftOwnershipService.tokenExists(id.toString());
+    return { id, exists };
   }
 
   @Get('/wallets/:address/nfts')
@@ -812,6 +853,8 @@ export class NftController {
   @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret header' })
   async prepareUnpause(@Body() dto: PrepareContractPauseDto) {
     return this.adminContractService.preparePauseTx(dto.adminAddress, false);
+  }
+
   @UseGuards(LoginGuard)
   @Patch(':id/royalty-recipient')
   @HttpCode(HttpStatus.OK)

--- a/src/nft/strategies/nft-ownership-verification.strategy.ts
+++ b/src/nft/strategies/nft-ownership-verification.strategy.ts
@@ -22,6 +22,15 @@ export interface NftOwnershipVerificationStrategy {
     contractId: string,
     walletAddress: string,
   ): Promise<number[]>;
+
+  /**
+   * Check whether a token with the given ID has been minted.
+   * Returns true when the token exists on-chain, false otherwise (Issue #688).
+   */
+  tokenExists(
+    contractId: string,
+    tokenId: string,
+  ): Promise<boolean>;
 }
 
 /**
@@ -134,8 +143,7 @@ export class SorobanOwnerOfVerificationStrategy implements NftOwnershipVerificat
   async getWalletTokenIds(
     contractId: string,
     walletAddress: string,
-  ): Promise<number[]> {
-    const server = new StellarSdk.rpc.Server(this.rpcUrl);
+  ): Promise<number[]> {    const server = new StellarSdk.rpc.Server(this.rpcUrl);
     const ownerScVal = new StellarSdk.Address(walletAddress).toScVal();
 
     const ledgerKey = StellarSdk.xdr.LedgerKey.contractData(
@@ -171,5 +179,18 @@ export class SorobanOwnerOfVerificationStrategy implements NftOwnershipVerificat
     } catch (e) {
       return [];
     }
+  }
+
+  /**
+   * Lightweight token existence check (Issue #688).
+   * Calls `owner_of` on the contract — if we get a non-null owner back,
+   * the token exists. If the simulation errors or returns void, it doesn't.
+   */
+  async tokenExists(
+    contractId: string,
+    tokenId: string,
+  ): Promise<boolean> {
+    const owner = await this.getOwner(contractId, tokenId);
+    return owner !== null;
   }
 }


### PR DESCRIPTION
- Add tokenExists() to NftOwnershipVerificationStrategy interface
- Implement tokenExists() in SorobanOwnerOfVerificationStrategy (reuses owner_of for efficient storage lookup)
- Add tokenExists() to NftOwnershipService with circuit-breaker protection
- Add GET /nfts/:id/exists endpoint to NftController (no auth required) returning { id, exists: boolean }
- Fix pre-existing missing closing brace on prepareUnpause method
- Fix pre-existing duplicate BadRequestException import
- Add unit tests (4 passing)

Closes #688 