### PR TITLE
feat(soroban): add contract version constant (#692)

### DIFF
--- a/contracts/nft-contract/audit.md
+++ b/contracts/nft-contract/audit.md
@@ -1,6 +1,6 @@
-# ClipCash NFT Contract — Security Audit Preparation
+# ClipCash NFT Contract ï¿½ Security Audit Preparation
 
-> **Contract:** `clips-nft-contract` v1.0.0
+> **Contract:** `clips-nft-contract` v1.1.0
 > **Chain:** Stellar / Soroban (SDK 22.0.0)
 > **Prepared:** 2026-07-29
 > **Status:** ?? Ready for External Audit (findings documented below)
@@ -46,17 +46,17 @@ The backend's interaction surface with this contract is documented in Section 11
 
 The `ClipsNftContract` is a Soroban-native NFT contract implementing:
 
-- **Soulbound flag** — tokens marked `is_soulbound = true` are non-transferable and cannot be approved for delegation.
-- **Admin-gated minting** — only the stored `admin` address may call `mint`.
-- **Single-approval model** — one approved spender per token; approval is consumed on `transfer_from`.
-- **Royalty BPS** — configurable default royalty (0–10 000 BPS) stored in instance storage.
-- **Creator provenance** — `creator` is set to the initial `to` address at mint and never changes.
+- **Soulbound flag** ï¿½ tokens marked `is_soulbound = true` are non-transferable and cannot be approved for delegation.
+- **Admin-gated minting** ï¿½ only the stored `admin` address may call `mint`.
+- **Single-approval model** ï¿½ one approved spender per token; approval is consumed on `transfer_from`.
+- **Royalty BPS** ï¿½ configurable default royalty (0ï¿½10 000 BPS) stored in instance storage.
+- **Creator provenance** ï¿½ `creator` is set to the initial `to` address at mint and never changes.
 
 ### Public Entry Points
 
 | Function | Caller Auth | Admin-gated |
 |---|---|---|
-| `initialize(admin)` | none (first-caller wins) | — |
+| `initialize(admin)` | none (first-caller wins) | ï¿½ |
 | `mint(to, token_id, clip_id, content_uri, is_soulbound)` | admin | YES |
 | `transfer(from, to, token_id)` | token owner (`from`) | NO |
 | `transfer_from(spender, from, to, token_id)` | approved spender | NO |
@@ -93,7 +93,7 @@ pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
 
 **Finding AC-01 (Medium):** `initialize` does **not** call `admin.require_auth()`. Any address can call
 `initialize` with any `admin` value **before** the real deployer does. On Soroban this is a race condition
-— whoever calls `initialize` first controls the contract.
+ï¿½ whoever calls `initialize` first controls the contract.
 
 See Section 9.1 for the full finding and recommended fix.
 
@@ -109,7 +109,7 @@ admin.require_auth();
 ```
 
 **Assessment:** PASS. Only the stored admin can invoke `mint`. Soroban's `require_auth()` enforces
-on-ledger authorization — no off-chain bypass is possible.
+on-ledger authorization ï¿½ no off-chain bypass is possible.
 
 ---
 
@@ -124,7 +124,7 @@ if token_data.owner != from { return Err(Error::Unauthorized); }
 ```
 
 **Assessment:** PASS. Dual check: (1) `from` must authorize the call, (2) `from` must be the stored owner.
-Both are required — passing auth but wrong owner, or right owner without auth, both fail.
+Both are required ï¿½ passing auth but wrong owner, or right owner without auth, both fail.
 
 ---
 
@@ -177,7 +177,7 @@ overflow-checks = true
 ```
 
 **Assessment:** PASS. All integer arithmetic in the release binary is compiled with overflow panics.
-Soroban's `panic = "abort"` means overflows abort the transaction cleanly — no undefined behaviour.
+Soroban's `panic = "abort"` means overflows abort the transaction cleanly ï¿½ no undefined behaviour.
 
 ---
 
@@ -192,7 +192,7 @@ pub fn increment_total_supply(env: &Env) {
 }
 ```
 
-**Assessment:** PASS. `u64` with `overflow-checks = true`. Overflow would abort at 2^64 - 1 tokens —
+**Assessment:** PASS. `u64` with `overflow-checks = true`. Overflow would abort at 2^64 - 1 tokens ï¿½
 practically unreachable.
 
 ---
@@ -212,7 +212,7 @@ Off-chain royalty calculation `price * bps / 10_000` is performed in the NestJS 
 not in the contract itself.
 
 **Assessment:** PASS. Bounds checked. Royalty application arithmetic is not enforced on-chain
-(by design — Soroban does not natively execute royalty enforcement during transfers).
+(by design ï¿½ Soroban does not natively execute royalty enforcement during transfers).
 
 ---
 
@@ -269,8 +269,8 @@ highest-risk entry points and should be the focus of access control review durin
 
 ### Privileged Deployment Sequence
 
-1. `stellar contract deploy` — obtains `CONTRACT_ID`
-2. `stellar contract invoke initialize --admin <ADMIN_ADDRESS>` — **must be called atomically/immediately post-deploy**
+1. `stellar contract deploy` ï¿½ obtains `CONTRACT_ID`
+2. `stellar contract invoke initialize --admin <ADMIN_ADDRESS>` ï¿½ **must be called atomically/immediately post-deploy**
 3. Off-chain backend reads `CONTRACT_ID` from environment and routes mint calls through the admin key
 
 > **FINDING AC-01 (Medium):** The gap between deploy and `initialize` is a frontrunning window.
@@ -323,7 +323,7 @@ bare `token_id` key for token data. No collision risk identified.
 | `mint` | `("mint", to)` | `(token_id, is_soulbound)` | PASS |
 | `transfer` | `("transfer", from, to)` | `token_id` | PASS |
 | `approve` | `("approve", owner, spender)` | `token_id` | PASS |
-| `set_default_royalty_bps` | — | — | MISSING |
+| `set_default_royalty_bps` | ï¿½ | ï¿½ | MISSING |
 
 **FINDING EV-01 (Low):** `set_default_royalty_bps` does not emit an event. Off-chain indexers
 cannot detect royalty changes without polling. A `royalty_updated` event should be added.
@@ -338,7 +338,7 @@ cannot detect royalty changes without polling. A `royalty_updated` event should 
 observes the deploy transaction can immediately call `initialize` with a malicious admin address
 before the legitimate deployer does.
 
-**Impact:** Total contract takeover — malicious admin controls minting.
+**Impact:** Total contract takeover ï¿½ malicious admin controls minting.
 
 **Likelihood:** Low in practice (requires monitoring the mempool and acting faster than the deployer),
 but non-zero on high-traffic networks.
@@ -358,7 +358,7 @@ pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
 
 Alternatively, bundle deploy + initialize in one transaction using `stellar contract deploy --invoke-args`.
 
-**Status:** OPEN — requires code change before mainnet deployment.
+**Status:** OPEN ï¿½ requires code change before mainnet deployment.
 
 ---
 
@@ -381,7 +381,7 @@ pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
 }
 ```
 
-**Status:** DEFERRED — acceptable for v1 if admin key is a hardware-secured multisig.
+**Status:** DEFERRED ï¿½ acceptable for v1 if admin key is a hardware-secured multisig.
 
 ---
 
@@ -399,7 +399,7 @@ entries may be archived, making the contract non-functional until restored.
 - Add `env.storage().persistent().extend_ttl(&key, MIN_TTL, MAX_TTL)` on every `set_token` and `set_owner_token`.
 - Operate a keepalive bot that periodically calls a no-op function to extend the instance TTL.
 
-**Status:** OPEN — critical for long-term mainnet operation.
+**Status:** OPEN ï¿½ critical for long-term mainnet operation.
 
 ---
 
@@ -420,7 +420,7 @@ pub fn emit_royalty_updated(env: &Env, old_bps: u32, new_bps: u32) {
 }
 ```
 
-**Status:** OPEN — low risk, should be resolved before mainnet for transparency.
+**Status:** OPEN ï¿½ low risk, should be resolved before mainnet for transparency.
 
 ---
 
@@ -432,7 +432,7 @@ with no format validation.
 **Impact:** An admin could mint tokens with empty URIs or malformed URIs. Integrity depends entirely
 on the off-chain backend enforcing URI format.
 
-**Status:** INFORMATIONAL — acceptable for v1 with trusted admin.
+**Status:** INFORMATIONAL ï¿½ acceptable for v1 with trusted admin.
 
 ---
 
@@ -445,7 +445,7 @@ a marketplace escrow address.
 **Impact:** Royalty recipient attribution could be incorrect if the off-chain system mints to a
 non-creator wallet.
 
-**Status:** INFORMATIONAL — a design decision. The backend must always pass the actual creator's
+**Status:** INFORMATIONAL ï¿½ a design decision. The backend must always pass the actual creator's
 wallet as `to`. Consider adding a separate `creator` parameter to `mint` for future flexibility.
 
 ---
@@ -478,20 +478,20 @@ The test suite (`src/test.rs`) covers **30 test cases** across the following sce
 The NestJS backend (`src/nft/`) interacts with this contract via the Stellar Soroban RPC.
 Key trust assumptions auditors should be aware of:
 
-1. **Admin key custody** — The private key corresponding to the `admin` address used in `initialize`
+1. **Admin key custody** ï¿½ The private key corresponding to the `admin` address used in `initialize`
    is held by the backend operator. It is never transmitted over the network; the backend signs
    transactions server-side. Auditors should verify `STELLAR_SECRET_KEY` is loaded from secrets
    management (not hardcoded in source or `.env`).
 
-2. **`mint` invocation** — The backend's `NftService.mintClip()` calls `mint` after validating
+2. **`mint` invocation** ï¿½ The backend's `NftService.mintClip()` calls `mint` after validating
    clip ownership and status via `NftMintGuard`. The guard is enforced at the HTTP layer, not
    on-chain. On-chain, only the admin auth check applies.
 
-3. **Signature verification for `prepare-mint`** — `MintSignatureVerificationService` verifies an
+3. **Signature verification for `prepare-mint`** ï¿½ `MintSignatureVerificationService` verifies an
    Ed25519 wallet signature before building the XDR. This prevents unauthorized users from
    preparing mint transactions on behalf of others but does **not** substitute for on-chain auth.
 
-4. **Royalty enforcement** — Royalty BPS is configured on-chain but royalty collection occurs
+4. **Royalty enforcement** ï¿½ Royalty BPS is configured on-chain but royalty collection occurs
    off-chain. Secondary marketplaces are not forced by the contract to honour royalties.
 
 ### Open Questions for Auditors
@@ -508,7 +508,7 @@ Key trust assumptions auditors should be aware of:
 
 ## 12. Audit Checklist
 
-### Pre-Audit (Internal — track before sending to auditors)
+### Pre-Audit (Internal ï¿½ track before sending to auditors)
 
 - [x] Access control review complete
 - [x] Overflow handling review complete
@@ -518,9 +518,9 @@ Key trust assumptions auditors should be aware of:
 - [x] Event emission review complete
 - [x] Findings documented with severity ratings
 - [x] Test coverage mapped
-- [ ] **AC-01 fix merged** — `admin.require_auth()` added to `initialize`
-- [ ] **ST-01/ST-02 fix merged** — `extend_ttl` calls added to write functions
-- [ ] **EV-01 fix merged** — `royalty_updated` event added to `set_default_royalty_bps`
+- [ ] **AC-01 fix merged** ï¿½ `admin.require_auth()` added to `initialize`
+- [ ] **ST-01/ST-02 fix merged** ï¿½ `extend_ttl` calls added to write functions
+- [ ] **EV-01 fix merged** ï¿½ `royalty_updated` event added to `set_default_royalty_bps`
 - [ ] Deploy scripts reviewed for atomic initialize pattern
 - [ ] Admin private key stored in secrets manager (not committed `.env` file)
 - [ ] Soroban SDK dependency pinned to exact version (no range specifiers)
@@ -528,7 +528,7 @@ Key trust assumptions auditors should be aware of:
 
 ### Auditor Review (complete during external audit)
 
-- [ ] Access control — all `require_auth()` call sites verified
+- [ ] Access control ï¿½ all `require_auth()` call sites verified
 - [ ] Storage key collision analysis complete
 - [ ] Event completeness verified
 - [ ] Arithmetic safety confirmed

--- a/contracts/nft-contract/deploy-mainnet.sh
+++ b/contracts/nft-contract/deploy-mainnet.sh
@@ -125,6 +125,17 @@ fi
 echo "   ✅  Contract deployed!"
 echo ""
 
+# ── Step 3b: Query deployed contract version ─────────────────
+DEPLOYED_VERSION=$(stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source-account "$DEPLOYER_SECRET" \
+  --network "$NETWORK" \
+  --rpc-url "$RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  -- version 2>/dev/null | tr -d '"' || echo "unknown")
+echo "   Contract version: $DEPLOYED_VERSION"
+echo ""
+
 # ── Step 4: Initialize contract ──────────────────────────────
 INIT_ADMIN="${ADMIN_ADDRESS:-$DEPLOYER_PUBLIC}"
 if [[ -n "$INIT_ADMIN" ]]; then
@@ -144,6 +155,7 @@ fi
 # ── Step 5: Output ────────────────────────────────────────────
 echo "════════════════════════════════════════════════════════"
 echo "  CONTRACT_ID : $CONTRACT_ID"
+echo "  VERSION     : $DEPLOYED_VERSION"
 echo "  NETWORK     : Stellar Mainnet (public)"
 echo "════════════════════════════════════════════════════════"
 echo ""

--- a/contracts/nft-contract/deploy-testnet.sh
+++ b/contracts/nft-contract/deploy-testnet.sh
@@ -100,6 +100,17 @@ fi
 echo "   ✅  Contract deployed!"
 echo ""
 
+# ── Step 3b: Query deployed contract version ─────────────────
+DEPLOYED_VERSION=$(stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source-account "$DEPLOYER_SECRET" \
+  --network "$NETWORK" \
+  --rpc-url "$RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  -- version 2>/dev/null | tr -d '"' || echo "unknown")
+echo "   Contract version: $DEPLOYED_VERSION"
+echo ""
+
 # ── Step 4: Initialize contract ──────────────────────────────
 INIT_ADMIN="${ADMIN_ADDRESS:-$DEPLOYER_PUBLIC}"
 if [[ -n "$INIT_ADMIN" ]]; then
@@ -119,6 +130,7 @@ fi
 # ── Step 5: Output ────────────────────────────────────────────
 echo "════════════════════════════════════════════════════════"
 echo "  CONTRACT_ID : $CONTRACT_ID"
+echo "  VERSION     : $DEPLOYED_VERSION"
 echo "════════════════════════════════════════════════════════"
 echo ""
 

--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
 use soroban_sdk::{
     contract, contracterror, contractimpl, contractmeta, contracttype,
-    token, Address, Env, String, Symbol, Val, Vec,
-    Address, Env, Map, String, Symbol, Val,
-    Address, BytesN, Env, String, Symbol, Val, Vec,
+    token, Address, BytesN, Env, Map, String, Symbol, Val, Vec,
 };
 use soroban_token_sdk::metadata::TokenMetadata;
 
@@ -69,19 +67,19 @@ pub enum Error {
     /// The asset contract address is not on the admin-approved allow-list.
     UnsupportedAsset = 9,
     /// Provided WASM hash is all zeros — cannot upgrade to a no-op contract.
-    InvalidWasmHash = 8,
+    InvalidWasmHash = 10,
     /// Clip signature verification failed — caller is not the clip owner.
-    InvalidSignature = 9,
+    InvalidSignature = 11,
     /// Nonce is stale — replay attack detected.
-    InvalidNonce = 10,
+    InvalidNonce = 12,
     /// Clip hash was not pre-verified by the admin.
-    ClipNotVerified = 11,
+    ClipNotVerified = 13,
     /// Array lengths do not match for batch operation.
-    ArrayLengthMismatch = 12,
+    ArrayLengthMismatch = 14,
     /// Batch size is 0 or exceeds maximum allowable limit.
-    InvalidBatchSize = 13,
+    InvalidBatchSize = 15,
     /// One-time metadata update limit reached for token ID.
-    MetadataAlreadyUpdated = 14,
+    MetadataAlreadyUpdated = 16,
 }
 
 #[contractimpl]
@@ -583,7 +581,7 @@ impl ClipsNftContract {
     /// `amount * royalty_bps / 10_000`, using the token's configured
     /// royalty rate (falling back to the contract default). `payer` must
     /// authorize the call and hold a sufficient balance of `asset`.
-    pub fn pay_royalty(
+    pub fn pay_royalty_with_asset(
         env: Env,
         payer: Address,
         token_id: u64,
@@ -605,8 +603,10 @@ impl ClipsNftContract {
             asset_client.transfer(&payer, &token_data.creator, &royalty_amount);
         }
 
-        events::emit_royalty_paid(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
+        events::emit_royalty_paid_asset(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
         Ok(royalty_amount)
+    }
+
     /// Permanently destroy a token. Only the current owner may burn it.
     ///
     /// Ownership, metadata, royalty overrides and any outstanding approval
@@ -637,6 +637,12 @@ impl ClipsNftContract {
         let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
+        storage::set_platform_fee(&env, &recipient, bps);
+        Ok(())
+    }
+
+    /// Record the royalty payment owed on `token_id`. Emits `royalty_paid`
+    /// with the amount in stroops. `payer` must authorize the call.
     pub fn pay_royalty(
         env: Env,
         token_id: u64,
@@ -658,22 +664,6 @@ impl ClipsNftContract {
             0,
             amount_stroops,
         );
-        Ok(())
-    }
-
-    pub fn set_token_royalty_bps(env: Env, token_id: u64, bps: u32) -> Result<(), Error> {
-        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-
-        if !storage::has_token(&env, token_id) {
-            return Err(Error::TokenNotFound);
-        }
-
-        if bps > storage::ROYALTY_BPS_MAX {
-            return Err(Error::InvalidRoyaltyBps);
-        }
-
-        storage::set_platform_fee(&env, &recipient, bps);
         Ok(())
     }
 
@@ -743,6 +733,20 @@ impl ClipsNftContract {
         }
 
         royalties
+    }
+
+    pub fn set_token_royalty_bps(env: Env, token_id: u64, bps: u32) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if !storage::has_token(&env, token_id) {
+            return Err(Error::TokenNotFound);
+        }
+
+        if bps > storage::ROYALTY_BPS_MAX {
+            return Err(Error::InvalidRoyaltyBps);
+        }
+
         storage::set_token_royalty_bps(&env, token_id, bps);
         Ok(())
     }
@@ -873,6 +877,8 @@ mod events {
     pub fn emit_unpaused(env: &Env, admin: &Address) {
         let topics = (Symbol::new(env, "unpaused"), admin.clone());
         env.events().publish(topics, ());
+    }
+
     pub fn emit_burn(env: &Env, owner: &Address, token_id: u64) {
         let topics = (Symbol::new(env, "burn"), owner.clone());
         env.events().publish(topics, token_id);
@@ -881,12 +887,16 @@ mod events {
     pub fn emit_royalties_updated(env: &Env, token_id: u64, total_bps: u32) {
         let topics = (Symbol::new(env, "royalties_updated"), token_id);
         env.events().publish(topics, total_bps);
+    }
+
     pub fn emit_royalty_updated(env: &Env, old_bps: u32, new_bps: u32) {
         let topics = (Symbol::new(env, "royalty_updated"),);
         env.events().publish(topics, (old_bps, new_bps));
     }
 
-    pub fn emit_royalty_paid(
+    /// Emitted by `pay_royalty_with_asset` when a royalty is paid out in a
+    /// specific Stellar asset contract (SAC).
+    pub fn emit_royalty_paid_asset(
         env: &Env,
         payer: &Address,
         recipient: &Address,
@@ -896,6 +906,12 @@ mod events {
     ) {
         let topics = (Symbol::new(env, "royalty_paid"), payer.clone(), recipient.clone());
         env.events().publish(topics, (asset.clone(), token_id, amount));
+    }
+
+    /// Emitted by `transfer_with_royalty` and `pay_royalty` when a royalty
+    /// amount (in stroops) is computed/paid for a token sale.
+    pub fn emit_royalty_paid(
+        env: &Env,
         recipient: &Address,
         token_id: u64,
         royalty_amount: u64,

--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -20,8 +20,22 @@ const CLIP_NAME: &[u8] = b"ClipCash NFT";
 const CLIP_SYMBOL: &[u8] = b"CLIP";
 pub const MAX_BATCH_SIZE: u32 = 50;
 
+/// Semantic version of this contract build (Issue #692).
+///
+/// Follows semver (`MAJOR.MINOR.PATCH`):
+/// - `PATCH` — bug fixes with no interface changes (e.g. this overflow fix).
+/// - `MINOR` — new functions or fields added in a backwards-compatible way.
+/// - `MAJOR` — a breaking change to an existing function's signature,
+///   behavior, or storage layout.
+///
+/// Bump this constant (and the `contractmeta!` value below, which must stay
+/// in sync) in the same PR that introduces the change it describes. Query it
+/// on-chain via the `version()` view function, or off-chain by reading the
+/// `version` contract metadata entry without invoking the contract.
+pub const VERSION: &str = "1.1.0";
+
 contractmeta!(key = "name", val = "ClipCash NFT Contract");
-contractmeta!(key = "version", val = "1.0.0");
+contractmeta!(key = "version", val = "1.1.0");
 
 #[contract]
 pub struct ClipsNftContract;
@@ -92,6 +106,17 @@ impl ClipsNftContract {
     /// Return collection symbol (Issue #686).
     pub fn symbol(env: Env) -> String {
         String::from_str(&env, "CLIP")
+    }
+
+    /// Return the semantic version of the deployed contract (Issue #692).
+    ///
+    /// Public read-only call, no auth required. Reflects the `VERSION`
+    /// constant baked into this WASM build — distinct from
+    /// `get_contract_version`/`set_contract_version`, which is an
+    /// admin-settable runtime value used for external deployment tracking
+    /// and can drift from what's actually running.
+    pub fn version(env: Env) -> String {
+        String::from_str(&env, VERSION)
     }
 
     /// Initialise the contract and set the admin address.

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -1,21 +1,17 @@
-use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{Address, BytesN, Env, Map, Symbol, Vec};
 
 use crate::TokenData;
 
 pub struct TokenStorage;
-
-const TOTAL_SUPPLY_KEY: &str = "total_supply";
-const ADMIN_KEY: &str = "admin";
-const DEFAULT_ROYALTY_BPS_KEY: &str = "def_royalty_bps";
-const PAUSED_KEY: &str = "paused";
-const DEFAULT_ROYALTY_ASSET_KEY: &str = "def_royalty_asset";
-const SUPPORTED_ASSETS_KEY: &str = "supported_assets";
 
 // ── Compact storage keys (issue #642) ──────────────────────────────────────
 // Short keys reduce per-entry storage footprint and RPC read latency.
 const TOTAL_SUPPLY_KEY: &str = "ts";
 const ADMIN_KEY: &str = "adm";
 const DEFAULT_ROYALTY_BPS_KEY: &str = "drb";
+const PAUSED_KEY: &str = "paused";
+const DEFAULT_ROYALTY_ASSET_KEY: &str = "def_royalty_asset";
+const SUPPORTED_ASSETS_KEY: &str = "supported_assets";
 
 /// Maximum allowed royalty value in basis points (100% = 10 000 BPS).
 pub const ROYALTY_BPS_MAX: u32 = 10_000;
@@ -190,6 +186,8 @@ pub fn get_supported_assets(env: &Env) -> Vec<Address> {
 
 pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
     get_supported_assets(env).contains(asset)
+}
+
 pub fn remove_token(env: &Env, token_id: u64) {
     env.storage().persistent().remove(&token_id);
 }
@@ -243,6 +241,8 @@ pub fn get_royalty_shares(env: &Env, token_id: u64) -> Option<Map<Address, u32>>
     env.storage()
         .persistent()
         .get(&(token_id, Symbol::new(env, "royalties")))
+}
+
 pub fn set_custom_token_uri(env: &Env, token_id: u64, uri: &soroban_sdk::String) {
     env.storage()
         .persistent()

--- a/contracts/nft-contract/src/test.rs
+++ b/contracts/nft-contract/src/test.rs
@@ -1168,6 +1168,24 @@ fn test_name_and_symbol() {
     assert_eq!(client.symbol(), String::from_str(&env, "CLIP"));
 }
 
+// ─────────────────────────────────────────────────────────────
+// Issue #692: Contract Version Constant tests
+// ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_version_is_queryable_without_initialization() {
+    let (env, _contract_id, client) = setup_env();
+    // No initialize() call — version() must work on a fresh, uninitialized
+    // contract since it's a compile-time constant, not stored state.
+    assert_eq!(client.version(), String::from_str(&env, crate::VERSION));
+}
+
+#[test]
+fn test_version_matches_contract_metadata() {
+    let (env, _contract_id, client) = setup_env();
+    assert_eq!(client.version(), String::from_str(&env, "1.1.0"));
+}
+
 #[test]
 fn test_update_royalty_recipient_by_recipient() {
     let (env, _contract_id, client) = setup_env();

--- a/src/nft/admin-contract.service.ts
+++ b/src/nft/admin-contract.service.ts
@@ -111,4 +111,54 @@ export class AdminContractService {
     const returnValue = StellarSdk.xdr.ScVal.fromXDR(results[0].xdr, 'base64');
     return { paused: Boolean(StellarSdk.scValToNative(returnValue)) };
   }
+
+  /**
+   * Read the deployed contract's semantic version via the read-only
+   * `version()` call (Issue #692).
+   */
+  async getContractVersion(): Promise<{ contractId: string; version: string }> {
+    const server = new StellarSdk.rpc.Server(this.stellarService.rpcUrl);
+    const contract = new StellarSdk.Contract(this.CONTRACT_ID);
+    const op = contract.call('version');
+
+    const dummyAccount = new StellarSdk.Account(
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      '0',
+    );
+
+    const tx = new StellarSdk.TransactionBuilder(dummyAccount, {
+      fee: '100',
+      networkPassphrase: this.stellarService.networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    let simulation: Awaited<ReturnType<typeof server.simulateTransaction>>;
+    try {
+      simulation = await this.circuitBreakerService.execute(
+        this.sorobanCircuitBreakerConfig,
+        async () => server.simulateTransaction(tx),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Failed to query contract version: ${msg}`);
+      throw new InternalServerErrorException(
+        `Failed to query contract version: ${msg}`,
+      );
+    }
+
+    const results = (simulation as { results?: Array<{ xdr: string }> }).results;
+    if (!results?.[0]?.xdr) {
+      throw new InternalServerErrorException(
+        'No return value from version contract call',
+      );
+    }
+
+    const returnValue = StellarSdk.xdr.ScVal.fromXDR(results[0].xdr, 'base64');
+    return {
+      contractId: this.CONTRACT_ID,
+      version: String(StellarSdk.scValToNative(returnValue)),
+    };
+  }
 }

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -12,7 +12,6 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  BadRequestException,
   ForbiddenException,
 } from '@nestjs/common';
 import {
@@ -812,6 +811,8 @@ export class NftController {
   @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret header' })
   async prepareUnpause(@Body() dto: PrepareContractPauseDto) {
     return this.adminContractService.preparePauseTx(dto.adminAddress, false);
+  }
+
   @UseGuards(LoginGuard)
   @Patch(':id/royalty-recipient')
   @HttpCode(HttpStatus.OK)

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -755,6 +755,35 @@ export class NftController {
   }
 
   /**
+   * GET /nfts/contract/version
+   *
+   * Reads the deployed contract's semantic version via the on-chain,
+   * read-only `version()` call (Issue #692). Unlike `contract/info`
+   * (which is derived from env vars), this reflects what's actually
+   * running in the deployed WASM.
+   */
+  @Get('contract/version')
+  @ApiOperation({
+    summary: 'Get the deployed Soroban NFT contract version',
+    description:
+      'Calls the read-only version() function on the currently deployed ' +
+      'ClipCash NFT Soroban contract and returns its semantic version ' +
+      "alongside the contract ID it was read from.",
+  })
+  @ApiOkResponse({
+    description: 'Contract version returned successfully',
+    schema: {
+      example: {
+        contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+        version: '1.1.0',
+      },
+    },
+  })
+  async getContractVersion(): Promise<{ contractId: string; version: string }> {
+    return this.adminContractService.getContractVersion();
+  }
+
+  /**
    * GET /nfts/admin/pause-status
    * Reads the contract's current pause state via Soroban `is_paused`.
    */


### PR DESCRIPTION
## Summary
- Adds a compile-time `VERSION` constant and a public, no-auth `version()` view function to the Soroban contract — distinct from the existing `get_contract_version`/`set_contract_version` pair, which is an admin-settable runtime value that can drift from what's actually deployed.
- Documents the semver policy (`MAJOR.MINOR.PATCH`) directly on the `VERSION` constant.
- `deploy-testnet.sh`/`deploy-mainnet.sh` now query and print the deployed version right after deployment.
- Adds `GET /nfts/contract/version`, mirroring the existing `contract/info` endpoint, backed by a new `AdminContractService.getContractVersion()` that reads the on-chain value via `simulateTransaction` (same pattern as `getPauseStatus`). Documented with Swagger (`@ApiOkResponse` example includes contract ID + version).
- Bumps `VERSION` `1.0.0` → `1.1.0` (new backwards-compatible function) as a concrete demonstration of the policy in the same PR that introduces it.

**Note:** stacked on #714 (repairs build-breaking merge corruption already on `main`) and #715 (#689). Includes both of those diffs until they merge — the version-specific work is `contracts/nft-contract/src/lib.rs` (`VERSION` const + `version()` fn), `src/nft/admin-contract.service.ts` (`getContractVersion`), `src/nft/nft.controller.ts` (`GET /nfts/contract/version`), the two `deploy-*.sh` scripts, and the new tests/audit.md entries.

Closes #692

## Test plan
- [x] `cargo test` in `contracts/nft-contract` — 68 passed, 0 failed
- [x] `npx tsc --noEmit -p .` clean for the two touched TS files