### PR TITLE
fix(nft-contract): repair corrupted merges in lib.rs and storage.rs

### DIFF
--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -67,9 +67,9 @@ pub enum Error {
     /// The asset contract address is not on the admin-approved allow-list.
     UnsupportedAsset = 9,
     /// Provided WASM hash is all zeros — cannot upgrade to a no-op contract.
-    InvalidWasmHash = 8,
+    InvalidWasmHash = 19,
     /// Clip signature verification failed — caller is not the clip owner.
-    InvalidSignature = 9,
+    InvalidSignature = 20,
     /// Nonce is stale — replay attack detected.
     InvalidNonce = 10,
     /// Clip hash was not pre-verified by the admin.
@@ -89,7 +89,7 @@ pub enum Error {
     /// XLM token SAC address has not been configured (Issue #676).
     XlmTokenNotConfigured = 18,
     /// No royalties have accrued yet — nothing to claim.
-    InsufficientBalance = 15,
+    InsufficientBalance = 21,
 }
 
 #[contractimpl]
@@ -642,7 +642,7 @@ impl ClipsNftContract {
     /// `amount * royalty_bps / 10_000`, using the token's configured
     /// royalty rate (falling back to the contract default). `payer` must
     /// authorize the call and hold a sufficient balance of `asset`.
-    pub fn pay_royalty(
+    pub fn pay_royalty_with_asset(
         env: Env,
         payer: Address,
         token_id: u64,
@@ -664,8 +664,10 @@ impl ClipsNftContract {
             asset_client.transfer(&payer, &token_data.creator, &royalty_amount);
         }
 
-        events::emit_royalty_paid(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
+        events::emit_royalty_paid_asset(&env, &payer, &token_data.creator, &asset, token_id, royalty_amount);
         Ok(royalty_amount)
+    }
+
     /// Permanently destroy a token. Only the current owner may burn it.
     ///
     /// Ownership, metadata, royalty overrides and any outstanding approval
@@ -696,6 +698,16 @@ impl ClipsNftContract {
         let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
+        if bps > storage::ROYALTY_BPS_MAX {
+            return Err(Error::InvalidRoyaltyBps);
+        }
+
+        storage::set_platform_fee(&env, &recipient, bps);
+        Ok(())
+    }
+
+    /// Record a royalty payment made off-chain (in stroops) for `token_id`,
+    /// emitting a `royalty_paid` event for indexers.
     pub fn pay_royalty(
         env: Env,
         token_id: u64,
@@ -732,7 +744,7 @@ impl ClipsNftContract {
             return Err(Error::InvalidRoyaltyBps);
         }
 
-        storage::set_platform_fee(&env, &recipient, bps);
+        storage::set_token_royalty_bps(&env, token_id, bps);
         Ok(())
     }
 
@@ -802,8 +814,6 @@ impl ClipsNftContract {
         }
 
         royalties
-        storage::set_token_royalty_bps(&env, token_id, bps);
-        Ok(())
     }
 
     pub fn get_token_royalty_bps(env: Env, token_id: u64) -> Option<u32> {
@@ -973,6 +983,8 @@ impl ClipsNftContract {
         admin.require_auth();
         storage::set_xlm_token_address(&env, &xlm_token);
         Ok(())
+    }
+
     /// Return a paginated slice of token IDs owned by `owner`.
     ///
     /// `limit`  – maximum number of token IDs to return (capped at 100).
@@ -992,6 +1004,8 @@ impl ClipsNftContract {
             i += 1;
         }
         result
+    }
+
     /// Accumulate royalties for a token.  Called after each royalty payment so
     /// that the owed balance grows until the creator calls `claim_royalties`.
     ///
@@ -1117,6 +1131,8 @@ mod events {
     pub fn emit_unpaused(env: &Env, admin: &Address) {
         let topics = (Symbol::new(env, "unpaused"), admin.clone());
         env.events().publish(topics, ());
+    }
+
     pub fn emit_burn(env: &Env, owner: &Address, token_id: u64) {
         let topics = (Symbol::new(env, "burn"), owner.clone());
         env.events().publish(topics, token_id);
@@ -1125,12 +1141,14 @@ mod events {
     pub fn emit_royalties_updated(env: &Env, token_id: u64, total_bps: u32) {
         let topics = (Symbol::new(env, "royalties_updated"), token_id);
         env.events().publish(topics, total_bps);
+    }
+
     pub fn emit_royalty_updated(env: &Env, old_bps: u32, new_bps: u32) {
         let topics = (Symbol::new(env, "royalty_updated"),);
         env.events().publish(topics, (old_bps, new_bps));
     }
 
-    pub fn emit_royalty_paid(
+    pub fn emit_royalty_paid_asset(
         env: &Env,
         payer: &Address,
         recipient: &Address,
@@ -1140,6 +1158,10 @@ mod events {
     ) {
         let topics = (Symbol::new(env, "royalty_paid"), payer.clone(), recipient.clone());
         env.events().publish(topics, (asset.clone(), token_id, amount));
+    }
+
+    pub fn emit_royalty_paid(
+        env: &Env,
         recipient: &Address,
         token_id: u64,
         royalty_amount: u64,

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -211,24 +211,6 @@ pub fn is_approved_for_all(env: &Env, owner: &Address, operator: &Address) -> bo
 }
 
 // ── Default royalty BPS ──────────────────────────────────────────────────────
-// ── Issue #675: Operator approvals ─────────────────────────────────────────
-
-/// Set operator approval for all tokens owned by `owner`.
-/// Allows `operator` to transfer any of owner's NFTs via `transfer_from`.
-pub fn set_approval_for_all(env: &Env, owner: &Address, operator: &Address, approved: bool) {
-    let key = (Symbol::new(env, "op_appr"), owner.clone(), operator.clone());
-    if approved {
-        env.storage().persistent().set(&key, &true);
-    } else {
-        env.storage().persistent().remove(&key);
-    }
-}
-
-/// Check whether `operator` is approved to manage all of `owner`'s NFTs.
-pub fn is_approved_for_all(env: &Env, owner: &Address, operator: &Address) -> bool {
-    let key = (Symbol::new(env, "op_appr"), owner.clone(), operator.clone());
-    env.storage().persistent().get(&key).unwrap_or(false)
-}
 
 pub fn set_default_royalty_bps(env: &Env, bps: u32) {
     env.storage()
@@ -499,48 +481,6 @@ pub fn get_xlm_token_address(env: &Env) -> Option<Address> {
         .get(&Symbol::new(env, XLM_TOKEN_KEY))
 }
 
-// ── Issue #676: Emergency withdraw timelock ─────────────────────────────────
-
-/// 24 hours expressed in seconds.
-pub const WITHDRAW_TIMELOCK_SECS: u64 = 86_400;
-
-const WITHDRAW_UNLOCK_KEY: &str = "wdraw_unlock";
-const XLM_TOKEN_KEY: &str = "xlm_token";
-
-/// Persist the timestamp after which `withdraw_xlm` may execute.
-pub fn set_withdraw_unlock_time(env: &Env, unlock_time: u64) {
-    env.storage()
-        .instance()
-        .set(&Symbol::new(env, WITHDRAW_UNLOCK_KEY), &unlock_time);
-}
-
-/// Retrieve the pending unlock timestamp, or `None` when not initiated.
-pub fn get_withdraw_unlock_time(env: &Env) -> Option<u64> {
-    env.storage()
-        .instance()
-        .get(&Symbol::new(env, WITHDRAW_UNLOCK_KEY))
-}
-
-/// Clear the timelock after a successful withdrawal so it cannot be
-/// re-used without a fresh `initiate_withdraw` call.
-pub fn clear_withdraw_unlock_time(env: &Env) {
-    env.storage()
-        .instance()
-        .remove(&Symbol::new(env, WITHDRAW_UNLOCK_KEY));
-}
-
-/// Persist the XLM Stellar Asset Contract (SAC) address.
-pub fn set_xlm_token_address(env: &Env, address: &Address) {
-    env.storage()
-        .instance()
-        .set(&Symbol::new(env, XLM_TOKEN_KEY), address);
-}
-
-/// Retrieve the configured XLM SAC address.
-pub fn get_xlm_token_address(env: &Env) -> Option<Address> {
-    env.storage()
-        .instance()
-        .get(&Symbol::new(env, XLM_TOKEN_KEY))
 // ── Royalty accumulation and claiming ───────────────────────────────────────
 
 /// Store accumulated royalties for a token (amount owed to creator).

--- a/contracts/nft-contract/src/test.rs
+++ b/contracts/nft-contract/src/test.rs
@@ -22,6 +22,28 @@ fn s(env: &Env, v: &str) -> String {
     String::from_str(env, v)
 }
 
+/// Batch-mint `count` tokens (IDs `1..=count`) to `owner` and return the
+/// minted token IDs, for tests exercising pagination over a large collection.
+fn batch_mint_n(
+    env: &Env,
+    client: &ClipsNftContractClient<'static>,
+    owner: &Address,
+    count: u64,
+) -> Vec<u64> {
+    let mut token_ids = Vec::new(env);
+    let mut clip_ids = Vec::new(env);
+    let mut uris = Vec::new(env);
+    let mut soulbound = Vec::new(env);
+    for i in 1..=count {
+        token_ids.push_back(i);
+        clip_ids.push_back(s(env, "clip"));
+        uris.push_back(s(env, "uri"));
+        soulbound.push_back(false);
+    }
+    client.batch_mint(owner, &token_ids, &clip_ids, &uris, &soulbound);
+    token_ids
+}
+
 // ─────────────────────────────────────────────────────────────
 // Initialization
 // ─────────────────────────────────────────────────────────────
@@ -1301,9 +1323,7 @@ fn test_get_user_tokens_pagination_first_page() {
 
     for i in 1..=5 {
         let token_id = i;
-        let clip_id = format!("clip_{}", i);
-        let uri = format!("uri_{}", i);
-        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+        client.mint(&owner, &token_id, &s(&env, "clip"), &s(&env, "uri"), &false);
     }
 
     let page1 = client.get_user_tokens(&owner, &2, &0);
@@ -1323,9 +1343,7 @@ fn test_get_user_tokens_pagination_second_page() {
 
     for i in 1..=5 {
         let token_id = i;
-        let clip_id = format!("clip_{}", i);
-        let uri = format!("uri_{}", i);
-        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+        client.mint(&owner, &token_id, &s(&env, "clip"), &s(&env, "uri"), &false);
     }
 
     let page2 = client.get_user_tokens(&owner, &2, &2);
@@ -1345,9 +1363,7 @@ fn test_get_user_tokens_pagination_last_page_partial() {
 
     for i in 1..=5 {
         let token_id = i;
-        let clip_id = format!("clip_{}", i);
-        let uri = format!("uri_{}", i);
-        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+        client.mint(&owner, &token_id, &s(&env, "clip"), &s(&env, "uri"), &false);
     }
 
     let last_page = client.get_user_tokens(&owner, &2, &4);
@@ -1381,9 +1397,7 @@ fn test_get_user_tokens_limit_exceeds_total() {
 
     for i in 1..=3 {
         let token_id = i;
-        let clip_id = format!("clip_{}", i);
-        let uri = format!("uri_{}", i);
-        client.mint(&owner, &token_id, &s(&env, &clip_id), &s(&env, &uri), &false);
+        client.mint(&owner, &token_id, &s(&env, "clip"), &s(&env, "uri"), &false);
     }
 
     let result = client.get_user_tokens(&owner, &100, &0);
@@ -1415,11 +1429,7 @@ fn test_get_user_tokens_limit_capped_at_100() {
     client.initialize(&admin);
 
     // Mint 50 tokens (batch limit is 50)
-    let token_ids: Vec<u64> = (1..=50).collect();
-    let clip_ids: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("clip_{}", i))).collect();
-    let uris: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("uri_{}", i))).collect();
-    let soulbound: Vec<bool> = (1..=50).map(|_| false).collect();
-    client.batch_mint(&owner, &token_ids, &clip_ids, &uris, &soulbound);
+    batch_mint_n(&env, &client, &owner, 50);
 
     // Request 200 (should be capped to 100, but only 50 exist)
     let result = client.get_user_tokens(&owner, &200, &0);
@@ -1436,11 +1446,7 @@ fn test_get_user_tokens_large_collection_multi_page() {
     client.initialize(&admin);
 
     // Mint 50 tokens via batch
-    let token_ids: Vec<u64> = (1..=50).collect();
-    let clip_ids: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("clip_{}", i))).collect();
-    let uris: Vec<String> = (1..=50).map(|i| String::from_str(&env, &format!("uri_{}", i))).collect();
-    let soulbound: Vec<bool> = (1..=50).map(|_| false).collect();
-    client.batch_mint(&owner, &token_ids, &clip_ids, &uris, &soulbound);
+    batch_mint_n(&env, &client, &owner, 50);
 
     // Page 1
     let page1 = client.get_user_tokens(&owner, &20, &0);

--- a/src/clips/nft-mint.service.spec.ts
+++ b/src/clips/nft-mint.service.spec.ts
@@ -132,6 +132,7 @@ const royaltyConfigMock = {
   getCreatorRoyaltyBps: jest.fn().mockReturnValue(1000),
   getPlatformWallet: jest.fn().mockReturnValue('GDV76E6XN6A3Q3WXVZ4KPRQ7L6E6XN6A3Q3WXVZ4KPRQ7L6E6XN6'),
   buildRoyaltyMap: jest.fn(),
+  getRoyaltyAsset: jest.fn().mockReturnValue({ code: 'native' }),
 };
 
 describe('NftMintService.uploadMetadataToIPFS', () => {

--- a/src/clips/nft-mint.service.ts
+++ b/src/clips/nft-mint.service.ts
@@ -577,6 +577,8 @@ export class NftMintService {
       ? 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA'
       : 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
   }
+
+  private buildMetadata(clip: {
     id: number;
     title: string | null;
     caption: string | null;

--- a/src/nft/nft-ownership.service.ts
+++ b/src/nft/nft-ownership.service.ts
@@ -147,6 +147,9 @@ export class NftOwnershipService {
       this.logger.error(`Failed to check token existence for token ${tokenId}`, error);
       return false;
     }
+  }
+
+  /**
    * Get a paginated slice of token IDs owned by a wallet address.
    *
    * Uses offset-based pagination: `cursor` is the 0-based index into the

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -960,41 +960,6 @@ export class NftController {
         xdr: 'AAAA...',
         action: 'initiate_withdraw',
         unlockAfterSeconds: 86400,
-  /**
-   * POST /nfts/tokens/:tokenId/approve
-   *
-   * Prepares an unsigned Soroban `approve(owner, spender, token_id)` XDR
-   * for the owner to sign. Grants `spender` the right to transfer one
-   * specific token (Issue #675).
-   */
-  @UseGuards(LoginGuard)
-  @Post('tokens/:tokenId/approve')
-  @HttpCode(HttpStatus.CREATED)
-  @ApiBearerAuth('access-token')
-  @ApiOperation({
-    summary: 'Approve a spender for a specific NFT token (Issue #675)',
-    description:
-      'Calls the Soroban `approve(owner, spender, token_id)` function. ' +
-      'Grants `spenderAddress` the right to call `transfer_from` for this ' +
-      'single token. Pass `spenderAddress` as null / empty string to revoke.',
-  })
-  @ApiParam({ name: 'tokenId', description: 'On-chain token ID', example: 42 })
-  @ApiBody({
-    schema: {
-      example: {
-        ownerAddress: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
-        spenderAddress: 'GDEST...ABC',
-      },
-    },
-  })
-  @ApiOkResponse({
-    description: 'Unsigned approve XDR returned',
-    schema: {
-      example: {
-        xdr: 'AAAA...',
-        tokenId: 42,
-        owner: 'GC6X...',
-        spender: 'GDEST...',
         contractId: 'CAA...',
         network: 'testnet',
       },
@@ -1002,28 +967,6 @@ export class NftController {
   })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid x-admin-secret' })
   async prepareInitiateWithdraw(@Body() body: { adminAddress: string }) {
-  @ApiUnauthorizedResponse({ description: 'Bearer JWT required' })
-  @ApiBadRequestResponse({ description: 'Invalid address or token not owned by caller' })
-  async prepareApprove(
-    @Param('tokenId', ParseIntPipe) tokenId: number,
-    @Body() body: { ownerAddress: string; spenderAddress: string },
-    @Req() req: Request,
-  ) {
-    const userId = Number((req as any).user?.id ?? 0);
-    await this.nftMintService.validateClipOwner(tokenId, userId);
-
-    const { ownerAddress, spenderAddress } = body;
-    [ownerAddress, spenderAddress].forEach((addr) => {
-      const check = (this as any).stellarService?.validateAddress(addr) ??
-        { valid: addr?.length > 0 };
-      if (!check.valid) {
-        throw new BadRequestException(`Invalid Stellar address: ${addr}`);
-      }
-    });
-
-    const server = new (await import('@stellar/stellar-sdk')).default.rpc.Server(
-      (this as any).stellarService?.rpcUrl ?? process.env.SOROBAN_RPC_URL ?? '',
-    );
     const StellarSdk = (await import('@stellar/stellar-sdk')).default;
     const contractId =
       process.env.SOROBAN_NFT_CONTRACT_ID ??
@@ -1045,19 +988,6 @@ export class NftController {
     const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
       fee: '10000',
       networkPassphrase,
-    const contract = new StellarSdk.Contract(contractId);
-    const sourceAccount = await server.getAccount(ownerAddress);
-
-    const op = contract.call(
-      'approve',
-      StellarSdk.Address.fromString(ownerAddress).toScVal(),
-      StellarSdk.Address.fromString(spenderAddress).toScVal(),
-      StellarSdk.nativeToScVal(BigInt(tokenId), { type: 'u64' }),
-    );
-
-    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
-      fee: '10000',
-      networkPassphrase: (this as any).stellarService?.networkPassphrase ?? '',
     })
       .addOperation(op)
       .setTimeout(StellarSdk.TimeoutInfinite)
@@ -1067,9 +997,6 @@ export class NftController {
       xdr: tx.toXDR(),
       action: 'initiate_withdraw',
       unlockAfterSeconds: 86400,
-      tokenId,
-      owner: ownerAddress,
-      spender: spenderAddress,
       contractId,
       network: (this as any).stellarService?.network ?? process.env.STELLAR_NETWORK ?? 'testnet',
     };
@@ -1108,60 +1035,12 @@ export class NftController {
     secondsRemaining: number;
     ready: boolean;
   }> {
-   * POST /nfts/approvals/operator
-   *
-   * Grant or revoke operator-level approval for ALL tokens owned by the
-   * caller. Prepares an unsigned Soroban `set_approval_for_all` XDR
-   * (Issue #675).
-   */
-  @UseGuards(LoginGuard)
-  @Post('approvals/operator')
-  @HttpCode(HttpStatus.CREATED)
-  @ApiBearerAuth('access-token')
-  @ApiOperation({
-    summary: 'Grant or revoke operator approval for all tokens (Issue #675)',
-    description:
-      'Calls the Soroban `set_approval_for_all(owner, operator, approved)` ' +
-      'function. When `approved` is true, `operatorAddress` may call ' +
-      '`transfer_from` on any of the owner\'s tokens. ' +
-      'Set `approved` to false to revoke. Returns an unsigned XDR for signing.',
-  })
-  @ApiBody({
-    schema: {
-      example: {
-        ownerAddress: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
-        operatorAddress: 'GDEST...ABC',
-        approved: true,
-      },
-    },
-  })
-  @ApiOkResponse({
-    description: 'Unsigned set_approval_for_all XDR returned',
-    schema: {
-      example: {
-        xdr: 'AAAA...',
-        owner: 'GC6X...',
-        operator: 'GDEST...',
-        approved: true,
-        contractId: 'CAA...',
-        network: 'testnet',
-      },
-    },
-  })
-  @ApiUnauthorizedResponse({ description: 'Bearer JWT required' })
-  @ApiBadRequestResponse({ description: 'Invalid Stellar address' })
-  async prepareSetApprovalForAll(
-    @Body() body: { ownerAddress: string; operatorAddress: string; approved: boolean },
-  ) {
-    const { ownerAddress, operatorAddress, approved } = body;
-
     const StellarSdk = (await import('@stellar/stellar-sdk')).default;
     const contractId =
       process.env.SOROBAN_NFT_CONTRACT_ID ??
       'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
     const rpcUrl =
       (this as any).stellarService?.rpcUrl ??
-      process.env.SOROBAN_RPC_URL ??
       'https://soroban-testnet.stellar.org';
     const networkPassphrase =
       (this as any).stellarService?.networkPassphrase ??
@@ -1177,17 +1056,6 @@ export class NftController {
     const op = contract.call('get_withdraw_unlock_time');
     const tx = new StellarSdk.TransactionBuilder(dummyAccount, {
       fee: '100',
-    const sourceAccount = await server.getAccount(ownerAddress);
-
-    const op = contract.call(
-      'set_approval_for_all',
-      StellarSdk.Address.fromString(ownerAddress).toScVal(),
-      StellarSdk.Address.fromString(operatorAddress).toScVal(),
-      StellarSdk.nativeToScVal(approved, { type: 'bool' }),
-    );
-
-    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
-      fee: '10000',
       networkPassphrase,
     })
       .addOperation(op)
@@ -1265,6 +1133,219 @@ export class NftController {
     const amountStroops = BigInt(body.amountStroops ?? '0');
     if (amountStroops <= 0n) {
       throw new BadRequestException('amountStroops must be greater than 0');
+    }
+
+    const StellarSdk = (await import('@stellar/stellar-sdk')).default;
+    const contractId =
+      process.env.SOROBAN_NFT_CONTRACT_ID ??
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
+    const rpcUrl =
+      (this as any).stellarService?.rpcUrl ??
+      'https://soroban-testnet.stellar.org';
+    const networkPassphrase =
+      (this as any).stellarService?.networkPassphrase ??
+      'Test SDF Network ; September 2015';
+
+    const server = new StellarSdk.rpc.Server(rpcUrl);
+    const contract = new StellarSdk.Contract(contractId);
+    const sourceAccount = await server.getAccount(body.adminAddress);
+
+    const op = contract.call(
+      'withdraw_xlm',
+      StellarSdk.Address.fromString(body.recipientAddress).toScVal(),
+      StellarSdk.nativeToScVal(amountStroops, { type: 'i128' }),
+    );
+
+    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: '10000',
+      networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    return {
+      xdr: tx.toXDR(),
+      recipient: body.recipientAddress,
+      amountStroops: body.amountStroops,
+      contractId,
+      network: (this as any).stellarService?.network ?? process.env.STELLAR_NETWORK ?? 'testnet',
+    };
+  }
+
+  /**
+   * POST /nfts/tokens/:tokenId/approve
+   *
+   * Prepares an unsigned Soroban `approve(owner, spender, token_id)` XDR
+   * for the owner to sign. Grants `spender` the right to transfer one
+   * specific token (Issue #675).
+   */
+  @UseGuards(LoginGuard)
+  @Post('tokens/:tokenId/approve')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Approve a spender for a specific NFT token (Issue #675)',
+    description:
+      'Calls the Soroban `approve(owner, spender, token_id)` function. ' +
+      'Grants `spenderAddress` the right to call `transfer_from` for this ' +
+      'single token. Pass `spenderAddress` as null / empty string to revoke.',
+  })
+  @ApiParam({ name: 'tokenId', description: 'On-chain token ID', example: 42 })
+  @ApiBody({
+    schema: {
+      example: {
+        ownerAddress: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+        spenderAddress: 'GDEST...ABC',
+      },
+    },
+  })
+  @ApiOkResponse({
+    description: 'Unsigned approve XDR returned',
+    schema: {
+      example: {
+        xdr: 'AAAA...',
+        tokenId: 42,
+        owner: 'GC6X...',
+        spender: 'GDEST...',
+        contractId: 'CAA...',
+        network: 'testnet',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Bearer JWT required' })
+  @ApiBadRequestResponse({ description: 'Invalid address or token not owned by caller' })
+  async prepareApprove(
+    @Param('tokenId', ParseIntPipe) tokenId: number,
+    @Body() body: { ownerAddress: string; spenderAddress: string },
+    @Req() req: Request,
+  ) {
+    const userId = Number((req as any).user?.id ?? 0);
+    await this.nftMintService.validateClipOwner(tokenId, userId);
+
+    const { ownerAddress, spenderAddress } = body;
+    [ownerAddress, spenderAddress].forEach((addr) => {
+      const check = (this as any).stellarService?.validateAddress(addr) ??
+        { valid: addr?.length > 0 };
+      if (!check.valid) {
+        throw new BadRequestException(`Invalid Stellar address: ${addr}`);
+      }
+    });
+
+    const server = new (await import('@stellar/stellar-sdk')).default.rpc.Server(
+      (this as any).stellarService?.rpcUrl ?? process.env.SOROBAN_RPC_URL ?? '',
+    );
+    const StellarSdk = (await import('@stellar/stellar-sdk')).default;
+    const contractId =
+      process.env.SOROBAN_NFT_CONTRACT_ID ??
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
+    const contract = new StellarSdk.Contract(contractId);
+    const sourceAccount = await server.getAccount(ownerAddress);
+
+    const op = contract.call(
+      'approve',
+      StellarSdk.Address.fromString(ownerAddress).toScVal(),
+      StellarSdk.Address.fromString(spenderAddress).toScVal(),
+      StellarSdk.nativeToScVal(BigInt(tokenId), { type: 'u64' }),
+    );
+
+    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: '10000',
+      networkPassphrase: (this as any).stellarService?.networkPassphrase ?? '',
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    return {
+      xdr: tx.toXDR(),
+      tokenId,
+      owner: ownerAddress,
+      spender: spenderAddress,
+      contractId,
+      network: (this as any).stellarService?.network ?? process.env.STELLAR_NETWORK ?? 'testnet',
+    };
+  }
+
+  /**
+   * POST /nfts/approvals/operator
+   *
+   * Grant or revoke operator-level approval for ALL tokens owned by the
+   * caller. Prepares an unsigned Soroban `set_approval_for_all` XDR
+   * (Issue #675).
+   */
+  @UseGuards(LoginGuard)
+  @Post('approvals/operator')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Grant or revoke operator approval for all tokens (Issue #675)',
+    description:
+      'Calls the Soroban `set_approval_for_all(owner, operator, approved)` ' +
+      'function. When `approved` is true, `operatorAddress` may call ' +
+      '`transfer_from` on any of the owner\'s tokens. ' +
+      'Set `approved` to false to revoke. Returns an unsigned XDR for signing.',
+  })
+  @ApiBody({
+    schema: {
+      example: {
+        ownerAddress: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+        operatorAddress: 'GDEST...ABC',
+        approved: true,
+      },
+    },
+  })
+  @ApiOkResponse({
+    description: 'Unsigned set_approval_for_all XDR returned',
+    schema: {
+      example: {
+        xdr: 'AAAA...',
+        owner: 'GC6X...',
+        operator: 'GDEST...',
+        approved: true,
+        contractId: 'CAA...',
+        network: 'testnet',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Bearer JWT required' })
+  @ApiBadRequestResponse({ description: 'Invalid Stellar address' })
+  async prepareSetApprovalForAll(
+    @Body() body: { ownerAddress: string; operatorAddress: string; approved: boolean },
+  ) {
+    const { ownerAddress, operatorAddress, approved } = body;
+
+    const StellarSdk = (await import('@stellar/stellar-sdk')).default;
+    const contractId =
+      process.env.SOROBAN_NFT_CONTRACT_ID ??
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4';
+    const rpcUrl =
+      (this as any).stellarService?.rpcUrl ??
+      process.env.SOROBAN_RPC_URL ??
+      'https://soroban-testnet.stellar.org';
+    const networkPassphrase =
+      (this as any).stellarService?.networkPassphrase ??
+      'Test SDF Network ; September 2015';
+
+    const server = new StellarSdk.rpc.Server(rpcUrl);
+    const contract = new StellarSdk.Contract(contractId);
+    const sourceAccount = await server.getAccount(ownerAddress);
+
+    const op = contract.call(
+      'set_approval_for_all',
+      StellarSdk.Address.fromString(ownerAddress).toScVal(),
+      StellarSdk.Address.fromString(operatorAddress).toScVal(),
+      StellarSdk.nativeToScVal(approved, { type: 'bool' }),
+    );
+
+    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: '10000',
+      networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
     return {
       xdr: tx.toXDR(),
       owner: ownerAddress,
@@ -1328,16 +1409,6 @@ export class NftController {
 
     const server = new StellarSdk.rpc.Server(rpcUrl);
     const contract = new StellarSdk.Contract(contractId);
-    const sourceAccount = await server.getAccount(body.adminAddress);
-
-    const op = contract.call(
-      'withdraw_xlm',
-      StellarSdk.Address.fromString(body.recipientAddress).toScVal(),
-      StellarSdk.nativeToScVal(amountStroops, { type: 'i128' }),
-    );
-
-    const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
-      fee: '10000',
     const dummyAccount = new StellarSdk.Account(
       'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
       '0',
@@ -1357,13 +1428,6 @@ export class NftController {
       .setTimeout(StellarSdk.TimeoutInfinite)
       .build();
 
-    return {
-      xdr: tx.toXDR(),
-      recipient: body.recipientAddress,
-      amountStroops: body.amountStroops,
-      contractId,
-      network: (this as any).stellarService?.network ?? process.env.STELLAR_NETWORK ?? 'testnet',
-    };
     const simulation = await server.simulateTransaction(tx);
     const results = (simulation as { results?: Array<{ xdr: string }> }).results;
     let approved = false;


### PR DESCRIPTION
## Summary

`contracts/nft-contract/src/lib.rs` and `storage.rs` currently do not compile on `main`. Several past PRs (royalty splitting #664, emergency withdraw #676, operator approvals #675, storage optimization #677) were merged with their function bodies textually interleaved instead of being properly conflict-resolved. This isn't caught by CI today because neither `ci.yml` nor `contract-testing.yml` actually builds the Rust contract crate.

Concretely, on `main` before this fix:
- Several functions are missing their closing `}` (e.g. the asset-based `pay_royalty`, `set_xlm_token_address`, `get_user_tokens`, several `events::emit_*` helpers, `storage::get_xlm_token_address`).
- Two independently-added `pay_royalty` functions (different signatures) were merged under the same name, which doesn't compile in Rust.
- `set_default_platform_fee`, `set_token_royalty_bps`, and `get_royalties` had their bodies shuffled across each other.
- The `Error` enum has three colliding discriminant values (`InvalidWasmHash`/`ContractPaused` both `= 8`, `InvalidSignature`/`UnsupportedAsset` both `= 9`, `InsufficientBalance`/`WithdrawNotInitiated` both `= 15`).
- `storage.rs` has the operator-approval and emergency-withdraw helpers fully duplicated — an older Symbol-tuple-keyed version alongside the newer `DataKey`-enum-keyed version from the Issue #677 storage optimization.

## Fix

- **lib.rs**: closed the orphaned function bodies; split the two colliding `pay_royalty` implementations into `pay_royalty` (stroops-based — kept this name since it matches the existing TS bindings and `test.rs` assertions) and `pay_royalty_with_asset` (asset/i128-based); likewise split the colliding `emit_royalty_paid` into that plus `emit_royalty_paid_asset`; reassigned the three duplicate `Error` discriminants to unique values; untangled `set_default_platform_fee` / `set_token_royalty_bps` / `get_royalties`.
- **storage.rs**: removed the superseded duplicate operator-approval and emergency-withdraw blocks, keeping the `DataKey`-enum-based versions.
- **test.rs**: fixed two tests that didn't compile because `soroban_sdk::Vec` doesn't implement `FromIterator` and `format!` isn't available in this `no_std` crate's test cfg.

No behavior changes beyond making the crate compile — both pre-existing `pay_royalty` call shapes are preserved under distinct names rather than deleting either.

## Test plan

- [x] `cargo check` passes with no errors (warnings only, pre-existing dead code)
- [x] `cargo test` — all 77 existing contract tests pass
- [ ] CI (this repo's workflows don't currently build the Rust contract, so this needs manual verification / a follow-up to add a `cargo test` CI job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)