### PR TITLE
feat(soroban): add Node.js backend mint example script (#694)

### DIFF
--- a/contracts/nft-contract/bindings/clips-nft-contract.ts
+++ b/contracts/nft-contract/bindings/clips-nft-contract.ts
@@ -3,6 +3,8 @@
  * Issue #682: Generate TypeScript Contract Bindings
  */
 
+import StellarSdk from '@stellar/stellar-sdk';
+
 export interface TokenData {
   owner: string;
   isSoulbound: boolean;
@@ -63,6 +65,51 @@ export class ClipsNftContractClient {
     isSoulbound: boolean,
   ): Promise<boolean> {
     return true;
+  }
+
+  /**
+   * Build (but do not sign or submit) a Soroban transaction that calls
+   * `mint` on the deployed contract, returning its XDR for an external
+   * signer to sign and submit (Issue #694).
+   *
+   * The contract's `mint` requires `admin.require_auth()` on-chain (see
+   * `contracts/nft-contract/src/lib.rs`), so `sourceAddress` must be the
+   * account that will sign the returned XDR — the contract's configured
+   * admin wallet. See `examples/mint-from-backend.ts` for a runnable
+   * end-to-end example, and `NftMintService.prepareMintTx` /
+   * `POST /nfts/prepare-mint` for how the backend does the equivalent
+   * for user-facing mints.
+   */
+  async buildMintTransaction(params: {
+    sourceAddress: string;
+    to: string;
+    tokenId: bigint;
+    clipId: string;
+    contentUri: string;
+    isSoulbound: boolean;
+  }): Promise<string> {
+    const server = new StellarSdk.rpc.Server(this.config.rpcUrl);
+    const sourceAccount = await server.getAccount(params.sourceAddress);
+
+    const contract = new StellarSdk.Contract(this.config.contractId);
+    const op = contract.call(
+      'mint',
+      StellarSdk.Address.fromString(params.to).toScVal(),
+      StellarSdk.nativeToScVal(params.tokenId, { type: 'u64' }),
+      StellarSdk.nativeToScVal(params.clipId, { type: 'string' }),
+      StellarSdk.nativeToScVal(params.contentUri, { type: 'string' }),
+      StellarSdk.nativeToScVal(params.isSoulbound, { type: 'bool' }),
+    );
+
+    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: '10000',
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    return tx.toXDR();
   }
 
   /**

--- a/contracts/nft-contract/examples/mint-from-backend.ts
+++ b/contracts/nft-contract/examples/mint-from-backend.ts
@@ -1,0 +1,114 @@
+/**
+ * examples/mint-from-backend.ts
+ *
+ * Reference implementation for preparing a ClipCash NFT mint transaction
+ * from a Node.js backend context, using the generated TypeScript bindings
+ * in ../bindings/clips-nft-contract.ts (Issue #694).
+ *
+ * This mirrors what `POST /nfts/prepare-mint` does server-side (see
+ * `src/clips/nft-mint.service.ts#prepareMintTx`): it builds and prints an
+ * *unsigned* transaction XDR. It does not sign or submit anything.
+ *
+ * IMPORTANT: the contract's `mint` function requires `admin.require_auth()`
+ * on-chain (see `contracts/nft-contract/src/lib.rs`), so the account that
+ * eventually signs the XDR this script prints must be the contract's
+ * configured admin wallet — not the recipient's wallet. `--source` below
+ * is that admin account's public key (it only needs to sign the sequence
+ * number / pay the fee here; the signing step itself happens separately,
+ * e.g. via `stellar tx sign` or a signer service).
+ *
+ * Usage:
+ *   export SOROBAN_NFT_CONTRACT_ID=C...   # deployed contract ID
+ *   export STELLAR_NETWORK=testnet        # or "public"
+ *
+ *   npx ts-node contracts/nft-contract/examples/mint-from-backend.ts \
+ *     --clip-id 42 \
+ *     --wallet GABCDEF...RECIPIENT \
+ *     --source GADMIN...ADMINACCOUNT \
+ *     [--content-uri ipfs://Qm.../metadata.json] \
+ *     [--soulbound]
+ *
+ * Output:
+ *   Unsigned transaction XDR, printed to stdout.
+ */
+
+import { parseArgs } from 'node:util';
+import { createClipsNftContractClient } from '../bindings/clips-nft-contract';
+
+interface NetworkConfig {
+  rpcUrl: string;
+  networkPassphrase: string;
+}
+
+function resolveNetwork(network: string): NetworkConfig {
+  const isMainnet = network.toLowerCase() === 'public';
+  return isMainnet
+    ? {
+        rpcUrl: 'https://soroban-rpc.stellar.org',
+        networkPassphrase: 'Public Global Stellar Network ; September 2015',
+      }
+    : {
+        rpcUrl: 'https://soroban-testnet.stellar.org',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      };
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      'clip-id': { type: 'string' },
+      wallet: { type: 'string' },
+      source: { type: 'string' },
+      'content-uri': { type: 'string' },
+      soulbound: { type: 'boolean', default: false },
+    },
+  });
+
+  const clipId = values['clip-id'];
+  const wallet = values.wallet;
+  const source = values.source;
+
+  if (!clipId || !wallet || !source) {
+    console.error(
+      'Usage: mint-from-backend.ts --clip-id <id> --wallet <G...> --source <G...admin> [--content-uri <uri>] [--soulbound]',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const contractId = process.env.SOROBAN_NFT_CONTRACT_ID;
+  if (!contractId) {
+    console.error('SOROBAN_NFT_CONTRACT_ID environment variable is required.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const { rpcUrl, networkPassphrase } = resolveNetwork(
+    process.env.STELLAR_NETWORK ?? 'testnet',
+  );
+
+  const client = createClipsNftContractClient({
+    contractId,
+    rpcUrl,
+    networkPassphrase,
+  });
+
+  const contentUri =
+    values['content-uri'] ?? `https://clips.cash/metadata/${clipId}`;
+
+  const xdr = await client.buildMintTransaction({
+    sourceAddress: source,
+    to: wallet,
+    tokenId: BigInt(clipId),
+    clipId,
+    contentUri,
+    isSoulbound: Boolean(values.soulbound),
+  });
+
+  console.log(xdr);
+}
+
+main().catch((err) => {
+  console.error('Failed to build mint transaction:', err);
+  process.exitCode = 1;
+});

--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
 use soroban_sdk::{
     contract, contracterror, contractimpl, contractmeta, contracttype,
-    token, Address, Env, String, Symbol, Val, Vec,
-    Address, Env, Map, String, Symbol, Val,
-    Address, BytesN, Env, String, Symbol, Val, Vec,
+    token, Address, BytesN, Env, Map, String, Symbol, Val, Vec,
 };
 use soroban_token_sdk::metadata::TokenMetadata;
 
@@ -69,19 +67,19 @@ pub enum Error {
     /// The asset contract address is not on the admin-approved allow-list.
     UnsupportedAsset = 9,
     /// Provided WASM hash is all zeros — cannot upgrade to a no-op contract.
-    InvalidWasmHash = 8,
+    InvalidWasmHash = 10,
     /// Clip signature verification failed — caller is not the clip owner.
-    InvalidSignature = 9,
+    InvalidSignature = 11,
     /// Nonce is stale — replay attack detected.
-    InvalidNonce = 10,
+    InvalidNonce = 12,
     /// Clip hash was not pre-verified by the admin.
-    ClipNotVerified = 11,
+    ClipNotVerified = 13,
     /// Array lengths do not match for batch operation.
-    ArrayLengthMismatch = 12,
+    ArrayLengthMismatch = 14,
     /// Batch size is 0 or exceeds maximum allowable limit.
-    InvalidBatchSize = 13,
+    InvalidBatchSize = 15,
     /// One-time metadata update limit reached for token ID.
-    MetadataAlreadyUpdated = 14,
+    MetadataAlreadyUpdated = 16,
 }
 
 #[contractimpl]
@@ -583,7 +581,7 @@ impl ClipsNftContract {
     /// `amount * royalty_bps / 10_000`, using the token's configured
     /// royalty rate (falling back to the contract default). `payer` must
     /// authorize the call and hold a sufficient balance of `asset`.
-    pub fn pay_royalty(
+    pub fn pay_royalty_with_asset(
         env: Env,
         payer: Address,
         token_id: u64,
@@ -605,8 +603,10 @@ impl ClipsNftContract {
             asset_client.transfer(&payer, &token_data.creator, &royalty_amount);
         }
 
-        events::emit_royalty_paid(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
+        events::emit_royalty_paid_asset(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
         Ok(royalty_amount)
+    }
+
     /// Permanently destroy a token. Only the current owner may burn it.
     ///
     /// Ownership, metadata, royalty overrides and any outstanding approval
@@ -637,6 +637,12 @@ impl ClipsNftContract {
         let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
+        storage::set_platform_fee(&env, &recipient, bps);
+        Ok(())
+    }
+
+    /// Record the royalty payment owed on `token_id`. Emits `royalty_paid`
+    /// with the amount in stroops. `payer` must authorize the call.
     pub fn pay_royalty(
         env: Env,
         token_id: u64,
@@ -658,22 +664,6 @@ impl ClipsNftContract {
             0,
             amount_stroops,
         );
-        Ok(())
-    }
-
-    pub fn set_token_royalty_bps(env: Env, token_id: u64, bps: u32) -> Result<(), Error> {
-        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-
-        if !storage::has_token(&env, token_id) {
-            return Err(Error::TokenNotFound);
-        }
-
-        if bps > storage::ROYALTY_BPS_MAX {
-            return Err(Error::InvalidRoyaltyBps);
-        }
-
-        storage::set_platform_fee(&env, &recipient, bps);
         Ok(())
     }
 
@@ -743,6 +733,20 @@ impl ClipsNftContract {
         }
 
         royalties
+    }
+
+    pub fn set_token_royalty_bps(env: Env, token_id: u64, bps: u32) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if !storage::has_token(&env, token_id) {
+            return Err(Error::TokenNotFound);
+        }
+
+        if bps > storage::ROYALTY_BPS_MAX {
+            return Err(Error::InvalidRoyaltyBps);
+        }
+
         storage::set_token_royalty_bps(&env, token_id, bps);
         Ok(())
     }
@@ -873,6 +877,8 @@ mod events {
     pub fn emit_unpaused(env: &Env, admin: &Address) {
         let topics = (Symbol::new(env, "unpaused"), admin.clone());
         env.events().publish(topics, ());
+    }
+
     pub fn emit_burn(env: &Env, owner: &Address, token_id: u64) {
         let topics = (Symbol::new(env, "burn"), owner.clone());
         env.events().publish(topics, token_id);
@@ -881,12 +887,16 @@ mod events {
     pub fn emit_royalties_updated(env: &Env, token_id: u64, total_bps: u32) {
         let topics = (Symbol::new(env, "royalties_updated"), token_id);
         env.events().publish(topics, total_bps);
+    }
+
     pub fn emit_royalty_updated(env: &Env, old_bps: u32, new_bps: u32) {
         let topics = (Symbol::new(env, "royalty_updated"),);
         env.events().publish(topics, (old_bps, new_bps));
     }
 
-    pub fn emit_royalty_paid(
+    /// Emitted by `pay_royalty_with_asset` when a royalty is paid out in a
+    /// specific Stellar asset contract (SAC).
+    pub fn emit_royalty_paid_asset(
         env: &Env,
         payer: &Address,
         recipient: &Address,
@@ -896,6 +906,12 @@ mod events {
     ) {
         let topics = (Symbol::new(env, "royalty_paid"), payer.clone(), recipient.clone());
         env.events().publish(topics, (asset.clone(), token_id, amount));
+    }
+
+    /// Emitted by `transfer_with_royalty` and `pay_royalty` when a royalty
+    /// amount (in stroops) is computed/paid for a token sale.
+    pub fn emit_royalty_paid(
+        env: &Env,
         recipient: &Address,
         token_id: u64,
         royalty_amount: u64,

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -1,21 +1,17 @@
-use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{Address, BytesN, Env, Map, Symbol, Vec};
 
 use crate::TokenData;
 
 pub struct TokenStorage;
-
-const TOTAL_SUPPLY_KEY: &str = "total_supply";
-const ADMIN_KEY: &str = "admin";
-const DEFAULT_ROYALTY_BPS_KEY: &str = "def_royalty_bps";
-const PAUSED_KEY: &str = "paused";
-const DEFAULT_ROYALTY_ASSET_KEY: &str = "def_royalty_asset";
-const SUPPORTED_ASSETS_KEY: &str = "supported_assets";
 
 // ── Compact storage keys (issue #642) ──────────────────────────────────────
 // Short keys reduce per-entry storage footprint and RPC read latency.
 const TOTAL_SUPPLY_KEY: &str = "ts";
 const ADMIN_KEY: &str = "adm";
 const DEFAULT_ROYALTY_BPS_KEY: &str = "drb";
+const PAUSED_KEY: &str = "paused";
+const DEFAULT_ROYALTY_ASSET_KEY: &str = "def_royalty_asset";
+const SUPPORTED_ASSETS_KEY: &str = "supported_assets";
 
 /// Maximum allowed royalty value in basis points (100% = 10 000 BPS).
 pub const ROYALTY_BPS_MAX: u32 = 10_000;
@@ -190,6 +186,8 @@ pub fn get_supported_assets(env: &Env) -> Vec<Address> {
 
 pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
     get_supported_assets(env).contains(asset)
+}
+
 pub fn remove_token(env: &Env, token_id: u64) {
     env.storage().persistent().remove(&token_id);
 }
@@ -243,6 +241,8 @@ pub fn get_royalty_shares(env: &Env, token_id: u64) -> Option<Map<Address, u32>>
     env.storage()
         .persistent()
         .get(&(token_id, Symbol::new(env, "royalties")))
+}
+
 pub fn set_custom_token_uri(env: &Env, token_id: u64, uri: &soroban_sdk::String) {
     env.storage()
         .persistent()

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -12,7 +12,6 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  BadRequestException,
   ForbiddenException,
 } from '@nestjs/common';
 import {
@@ -812,6 +811,8 @@ export class NftController {
   @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret header' })
   async prepareUnpause(@Body() dto: PrepareContractPauseDto) {
     return this.adminContractService.preparePauseTx(dto.adminAddress, false);
+  }
+
   @UseGuards(LoginGuard)
   @Patch(':id/royalty-recipient')
   @HttpCode(HttpStatus.OK)

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -357,7 +357,10 @@ export class NftController {
     summary: 'Prepare a Soroban mint transaction (returns XDR for signing)',
     description:
       'Builds an unsigned Soroban mint transaction XDR against the currently configured Stellar network ' +
-      '(testnet or public/mainnet, per STELLAR_NETWORK). Request body requires clipId and walletAddress.',
+      '(testnet or public/mainnet, per STELLAR_NETWORK). Request body requires clipId and walletAddress. ' +
+      'For a standalone Node.js reference implementation of this same XDR-building flow (useful when ' +
+      'integrating outside this API, e.g. from an ops script or another backend service), see ' +
+      'contracts/nft-contract/examples/mint-from-backend.ts.',
   })
   @ApiBody({ type: CreateMintPreparationDto })
   @ApiResponse({


### PR DESCRIPTION
## Summary
- Adds `contracts/nft-contract/examples/mint-from-backend.ts`, a runnable reference implementation for preparing a ClipCash NFT mint transaction from a Node.js backend context. Takes `--clip-id`, `--wallet`, and `--source` (the admin account, since the contract's `mint` requires `admin.require_auth()` on-chain — see `src/lib.rs`), and prints the unsigned transaction XDR to stdout.
- Extends the generated bindings (`bindings/clips-nft-contract.ts`) with a `buildMintTransaction()` method that does the real `contract.call` + `TransactionBuilder` work, matching the contract's actual `mint(to, token_id, clip_id, content_uri, is_soulbound)` signature. The existing `mint()` stub is left untouched for callers that just want a mock boolean.
- References the script from `POST /nfts/prepare-mint`'s Swagger description, for developers integrating outside the REST API.

**Note:** stacked on #714 (repairs build-breaking merge corruption already on `main`). Includes that diff until it merges — the #694-specific work is `contracts/nft-contract/bindings/clips-nft-contract.ts`, `contracts/nft-contract/examples/mint-from-backend.ts` (new file), and one description line in `src/nft/nft.controller.ts`.

Closes #694

## Test plan
- [x] `npx tsc --noEmit` clean for both touched/new TS files
- [x] Verified end-to-end against **Stellar testnet**: generated a fresh keypair, funded it via Friendbot, ran the script against a syntactically valid (undeployed) contract address, and decoded the resulting XDR — confirmed `mint(to=<wallet>, token_id=42, clip_id="42", content_uri="https://clips.cash/metadata/42", is_soulbound=false)` is encoded correctly.