### PR TITLE
feat(#679): configurable collection name and symbol

### DIFF
--- a/contracts/nft-contract/bindings/clips-nft-contract.ts
+++ b/contracts/nft-contract/bindings/clips-nft-contract.ts
@@ -53,6 +53,34 @@ export class ClipsNftContractClient {
   }
 
   /**
+   * Get the collection name (Issue #679 — admin-configurable via setName)
+   */
+  async name(): Promise<string> {
+    return 'ClipCash NFT';
+  }
+
+  /**
+   * Get the collection symbol (Issue #679 — admin-configurable via setSymbol)
+   */
+  async symbol(): Promise<string> {
+    return 'CLIP';
+  }
+
+  /**
+   * Update the collection name. Admin-only (Issue #679).
+   */
+  async setName(newName: string): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Update the collection symbol. Admin-only (Issue #679).
+   */
+  async setSymbol(newSymbol: string): Promise<boolean> {
+    return true;
+  }
+
+  /**
    * Mint a single clip NFT
    */
   async mint(

--- a/contracts/nft-contract/src/lib.rs
+++ b/contracts/nft-contract/src/lib.rs
@@ -16,8 +16,8 @@ pub use admin::Admin;
 pub use metadata::ClipMetadata;
 pub use storage::{get_token_metadata, set_token_metadata, ROYALTY_BPS_MAX};
 
-const CLIP_NAME: &[u8] = b"ClipCash NFT";
-const CLIP_SYMBOL: &[u8] = b"CLIP";
+const CLIP_NAME: &str = "ClipCash NFT";
+const CLIP_SYMBOL: &str = "CLIP";
 pub const MAX_BATCH_SIZE: u32 = 50;
 
 contractmeta!(key = "name", val = "ClipCash NFT Contract");
@@ -94,14 +94,43 @@ pub enum Error {
 
 #[contractimpl]
 impl ClipsNftContract {
-    /// Return collection name (Issue #686).
+    /// Return collection name (Issue #686). Admin-configurable (Issue
+    /// #679) — falls back to the default "ClipCash NFT" when never
+    /// overridden via `set_name`.
     pub fn name(env: Env) -> String {
-        String::from_str(&env, "ClipCash NFT")
+        storage::get_collection_name(&env)
+            .unwrap_or_else(|| String::from_str(&env, CLIP_NAME))
     }
 
-    /// Return collection symbol (Issue #686).
+    /// Return collection symbol (Issue #686). Admin-configurable (Issue
+    /// #679) — falls back to the default "CLIP" when never overridden via
+    /// `set_symbol`.
     pub fn symbol(env: Env) -> String {
-        String::from_str(&env, "CLIP")
+        storage::get_collection_symbol(&env)
+            .unwrap_or_else(|| String::from_str(&env, CLIP_SYMBOL))
+    }
+
+    /// Update the collection name so it can be rebranded without
+    /// redeploying the contract (Issue #679). Only the contract admin may
+    /// call this.
+    pub fn set_name(env: Env, new_name: String) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        storage::set_collection_name(&env, &new_name);
+        events::emit_name_updated(&env, &new_name);
+        Ok(())
+    }
+
+    /// Update the collection symbol (Issue #679). Only the contract admin
+    /// may call this.
+    pub fn set_symbol(env: Env, new_symbol: String) -> Result<(), Error> {
+        let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        storage::set_collection_symbol(&env, &new_symbol);
+        events::emit_symbol_updated(&env, &new_symbol);
+        Ok(())
     }
 
     /// Initialise the contract and set the admin address.
@@ -1146,6 +1175,18 @@ mod events {
     pub fn emit_royalty_updated(env: &Env, old_bps: u32, new_bps: u32) {
         let topics = (Symbol::new(env, "royalty_updated"),);
         env.events().publish(topics, (old_bps, new_bps));
+    }
+
+    /// Emitted when the admin renames the collection via `set_name` (Issue #679).
+    pub fn emit_name_updated(env: &Env, new_name: &String) {
+        let topics = (Symbol::new(env, "name_updated"),);
+        env.events().publish(topics, new_name.clone());
+    }
+
+    /// Emitted when the admin changes the collection symbol via `set_symbol` (Issue #679).
+    pub fn emit_symbol_updated(env: &Env, new_symbol: &String) {
+        let topics = (Symbol::new(env, "symbol_updated"),);
+        env.events().publish(topics, new_symbol.clone());
     }
 
     pub fn emit_royalty_paid_asset(

--- a/contracts/nft-contract/src/storage.rs
+++ b/contracts/nft-contract/src/storage.rs
@@ -82,6 +82,8 @@ const WASM_HASH_KEY:            &str = "wasm";
 const CONTRACT_VERSION_KEY:     &str = "ver";
 const WITHDRAW_UNLOCK_KEY:      &str = "wu";
 const XLM_TOKEN_KEY:            &str = "xlm";
+const COLLECTION_NAME_KEY:      &str = "cname";
+const COLLECTION_SYMBOL_KEY:    &str = "csym";
 
 // ── Admin ────────────────────────────────────────────────────────────────────
 
@@ -95,6 +97,34 @@ pub fn set_admin(env: &Env, admin: &Address) {
 
 pub fn get_admin(env: &Env) -> Option<Address> {
     env.storage().instance().get(&Symbol::new(env, ADMIN_KEY))
+}
+
+// ── Collection name / symbol (Issue #679) ────────────────────────────────────
+// `None` means "no admin override yet" — callers fall back to the contract's
+// hardcoded default name/symbol.
+
+pub fn set_collection_name(env: &Env, name: &soroban_sdk::String) {
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, COLLECTION_NAME_KEY), name);
+}
+
+pub fn get_collection_name(env: &Env) -> Option<soroban_sdk::String> {
+    env.storage()
+        .instance()
+        .get(&Symbol::new(env, COLLECTION_NAME_KEY))
+}
+
+pub fn set_collection_symbol(env: &Env, symbol: &soroban_sdk::String) {
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, COLLECTION_SYMBOL_KEY), symbol);
+}
+
+pub fn get_collection_symbol(env: &Env) -> Option<soroban_sdk::String> {
+    env.storage()
+        .instance()
+        .get(&Symbol::new(env, COLLECTION_SYMBOL_KEY))
 }
 
 // ── Token data ───────────────────────────────────────────────────────────────

--- a/contracts/nft-contract/src/test.rs
+++ b/contracts/nft-contract/src/test.rs
@@ -1190,6 +1190,82 @@ fn test_name_and_symbol() {
     assert_eq!(client.symbol(), String::from_str(&env, "CLIP"));
 }
 
+// ─────────────────────────────────────────────────────────────
+// Configurable collection name / symbol (Issue #679)
+// ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_name_updates_name() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.set_name(&s(&env, "Rebranded Clips"));
+    assert_eq!(client.name(), s(&env, "Rebranded Clips"));
+    // Symbol is unaffected by a name change.
+    assert_eq!(client.symbol(), String::from_str(&env, "CLIP"));
+}
+
+#[test]
+fn test_set_symbol_updates_symbol() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.set_symbol(&s(&env, "RCLP"));
+    assert_eq!(client.symbol(), s(&env, "RCLP"));
+    // Name is unaffected by a symbol change.
+    assert_eq!(client.name(), String::from_str(&env, "ClipCash NFT"));
+}
+
+#[test]
+fn test_set_name_requires_admin_auth() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+    env.set_auths(&[]);
+
+    let result = client.try_set_name(&s(&env, "Hijacked"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_symbol_requires_admin_auth() {
+    let (env, _cid, client) = setup_env();
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+    env.set_auths(&[]);
+
+    let result = client.try_set_symbol(&s(&env, "HACK"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_name_before_initialize_is_rejected() {
+    let (env, _cid, client) = setup_env();
+
+    env.mock_all_auths();
+    let result = client.try_set_name(&s(&env, "Too Early"));
+    assert_eq!(result.unwrap_err().unwrap(), Error::NotInitialized);
+}
+
+#[test]
+fn test_set_symbol_before_initialize_is_rejected() {
+    let (env, _cid, client) = setup_env();
+
+    env.mock_all_auths();
+    let result = client.try_set_symbol(&s(&env, "TOO"));
+    assert_eq!(result.unwrap_err().unwrap(), Error::NotInitialized);
+}
+
 #[test]
 fn test_update_royalty_recipient_by_recipient() {
     let (env, _contract_id, client) = setup_env();

--- a/src/nft/admin-contract.service.spec.ts
+++ b/src/nft/admin-contract.service.spec.ts
@@ -1,0 +1,90 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { AdminContractService } from './admin-contract.service';
+
+const mockSimulateTransaction = jest.fn();
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const mockTx = { toXDR: jest.fn().mockReturnValue('mock-xdr') };
+  const mockBuilder = {
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue(mockTx),
+  };
+
+  const sdkShape = {
+    rpc: {
+      Server: jest.fn().mockImplementation(() => ({
+        getAccount: jest.fn().mockResolvedValue({}),
+        simulateTransaction: mockSimulateTransaction,
+      })),
+    },
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn((fnName: string) => ({ fnName })),
+    })),
+    Account: jest.fn().mockImplementation(() => ({})),
+    TransactionBuilder: jest.fn().mockImplementation(() => mockBuilder),
+    TimeoutInfinite: 0,
+    xdr: {
+      ScVal: {
+        // Stash the raw xdr string so scValToNative below can look up the
+        // per-call return value keyed by which contract fn produced it.
+        fromXDR: jest.fn((xdrStr: string) => ({ __xdr: xdrStr })),
+      },
+    },
+    scValToNative: jest.fn((scVal: { __xdr: string }) => scVal.__xdr),
+  };
+
+  return { __esModule: true, default: sdkShape, ...sdkShape };
+});
+
+describe('AdminContractService.getCollectionInfo (Issue #679)', () => {
+  let service: AdminContractService;
+  const stellarService = {
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  };
+  const circuitBreakerService = {
+    execute: jest.fn((_config: unknown, fn: () => unknown) => fn()),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    circuitBreakerService.execute.mockImplementation((_config: unknown, fn: () => unknown) => fn());
+    service = new AdminContractService(stellarService as any, circuitBreakerService as any);
+  });
+
+  it('returns name, symbol, and contractId from the name()/symbol() contract calls', async () => {
+    mockSimulateTransaction.mockImplementation(async (tx: { toXDR: () => string }) => {
+      // Both calls produce the same mock tx object shape here since the
+      // TransactionBuilder mock is shared; differentiate via call order.
+      const callIndex = mockSimulateTransaction.mock.calls.length;
+      const value = callIndex === 1 ? 'ClipCash NFT' : 'CLIP';
+      return { results: [{ xdr: value }] };
+    });
+
+    const result = await service.getCollectionInfo();
+
+    expect(result.name).toBe('ClipCash NFT');
+    expect(result.symbol).toBe('CLIP');
+    expect(result.contractId).toBe(
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+    );
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws InternalServerErrorException when a contract call returns no value', async () => {
+    mockSimulateTransaction.mockResolvedValue({ results: [] });
+
+    await expect(service.getCollectionInfo()).rejects.toBeInstanceOf(
+      InternalServerErrorException,
+    );
+  });
+
+  it('throws InternalServerErrorException when the circuit breaker rejects', async () => {
+    circuitBreakerService.execute.mockRejectedValue(new Error('Soroban RPC down'));
+
+    await expect(service.getCollectionInfo()).rejects.toBeInstanceOf(
+      InternalServerErrorException,
+    );
+  });
+});

--- a/src/nft/admin-contract.service.ts
+++ b/src/nft/admin-contract.service.ts
@@ -168,4 +168,67 @@ export class AdminContractService {
     const returnValue = StellarSdk.xdr.ScVal.fromXDR(results[0].xdr, 'base64');
     return { paused: Boolean(StellarSdk.scValToNative(returnValue)) };
   }
+
+  /**
+   * Query the on-chain `name()` and `symbol()` view functions (Issue #679).
+   *
+   * Both are admin-configurable via `set_name`/`set_symbol` on the
+   * contract, so this always reflects the current collection branding
+   * rather than a hardcoded value.
+   */
+  async getCollectionInfo(): Promise<{ name: string; symbol: string; contractId: string }> {
+    const [name, symbol] = await Promise.all([
+      this.callViewFunction('name'),
+      this.callViewFunction('symbol'),
+    ]);
+
+    return {
+      name: String(name),
+      symbol: String(symbol),
+      contractId: this.CONTRACT_ID,
+    };
+  }
+
+  /**
+   * Simulate a no-argument, no-auth contract view call and return its
+   * decoded native value.
+   */
+  private async callViewFunction(fnName: string): Promise<unknown> {
+    const server = new StellarSdk.rpc.Server(this.stellarService.rpcUrl);
+    const contract = new StellarSdk.Contract(this.CONTRACT_ID);
+    const op = contract.call(fnName);
+
+    const dummyAccount = new StellarSdk.Account(
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      '0',
+    );
+
+    const tx = new StellarSdk.TransactionBuilder(dummyAccount, {
+      fee: '100',
+      networkPassphrase: this.stellarService.networkPassphrase,
+    })
+      .addOperation(op)
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    let simulation: Awaited<ReturnType<typeof server.simulateTransaction>>;
+    try {
+      simulation = await this.circuitBreakerService.execute(
+        this.sorobanCircuitBreakerConfig,
+        async () => server.simulateTransaction(tx),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Failed to call ${fnName}(): ${msg}`);
+      throw new InternalServerErrorException(`Failed to query contract ${fnName}(): ${msg}`);
+    }
+
+    const results = (simulation as { results?: Array<{ xdr: string }> }).results;
+    if (!results?.[0]?.xdr) {
+      throw new InternalServerErrorException(`No return value from ${fnName}() contract call`);
+    }
+
+    const returnValue = StellarSdk.xdr.ScVal.fromXDR(results[0].xdr, 'base64');
+    return StellarSdk.scValToNative(returnValue);
+  }
 }

--- a/src/nft/collection-info.controller.spec.ts
+++ b/src/nft/collection-info.controller.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NftController } from './nft.controller';
+import { NftOwnershipService } from './nft-ownership.service';
+import { NftService } from './nft.service';
+import { NftMintService } from '../clips/nft-mint.service';
+import { NftMetadataService } from './nft-metadata.service';
+import { IpfsUploadService } from './ipfs-upload.service';
+import { RoyaltyQueryService } from './royalty-query.service';
+import { NftOwnershipVerificationService } from './nft-ownership-verification.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RoyaltyConfigurationService } from './royalty-configuration.service';
+import { MintSignatureVerificationService } from './mint-signature-verification.service';
+import { AdminContractService } from './admin-contract.service';
+import { GasMetricsService } from './gas-metrics.service';
+import { NftMintGuard } from './guards/nft-mint.guard';
+import { LoginGuard } from '../auth/guards/login.guard';
+
+describe('NftController – GET /nfts/collection (Issue #679)', () => {
+  let controller: NftController;
+
+  const mockAdminContractService = {
+    getCollectionInfo: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NftController],
+      providers: [
+        { provide: NftService, useValue: {} },
+        { provide: NftMintService, useValue: {} },
+        { provide: NftMetadataService, useValue: { build: jest.fn() } },
+        { provide: IpfsUploadService, useValue: {} },
+        { provide: RoyaltyQueryService, useValue: { getRoyaltyInfo: jest.fn(), getRoyaltySplits: jest.fn() } },
+        { provide: NftOwnershipVerificationService, useValue: { verifyNFTOwnership: jest.fn() } },
+        { provide: NftOwnershipService, useValue: { tokenExists: jest.fn(), getOwner: jest.fn() } },
+        { provide: PrismaService, useValue: { clip: { findUnique: jest.fn() } } },
+        { provide: RoyaltyConfigurationService, useValue: { getCreatorRoyaltyBps: jest.fn(), getPlatformWallet: jest.fn() } },
+        { provide: MintSignatureVerificationService, useValue: { verify: jest.fn() } },
+        { provide: AdminContractService, useValue: mockAdminContractService },
+        { provide: GasMetricsService, useValue: { getStats: jest.fn() } },
+      ],
+    })
+      .overrideGuard(LoginGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(NftMintGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<NftController>(NftController);
+    jest.clearAllMocks();
+  });
+
+  it('returns the collection info from AdminContractService', async () => {
+    mockAdminContractService.getCollectionInfo.mockResolvedValue({
+      name: 'ClipCash NFT',
+      symbol: 'CLIP',
+      contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+    });
+
+    const result = await controller.getCollectionInfo();
+
+    expect(mockAdminContractService.getCollectionInfo).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      name: 'ClipCash NFT',
+      symbol: 'CLIP',
+      contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+    });
+  });
+});

--- a/src/nft/dto/collection-info.dto.ts
+++ b/src/nft/dto/collection-info.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/** Response for GET /nfts/collection (Issue #679). */
+export class CollectionInfoResponseDto {
+  @ApiProperty({
+    example: 'ClipCash NFT',
+    description: 'On-chain collection name, admin-configurable via set_name',
+  })
+  name!: string;
+
+  @ApiProperty({
+    example: 'CLIP',
+    description: 'On-chain collection symbol, admin-configurable via set_symbol',
+  })
+  symbol!: string;
+
+  @ApiProperty({
+    example: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEU4',
+    description: 'Soroban contract ID',
+  })
+  contractId!: string;
+}

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -102,6 +102,7 @@ import {
   UpdateRoyaltyRecipientResponseDto,
 } from './dto/update-royalty-recipient.dto';
 import { DeploymentStatusResponseDto } from './dto/deployment-status.dto';
+import { CollectionInfoResponseDto } from './dto/collection-info.dto';
 import { GasStatsResponseDto } from './dto/gas-stats.dto';
 import { GasMetricsService } from './gas-metrics.service';
 import {
@@ -1437,6 +1438,28 @@ export class NftController {
     }
 
     return { owner: ownerAddress, operator: operatorAddress, approved };
+  }
+
+  /**
+   * GET /nfts/collection
+   * Returns the collection's current name and symbol, which are
+   * admin-configurable via `set_name`/`set_symbol` on the Soroban contract
+   * (Issue #679) rather than fixed at deploy time.
+   */
+  @Get('collection')
+  @ApiOperation({
+    summary: 'Get collection name and symbol (Issue #679)',
+    description:
+      'Queries the on-chain `name()` and `symbol()` view functions. Both are ' +
+      'admin-configurable via `set_name`/`set_symbol`, so this reflects the current ' +
+      'collection branding rather than a hardcoded value.',
+  })
+  @ApiOkResponse({
+    description: 'Collection info returned successfully',
+    type: CollectionInfoResponseDto,
+  })
+  async getCollectionInfo(): Promise<CollectionInfoResponseDto> {
+    return this.adminContractService.getCollectionInfo();
   }
 
   @Get('deployment-status')


### PR DESCRIPTION
## Summary

Closes #679.

> The collection may be renamed without redeploying the contract.

**Depends on #719** (fixes pre-existing corruption in `lib.rs`/`nft.controller.ts` that this branch needed in order to compile/test — this diff includes those commits until #719 merges; only the last commit here is new).

## Changes

**Contract** (`contracts/nft-contract`):
- Added storage-backed collection name/symbol (instance storage, `"cname"`/`"csym"` keys).
- `name()`/`symbol()` now check storage first, falling back to the existing hardcoded defaults ("ClipCash NFT" / "CLIP") when never overridden — no behavior change for anyone who hasn't called the new setters.
- Added `set_name()` / `set_symbol()`, admin-only (`require_auth` + `NotInitialized` guard, matching the other admin setters), each emitting a `name_updated`/`symbol_updated` event.
- Reused the previously dead `CLIP_NAME`/`CLIP_SYMBOL` consts instead of the duplicated string literals that were there before.
- 6 new unit tests: name/symbol update independently, both require admin auth, both reject before `initialize()`.

**Backend** (`src/nft`):
- `AdminContractService.getCollectionInfo()` queries the on-chain `name()`/`symbol()` view functions (same simulate-transaction pattern as the existing `getClipId`/`getPauseStatus`) and returns `{ name, symbol, contractId }`.
- New `GET /nfts/collection` endpoint, documented with a response schema (`CollectionInfoResponseDto`) and example per the issue's Swagger/API task list.
- Unit tests for the service (including RPC-failure and empty-response error paths) and the controller wiring.

## Test plan

- [x] `cargo test` in `contracts/nft-contract` — 83 passed (77 pre-existing + 6 new)
- [x] `npx jest src/nft src/clips/nft-mint` — 19 suites / 147 tests passing
- [x] `npx tsc --noEmit` — no errors in any file touched by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)