### PR TITLE
docs(soroban): document royalty_recipient_updated event (#695)

### DIFF
--- a/contracts/nft-contract/docs/events.md
+++ b/contracts/nft-contract/docs/events.md
@@ -50,8 +50,9 @@ es.onmessage = (ev) => {
     case "mint":            handleMint(record);           break;
     case "transfer":        handleTransfer(record);       break;
     case "approve":         handleApprove(record);        break;
-    case "royalty_updated": handleRoyaltyUpdated(record); break;
-    case "royalty_paid":    handleRoyaltyPaid(record);    break;
+    case "royalty_updated":          handleRoyaltyUpdated(record);         break;
+    case "royalty_paid":             handleRoyaltyPaid(record);            break;
+    case "royalty_recipient_updated": handleRoyaltyRecipientUpdated(record); break;
   }
 };
 ```
@@ -228,6 +229,55 @@ Emitted whenever the contract admin updates the default royalty rate.
 
 ---
 
+### `royalty_recipient_updated`
+
+Emitted by `update_royalty_recipient` whenever the royalty recipient address
+for a token is changed. Only the *current* recipient can call
+`update_royalty_recipient`, so this event's `old_recipient` is always the
+signer of the transaction that emitted it.
+
+#### Topics (indexed)
+
+| Position | Type | Value |
+|---|---|---|
+| 0 | `Symbol` | `"royalty_recipient_updated"` |
+| 1 | `u64` | `token_id` — the NFT whose recipient changed |
+
+#### Data
+
+| Type | Value |
+|---|---|
+| `(Address, Address)` | `(old_recipient, new_recipient)` |
+
+#### Example JSON Payload
+
+```json
+{
+  "type": "contract",
+  "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+  "in_successful_contract_call": true,
+  "topic": [
+    { "type": "symbol", "value": "royalty_recipient_updated" },
+    { "type": "u64",    "value": "42" }
+  ],
+  "value": {
+    "type": "tuple",
+    "values": [
+      { "type": "address", "value": "GOLD...RCPT" },
+      { "type": "address", "value": "GNEW...RCPT" }
+    ]
+  }
+}
+```
+
+#### Filter by token
+
+```
+GET /events?type=contract&contract_id=<C...>&topic[0]=<royalty_recipient_updated_xdr>&topic[1]=<token_id_xdr>
+```
+
+---
+
 ### `royalty_paid`
 
 Emitted by the marketplace (via `pay_royalty`) whenever a secondary-sale
@@ -324,4 +374,5 @@ fn handle_event(env: &Env, ev: &SorobanEvent) {
 | `transfer` | `transfer` / `transfer_from` | `("transfer", from, to)` | `token_id` |
 | `approve` | `approve` | `("approve", owner, spender)` | `token_id` |
 | `royalty_updated` | `set_default_royalty_bps` | `("royalty_updated",)` | `(old_bps, new_bps)` |
+| `royalty_recipient_updated` | `update_royalty_recipient` | `("royalty_recipient_updated", token_id)` | `(old_recipient, new_recipient)` |
 | `royalty_paid` | `pay_royalty` | `("royalty_paid", token_id, payer)` | `(creator, amount_stroops)` |

--- a/contracts/nft-contract/src/test.rs
+++ b/contracts/nft-contract/src/test.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use crate::{ClipMetadata, ClipsNftContract, ClipsNftContractClient, Error};
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String, Vec};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events as _, testutils::Ledger as _, Address, BytesN, Env,
+    String, Symbol, TryIntoVal, Vec,
+};
 
 
 // ─────────────────────────────────────────────────────────────
@@ -1210,6 +1213,72 @@ fn test_update_royalty_recipient_unauthorized_rejected() {
 
     let result = client.try_update_royalty_recipient(&5002, &stranger);
     assert!(result.is_err(), "Unauthorized update of royalty recipient must fail");
+}
+
+// ─────────────────────────────────────────────────────────────
+// Issue #695: Emit Events for Royalty Recipient Changes tests
+// ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_update_royalty_recipient_emits_event_with_required_fields() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client.mint(&creator, &5003, &String::from_str(&env, "c5003"), &String::from_str(&env, "uri5003"), &false);
+
+    client.update_royalty_recipient(&5003, &new_recipient);
+
+    // RoyaltyRecipientUpdated must be emitted with token_id, old address,
+    // and new address (Issue #695 acceptance criteria).
+    let events = env.events().all();
+    let (event_contract_id, topics, data) = events.last().unwrap();
+    assert_eq!(event_contract_id, contract_id, "event must come from this contract");
+
+    let event_name: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(event_name, Symbol::new(&env, "royalty_recipient_updated"));
+
+    let token_id: u64 = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(token_id, 5003, "event must include the token ID");
+
+    let (old_recipient, emitted_new_recipient): (Address, Address) =
+        data.try_into_val(&env).unwrap();
+    assert_eq!(old_recipient, creator, "event must include the old address");
+    assert_eq!(emitted_new_recipient, new_recipient, "event must include the new address");
+}
+
+#[test]
+fn test_update_royalty_recipient_emits_event_on_every_update() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let second_recipient = Address::generate(&env);
+    let third_recipient = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client.mint(&creator, &5004, &String::from_str(&env, "c5004"), &String::from_str(&env, "uri5004"), &false);
+
+    // First update: creator -> second_recipient.
+    client.update_royalty_recipient(&5004, &second_recipient);
+    let (_, _, data) = env.events().all().last().unwrap();
+    let (old_recipient, new_recipient): (Address, Address) = data.try_into_val(&env).unwrap();
+    assert_eq!(old_recipient, creator);
+    assert_eq!(new_recipient, second_recipient);
+
+    // Second update: second_recipient -> third_recipient. A fresh event
+    // must be emitted reflecting the new transition, not a stale/missing one.
+    client.update_royalty_recipient(&5004, &third_recipient);
+    let (_, _, data) = env.events().all().last().unwrap();
+    let (old_recipient, new_recipient): (Address, Address) = data.try_into_val(&env).unwrap();
+    assert_eq!(
+        old_recipient, second_recipient,
+        "second update's event must reflect the recipient set by the first update"
+    );
+    assert_eq!(new_recipient, third_recipient);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- The on-chain event emission itself was already implemented (Issue #672 — `update_royalty_recipient` / `emit_royalty_recipient_updated`) with `token_id`, old address, and new address, but it was **undocumented** in `docs/events.md` and had no test asserting the event's actual topics/data (only its side effects on storage).
- Adds a `royalty_recipient_updated` section to `docs/events.md` — topics, data, example JSON payload, and filter-by-token query — matching the existing event docs' format, wires it into the WebSocket/SSE consumption example at the top of the doc, and adds it to the event summary table at the bottom.
- Adds two tests:
  - `test_update_royalty_recipient_emits_event_with_required_fields` — decodes the emitted event and asserts topics/data contain `token_id`, `old_recipient`, and `new_recipient` exactly.
  - `test_update_royalty_recipient_emits_event_on_every_update` — confirms a fresh, correctly-scoped event fires on a *second* update too, not just the first.

**Note:** stacked on #714 (repairs build-breaking merge corruption already on `main`). Includes that diff until it merges — the #695-specific work is `contracts/nft-contract/docs/events.md` and the two new tests in `contracts/nft-contract/src/test.rs`.

Closes #695

## Test plan
- [x] `cargo test` in `contracts/nft-contract` — 68 passed, 0 failed