### PR TITLE
Multi-currency earnings support

### DIFF
--- a/prisma/migrations/20260825_add_multi_currency_fields/migration.sql
+++ b/prisma/migrations/20260825_add_multi_currency_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: Add multi-currency fields to Earning model
+ALTER TABLE "Earning"
+  ADD COLUMN IF NOT EXISTS "amountInBaseCurrency" DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS "exchangeRate" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,17 +113,19 @@ model ClipPost {
 }
 
 model Earning {
-  id              Int       @id @default(autoincrement())
-  clipId          Int
-  amount          Float
-  currency        String    @default("USD")
-  date            DateTime
-  source          String?
-  isAnomaly       Boolean   @default(false)
-  anomalyReason   String?
-  createdAt       DateTime  @default(now())
-  deletedAt       DateTime?
-  clip            Clip      @relation(fields: [clipId], references: [id], onDelete: Cascade)
+  id                    Int       @id @default(autoincrement())
+  clipId                Int
+  amount                Float
+  currency              String    @default("USD")
+  amountInBaseCurrency  Float?
+  exchangeRate          Float?
+  date                  DateTime
+  source                String?
+  isAnomaly             Boolean   @default(false)
+  anomalyReason         String?
+  createdAt             DateTime  @default(now())
+  deletedAt             DateTime?
+  clip                  Clip      @relation(fields: [clipId], references: [id], onDelete: Cascade)
 }
 
 model UserPlatform {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,7 @@ import { QueueDashboardModule } from './queue-dashboard/queue-dashboard.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { QueueModule } from './queue/queue.module';
 import { GracefulShutdownModule } from './common/shutdown/graceful-shutdown.module';
+import { CommonModule } from './common/common.module';
 
 @Module({
   imports: [
@@ -137,6 +138,7 @@ import { GracefulShutdownModule } from './common/shutdown/graceful-shutdown.modu
     HealthModule,
     QueueDashboardModule,
     GracefulShutdownModule,
+    CommonModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CurrencyService } from './services/currency.service';
+import { RedisModule } from '../redis/redis.module';
+
+@Module({
+  imports: [RedisModule],
+  providers: [CurrencyService],
+  exports: [CurrencyService],
+})
+export class CommonModule {}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -9,3 +9,6 @@ export * from './exceptions/service-unavailable.exception';
 export * from './helpers/auth-error.helper';
 export * from './helpers/queue-registration.helper';
 export * from './helpers/safe-math.helper';
+
+// Services
+export * from './services/currency.service';

--- a/src/common/services/currency.service.ts
+++ b/src/common/services/currency.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from '../../redis/redis.service';
+
+export enum SupportedCurrency {
+  USD = 'USD',
+  EUR = 'EUR',
+  GBP = 'GBP',
+  XLM = 'XLM',
+  USDC = 'USDC',
+}
+
+const SUPPORTED_CURRENCIES = new Set<string>(Object.values(SupportedCurrency));
+
+const CACHE_KEY_PREFIX = 'currency:rates:';
+const CACHE_TTL_SECONDS = 3600;
+
+const EXCHANGE_RATE_API_BASE = 'https://api.exchangerate-api.com/v4/latest';
+
+@Injectable()
+export class CurrencyService {
+  private readonly logger = new Logger(CurrencyService.name);
+  private readonly baseCurrency: string;
+
+  constructor(private readonly redis: RedisService) {
+    this.baseCurrency =
+      process.env.DEFAULT_BASE_CURRENCY ?? SupportedCurrency.USD;
+  }
+
+  getBaseCurrency(): string {
+    return this.baseCurrency;
+  }
+
+  isSupportedCurrency(currency: string): boolean {
+    return SUPPORTED_CURRENCIES.has(currency.toUpperCase());
+  }
+
+  validateCurrency(currency: string): void {
+    if (!this.isSupportedCurrency(currency)) {
+      throw new Error(
+        `Unsupported currency: ${currency}. Supported: ${[...SUPPORTED_CURRENCIES].join(', ')}`,
+      );
+    }
+  }
+
+  async getExchangeRate(from: string, to: string): Promise<number> {
+    this.validateCurrency(from);
+    this.validateCurrency(to);
+
+    if (from.toUpperCase() === to.toUpperCase()) {
+      return 1;
+    }
+
+    const cacheKey = `${CACHE_KEY_PREFIX}${from.toUpperCase()}:${to.toUpperCase()}`;
+    const invertedCacheKey = `${CACHE_KEY_PREFIX}${to.toUpperCase()}:${from.toUpperCase()}`;
+
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return parseFloat(cached);
+    }
+
+    const invertedCached = await this.redis.get(invertedCacheKey);
+    if (invertedCached) {
+      const rate = parseFloat(invertedCached);
+      return rate > 0 ? 1 / rate : 0;
+    }
+
+    const rate = await this.fetchExchangeRate(from, to);
+    if (rate !== null) {
+      await this.redis.setex(cacheKey, CACHE_TTL_SECONDS, rate.toString());
+    }
+    return rate ?? 0;
+  }
+
+  async convert(
+    amount: number,
+    from: string,
+    to: string,
+  ): Promise<{ amount: number; rate: number }> {
+    const rate = await this.getExchangeRate(from, to);
+    return {
+      amount: Math.round(amount * rate * 100) / 100,
+      rate,
+    };
+  }
+
+  async convertToBaseCurrency(
+    amount: number,
+    from: string,
+  ): Promise<{ amountInBaseCurrency: number; rate: number }> {
+    return this.convert(amount, from, this.baseCurrency);
+  }
+
+  private async fetchExchangeRate(
+    from: string,
+    to: string,
+  ): Promise<number | null> {
+    try {
+      const fromUpper = from.toUpperCase();
+      const toUpper = to.toUpperCase();
+
+      const response = await fetch(`${EXCHANGE_RATE_API_BASE}/${fromUpper}`);
+      if (!response.ok) {
+        this.logger.warn(
+          `Exchange rate API returned ${response.status} for ${fromUpper}`,
+        );
+        return null;
+      }
+
+      const data = (await response.json()) as {
+        rates?: Record<string, number>;
+      };
+      if (!data.rates || !(toUpper in data.rates)) {
+        this.logger.warn(
+          `Rate for ${toUpper} not found in API response for ${fromUpper}`,
+        );
+        return null;
+      }
+
+      return data.rates[toUpper];
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch exchange rate ${from}→${to}: ${(error as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  async invalidateRatesCache(): Promise<void> {
+    const client = this.redis.getClient();
+    const keys = await client.keys(`${CACHE_KEY_PREFIX}*`);
+    if (keys.length > 0) {
+      await client.del(...keys);
+    }
+  }
+}

--- a/src/earnings/earnings.controller.ts
+++ b/src/earnings/earnings.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Query, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { ApiTags, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { EarningsService } from './earnings.service';
+import { Auth } from '../auth/decorators/auth.decorator';
+
+interface AuthRequest extends Request {
+  user: { userId: number };
+}
+
+@ApiTags('earnings')
+@ApiBearerAuth()
+@Auth()
+@Controller('earnings')
+export class EarningsController {
+  constructor(private readonly earningsService: EarningsService) {}
+
+  @Get()
+  @ApiQuery({ name: 'startDate', required: false, type: String })
+  @ApiQuery({ name: 'endDate', required: false, type: String })
+  async getEarnings(
+    @Req() req: AuthRequest,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    const filters: { startDate?: Date; endDate?: Date } = {};
+    if (startDate) filters.startDate = new Date(startDate);
+    if (endDate) filters.endDate = new Date(endDate);
+
+    return this.earningsService.getEarnings(req.user.userId, filters);
+  }
+
+  @Get('aggregate')
+  async aggregateEarnings(@Req() req: AuthRequest) {
+    return this.earningsService.aggregateEarnings(req.user.userId);
+  }
+}

--- a/src/earnings/earnings.module.ts
+++ b/src/earnings/earnings.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { EarningsService } from './earnings.service';
+import { EarningsController } from './earnings.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+import { RedisModule } from '../redis/redis.module';
+import { CommonModule } from '../common/common.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [PrismaModule, RedisModule, CommonModule, AuthModule],
+  controllers: [EarningsController],
+  providers: [EarningsService],
+  exports: [EarningsService],
+})
+export class EarningsModule {}

--- a/src/earnings/earnings.service.ts
+++ b/src/earnings/earnings.service.ts
@@ -1,0 +1,127 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CurrencyService } from '../common/services/currency.service';
+import { RedisService } from '../redis/redis.service';
+import { Prisma } from '@prisma/client';
+
+const CACHE_KEY_PREFIX = 'earnings:user:';
+const CACHE_TTL_SECONDS = 3600;
+
+@Injectable()
+export class EarningsService {
+  private readonly logger = new Logger(EarningsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly currencyService: CurrencyService,
+    private readonly redis: RedisService,
+  ) {}
+
+  async createEarning(data: {
+    clipId: number;
+    amount: number;
+    currency?: string;
+    date: Date;
+    source?: string;
+  }) {
+    const currency = (data.currency ?? 'USD').toUpperCase();
+    this.currencyService.validateCurrency(currency);
+
+    let amountInBaseCurrency: number | null = null;
+    let exchangeRate: number | null = null;
+
+    const baseCurrency = this.currencyService.getBaseCurrency();
+    if (currency !== baseCurrency) {
+      const conversion = await this.currencyService.convertToBaseCurrency(
+        data.amount,
+        currency,
+      );
+      amountInBaseCurrency = conversion.amount;
+      exchangeRate = conversion.rate;
+    } else {
+      amountInBaseCurrency = data.amount;
+      exchangeRate = 1;
+    }
+
+    return this.prisma.earning.create({
+      data: {
+        clipId: data.clipId,
+        amount: data.amount,
+        currency,
+        amountInBaseCurrency,
+        exchangeRate,
+        date: data.date,
+        source: data.source,
+      },
+    });
+  }
+
+  async getEarnings(
+    userId: number,
+    filters?: { startDate?: Date; endDate?: Date },
+  ) {
+    const cacheKey = `${CACHE_KEY_PREFIX}${userId}:${JSON.stringify(filters ?? {})}`;
+
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const where: Prisma.EarningWhereInput = {
+      clip: { video: { userId } },
+      deletedAt: null,
+    };
+
+    if (filters?.startDate || filters?.endDate) {
+      where.date = {};
+      if (filters.startDate) where.date.gte = filters.startDate;
+      if (filters.endDate) where.date.lte = filters.endDate;
+    }
+
+    const earnings = await this.prisma.earning.findMany({
+      where,
+      include: {
+        clip: {
+          select: { id: true, title: true },
+        },
+      },
+      orderBy: { date: 'desc' },
+    });
+
+    await this.redis.setex(
+      cacheKey,
+      CACHE_TTL_SECONDS,
+      JSON.stringify(earnings),
+    );
+    return earnings;
+  }
+
+  async aggregateEarnings(userId: number) {
+    const baseCurrency = this.currencyService.getBaseCurrency();
+
+    const result = await this.prisma.earning.aggregate({
+      where: { clip: { video: { userId } }, deletedAt: null },
+      _sum: {
+        amount: true,
+        amountInBaseCurrency: true,
+      },
+      _count: true,
+    });
+
+    return {
+      totalAmount: result._sum.amount ?? 0,
+      totalAmountInBaseCurrency: result._sum.amountInBaseCurrency ?? 0,
+      baseCurrency,
+      count: result._count,
+    };
+  }
+
+  async invalidateUserEarningsCache(userId: number): Promise<void> {
+    const pattern = `${CACHE_KEY_PREFIX}${userId}:*`;
+    const client = this.redis.getClient();
+    const keys = await client.keys(pattern);
+    if (keys.length > 0) {
+      await client.del(...keys);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add multi-currency support for earnings with a CurrencyService that fetches, caches, and converts exchange rates. Backward compatible with existing USD earnings.

## Changes
- Add \mountInBaseCurrency\ and \exchangeRate\ fields to Earning model (Prisma migration)
- Create \CurrencyService\: supports USD, EUR, GBP, XLM, USDC; fetches rates from exchangerate-api; caches in Redis (1hr TTL)
- Create \earnings/\ module: EarningsService, EarningsController, EarningsModule
- Base currency configurable via \DEFAULT_BASE_CURRENCY\ env var
- \createEarning\ auto-computes base currency conversion

## Acceptance Criteria
- [x] Earning model supports multiple currencies
- [x] Currency validation implemented
- [x] Exchange-rate service implemented with Redis caching
- [x] Base currency conversion implemented
- [x] Existing USD earnings remain compatible

## Related
Closes #777