### PR TITLE
Feature: multi-chain wallet support with chain-aware publicKey validation (#762)

### DIFF
--- a/src/wallets/dto/connect-wallet.dto.ts
+++ b/src/wallets/dto/connect-wallet.dto.ts
@@ -5,12 +5,22 @@ import {
   Matches,
   Length,
   IsOptional,
+  Validate,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { DEFAULT_CHAIN, SUPPORTED_CHAINS } from '../chain.constants';
+import { DEFAULT_CHAIN, SUPPORTED_CHAINS, SupportedChain } from '../chain.constants';
 
 /** Stellar ED25519 public key: starts with G, exactly 56 Base32 characters */
 const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+
+/** Solana public keys are base58-encoded 32-byte Ed25519 keys (32–44 chars) */
+const SOLANA_ADDRESS_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+/** Base / EVM addresses: 0x-prefixed 40-character hex */
+const EVM_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
 
 /**
  * Wallet provider types supported per chain:
@@ -37,6 +47,57 @@ export type SupportedWalletType = (typeof SUPPORTED_WALLET_TYPES)[number];
 
 /** @deprecated Use CreateWalletConnectionDto */
 export type ConnectWalletDto = CreateWalletConnectionDto;
+
+/**
+ * Validates that `address` matches the format expected for the given `chain`.
+ */
+function validateAddressForChain(address: string, chain: SupportedChain): boolean {
+  switch (chain) {
+    case 'stellar':
+      return STELLAR_PUBLIC_KEY_REGEX.test(address);
+    case 'solana':
+      return SOLANA_ADDRESS_REGEX.test(address);
+    case 'base':
+      return EVM_ADDRESS_REGEX.test(address);
+    default:
+      return false;
+  }
+}
+
+/**
+ * Returns a human-readable chain label for validation error messages.
+ */
+function chainDisplayName(chain: SupportedChain): string {
+  switch (chain) {
+    case 'stellar':
+      return 'Stellar (G-prefix, Base32, 56 chars)';
+    case 'solana':
+      return 'Solana (base58, 32–44 chars)';
+    case 'base':
+      return 'Base (0x-prefixed hex, 42 chars)';
+    default:
+      return chain;
+  }
+}
+
+/**
+ * Custom class-validator constraint that validates the `publicKey` field
+ * against the format expected for the selected `chain`.
+ */
+@ValidatorConstraint({ name: 'publicKeyForChain', async: false })
+export class PublicKeyForChainValidator implements ValidatorConstraintInterface {
+  validate(publicKey: string, args: ValidationArguments): boolean {
+    const object = args.object as CreateWalletConnectionDto;
+    const chain = (object.chain ?? DEFAULT_CHAIN) as SupportedChain;
+    return validateAddressForChain(publicKey, chain);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const object = args.object as CreateWalletConnectionDto;
+    const chain = (object.chain ?? DEFAULT_CHAIN) as SupportedChain;
+    return `publicKey must be a valid ${chainDisplayName(chain)} address`;
+  }
+}
 
 export class CreateWalletConnectionDto {
   @ApiProperty({
@@ -74,16 +135,13 @@ export class CreateWalletConnectionDto {
 
   @ApiProperty({
     description:
-      'Stellar ED25519 public key — must start with G and be exactly 56 Base32 characters',
+      'Public key for the wallet — format depends on chain: ' +
+      'Stellar G-prefix Base32 (56 chars), Solana base58 (32–44 chars), or 0x hex (42 chars)',
     example: 'GABC...XYZ',
   })
   @IsString()
   @IsNotEmpty({ message: 'publicKey must not be empty' })
-  @Length(56, 56, { message: 'publicKey must be exactly 56 characters' })
-  @Matches(STELLAR_PUBLIC_KEY_REGEX, {
-    message:
-      'publicKey must be a valid Stellar address (G-prefix, Base32, 56 chars)',
-  })
+  @Validate(PublicKeyForChainValidator)
   publicKey: string;
 
   @ApiProperty({

--- a/src/wallets/wallet-management.service.ts
+++ b/src/wallets/wallet-management.service.ts
@@ -100,6 +100,16 @@ export class WalletManagementService {
 
     this.walletValidationService.validateAddressForChain(dto.address, chain);
 
+    // Signature verification is only supported for Stellar wallets today;
+    // Solana and Base/EVM wallets will need their own verification flow.
+    if (chain === 'stellar') {
+      this.walletValidationService.verifySignatureOwnership(
+        dto.publicKey,
+        dto.signature,
+        dto.signedMessage,
+      );
+    }
+
     const wallet = await this.prisma.wallet.upsert({
       where: {
         address_chain: {


### PR DESCRIPTION
## Goal

Replace the hardcoded Stellar-only publicKey validation with chain-aware validation, allowing wallets on Solana and Base/EVM to be connected with correctly formatted addresses.

## Changes

- src/wallets/dto/connect-wallet.dto.ts: Added PublicKeyForChainValidator � a custom class-validator constraint that validates publicKey format based on the selected chain (Stellar: G-prefix Base32 56 chars, Solana: base58 32�44 chars, Base: 0x hex 42 chars). Removed the hardcoded @Matches / @Length decorators that forced Stellar format regardless of chain.
- src/wallets/wallet-management.service.ts: Added chain-aware signature verification � only Stellar wallets verify signatures via Keypair.fromPublicKey; Solana/EVM skip for now (awaiting their own verification flows).

## Testing
- 15 existing wallet validation tests pass unchanged

Closes #762