### PR TITLE
fix(contracts): repair corrupted merge in nft-contract lib.rs/storage.rs

### DIFF
--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
 use soroban_sdk::{
     contract, contracterror, contractimpl, contractmeta, contracttype,
-    token, Address, Env, String, Symbol, Val, Vec,
-    Address, Env, Map, String, Symbol, Val,
-    Address, BytesN, Env, String, Symbol, Val, Vec,
+    token, Address, BytesN, Env, Map, String, Symbol, Val, Vec,
 };
 use soroban_token_sdk::metadata::TokenMetadata;
 
@@ -69,19 +67,19 @@ pub enum Error {
     /// The asset contract address is not on the admin-approved allow-list.
     UnsupportedAsset = 9,
     /// Provided WASM hash is all zeros — cannot upgrade to a no-op contract.
-    InvalidWasmHash = 8,
+    InvalidWasmHash = 10,
     /// Clip signature verification failed — caller is not the clip owner.
-    InvalidSignature = 9,
+    InvalidSignature = 11,
     /// Nonce is stale — replay attack detected.
-    InvalidNonce = 10,
+    InvalidNonce = 12,
     /// Clip hash was not pre-verified by the admin.
-    ClipNotVerified = 11,
+    ClipNotVerified = 13,
     /// Array lengths do not match for batch operation.
-    ArrayLengthMismatch = 12,
+    ArrayLengthMismatch = 14,
     /// Batch size is 0 or exceeds maximum allowable limit.
-    InvalidBatchSize = 13,
+    InvalidBatchSize = 15,
     /// One-time metadata update limit reached for token ID.
-    MetadataAlreadyUpdated = 14,
+    MetadataAlreadyUpdated = 16,
 }
 
 #[contractimpl]
@@ -583,7 +581,7 @@ impl ClipsNftContract {
     /// `amount * royalty_bps / 10_000`, using the token's configured
     /// royalty rate (falling back to the contract default). `payer` must
     /// authorize the call and hold a sufficient balance of `asset`.
-    pub fn pay_royalty(
+    pub fn pay_royalty_with_asset(
         env: Env,
         payer: Address,
         token_id: u64,
@@ -605,8 +603,10 @@ impl ClipsNftContract {
             asset_client.transfer(&payer, &token_data.creator, &royalty_amount);
         }
 
-        events::emit_royalty_paid(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
+        events::emit_royalty_paid_asset(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
         Ok(royalty_amount)
+    }
+
     /// Permanently destroy a token. Only the current owner may burn it.
     ///
     /// Ownership, metadata, royalty overrides and any outstanding approval
@@ -637,6 +637,12 @@ impl ClipsNftContract {
         let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
+        storage::set_platform_fee(&env, &recipient, bps);
+        Ok(())
+    }
+
+    /// Record the royalty payment owed on `token_id`. Emits `royalty_paid`
+    /// with the amount in stroops. `payer` must authorize the call.
     pub fn pay_royalty(
         env: Env,
         token_id: u64,
@@ -658,22 +664,6 @@ impl ClipsNftContract {
             0,
             amount_stroops,
         );
-        Ok(())
-    }
-
-    pub fn set_token_royalty_bps(env: Env, token_id: u64, bps: u32) -> Result<(), Error> {
-        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-
-        if !storage::has_token(&env, token_id) {
-            return Err(Error::TokenNotFound);
-        }
-
-        if bps > storage::ROYALTY_BPS_MAX {
-            return Err(Error::InvalidRoyaltyBps);
-        }
-
-        storage::set_platform_fee(&env, &recipient, bps);
         Ok(())
     }
 
@@ -743,6 +733,20 @@ impl ClipsNftContract {
         }
 
         royalties
+    }
+
+    pub fn set_token_royalty_bps(env: Env, token_id: u64, bps: u32) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if !storage::has_token(&env, token_id) {
+            return Err(Error::TokenNotFound);
+        }
+
+        if bps > storage::ROYALTY_BPS_MAX {
+            return Err(Error::InvalidRoyaltyBps);
+        }
+
         storage::set_token_royalty_bps(&env, token_id, bps);
         Ok(())
     }
@@ -873,6 +877,8 @@ mod events {
     pub fn emit_unpaused(env: &Env, admin: &Address) {
         let topics = (Symbol::new(env, "unpaused"), admin.clone());
         env.events().publish(topics, ());
+    }
+
     pub fn emit_burn(env: &Env, owner: &Address, token_id: u64) {
         let topics = (Symbol::new(env, "burn"), owner.clone());
         env.events().publish(topics, token_id);
@@ -881,12 +887,16 @@ mod events {
     pub fn emit_royalties_updated(env: &Env, token_id: u64, total_bps: u32) {
         let topics = (Symbol::new(env, "royalties_updated"), token_id);
         env.events().publish(topics, total_bps);
+    }
+
     pub fn emit_royalty_updated(env: &Env, old_bps: u32, new_bps: u32) {
         let topics = (Symbol::new(env, "royalty_updated"),);
         env.events().publish(topics, (old_bps, new_bps));
     }
 
-    pub fn emit_royalty_paid(
+    /// Emitted by `pay_royalty_with_asset` when a royalty is paid out in a
+    /// specific Stellar asset contract (SAC).
+    pub fn emit_royalty_paid_asset(
         env: &Env,
         payer: &Address,
         recipient: &Address,
@@ -896,6 +906,12 @@ mod events {
     ) {
         let topics = (Symbol::new(env, "royalty_paid"), payer.clone(), recipient.clone());
         env.events().publish(topics, (asset.clone(), token_id, amount));
+    }
+
+    /// Emitted by `transfer_with_royalty` and `pay_royalty` when a royalty
+    /// amount (in stroops) is computed/paid for a token sale.
+    pub fn emit_royalty_paid(
+        env: &Env,
         recipient: &Address,
         token_id: u64,
         royalty_amount: u64,

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -1,21 +1,17 @@
-use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{Address, BytesN, Env, Map, Symbol, Vec};
 
 use crate::TokenData;
 
 pub struct TokenStorage;
-
-const TOTAL_SUPPLY_KEY: &str = "total_supply";
-const ADMIN_KEY: &str = "admin";
-const DEFAULT_ROYALTY_BPS_KEY: &str = "def_royalty_bps";
-const PAUSED_KEY: &str = "paused";
-const DEFAULT_ROYALTY_ASSET_KEY: &str = "def_royalty_asset";
-const SUPPORTED_ASSETS_KEY: &str = "supported_assets";
 
 // ── Compact storage keys (issue #642) ──────────────────────────────────────
 // Short keys reduce per-entry storage footprint and RPC read latency.
 const TOTAL_SUPPLY_KEY: &str = "ts";
 const ADMIN_KEY: &str = "adm";
 const DEFAULT_ROYALTY_BPS_KEY: &str = "drb";
+const PAUSED_KEY: &str = "paused";
+const DEFAULT_ROYALTY_ASSET_KEY: &str = "def_royalty_asset";
+const SUPPORTED_ASSETS_KEY: &str = "supported_assets";
 
 /// Maximum allowed royalty value in basis points (100% = 10 000 BPS).
 pub const ROYALTY_BPS_MAX: u32 = 10_000;
@@ -190,6 +186,8 @@ pub fn get_supported_assets(env: &Env) -> Vec<Address> {
 
 pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
     get_supported_assets(env).contains(asset)
+}
+
 pub fn remove_token(env: &Env, token_id: u64) {
     env.storage().persistent().remove(&token_id);
 }
@@ -243,6 +241,8 @@ pub fn get_royalty_shares(env: &Env, token_id: u64) -> Option<Map<Address, u32>>
     env.storage()
         .persistent()
         .get(&(token_id, Symbol::new(env, "royalties")))
+}
+
 pub fn set_custom_token_uri(env: &Env, token_id: u64, uri: &soroban_sdk::String) {
     env.storage()
         .persistent()

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -12,7 +12,6 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  BadRequestException,
   ForbiddenException,
 } from '@nestjs/common';
 import {
@@ -812,6 +811,8 @@ export class NftController {
   @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret header' })
   async prepareUnpause(@Body() dto: PrepareContractPauseDto) {
     return this.adminContractService.preparePauseTx(dto.adminAddress, false);
+  }
+
   @UseGuards(LoginGuard)
   @Patch(':id/royalty-recipient')
   @HttpCode(HttpStatus.OK)


### PR DESCRIPTION
## Summary
- `main`'s `contracts/nft-contract/src/lib.rs` currently fails to compile. A prior merge (760ffe8, PR #665) concatenated conflicting branches instead of resolving the conflict, leaving duplicate imports, duplicate `Error` enum discriminants (`8`/`9` each reused), two colliding `pay_royalty`/`emit_royalty_paid` definitions, and unbalanced braces.
- The dedicated Rust CI workflow apparently hasn't run since before that merge, so it went unnoticed.
- Restores a single coherent API: dedupes imports, renumbers `Error` discriminants uniquely, and renames the asset-based royalty payout to `pay_royalty_with_asset` / `emit_royalty_paid_asset` to avoid colliding with the stroops-based `pay_royalty` (which already has test coverage under that name).
- No behavior changes beyond the rename — all 66 existing contract tests pass.

This is a prerequisite fix, not tied to a specific issue — it unblocks building/testing the contract at all. Follow-up PRs for issues #689, #692, #694, #695 are stacked on top of this branch and should be rebased onto `main` once this merges.

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — 66 passed, 0 failed