### PR TITLE
Feature: wallet balance check before minting (#759)

### DIFF
--- a/src/nft/guards/nft-mint.guard.spec.ts
+++ b/src/nft/guards/nft-mint.guard.spec.ts
@@ -1,11 +1,17 @@
 import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { NftMintGuard } from './nft-mint.guard';
+import { LOW_BALANCE_THRESHOLD_XLM } from '../../stellar/stellar.service';
 
 describe('NftMintGuard', () => {
   const prismaMock = {
     clip: {
       findUnique: jest.fn(),
     },
+  };
+
+  const stellarServiceMock = {
+    validateAddress: jest.fn().mockReturnValue({ valid: true }),
+    getAccountBalance: jest.fn().mockResolvedValue(10),
   };
 
   let guard: NftMintGuard;
@@ -21,7 +27,9 @@ describe('NftMintGuard', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    guard = new NftMintGuard(prismaMock as any);
+    stellarServiceMock.validateAddress.mockReturnValue({ valid: true });
+    stellarServiceMock.getAccountBalance.mockResolvedValue(10);
+    guard = new NftMintGuard(prismaMock as any, stellarServiceMock as any);
   });
 
   const runGuard = (request: {
@@ -126,5 +134,74 @@ describe('NftMintGuard', () => {
     expect(prismaMock.clip.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: 1 } }),
     );
+  });
+
+  describe('wallet balance pre-check', () => {
+    it('allows minting when wallet balance is sufficient', async () => {
+      prismaMock.clip.findUnique.mockResolvedValue(mintableClip);
+      stellarServiceMock.getAccountBalance.mockResolvedValue(10);
+
+      await expect(
+        runGuard({ body: { clipId: 1, creatorWallet: 'GABC...XYZ' } }),
+      ).resolves.toBe(true);
+
+      expect(stellarServiceMock.getAccountBalance).toHaveBeenCalledWith('GABC...XYZ');
+    });
+
+    it('rejects minting when wallet balance is below threshold', async () => {
+      prismaMock.clip.findUnique.mockResolvedValue(mintableClip);
+      stellarServiceMock.getAccountBalance.mockResolvedValue(0.5);
+
+      await expect(
+        runGuard({ body: { clipId: 1, creatorWallet: 'GABC...XYZ' } }),
+      ).rejects.toThrow('Insufficient wallet balance');
+    });
+
+    it('rejects minting when wallet balance is exactly zero', async () => {
+      prismaMock.clip.findUnique.mockResolvedValue(mintableClip);
+      stellarServiceMock.getAccountBalance.mockResolvedValue(0);
+
+      await expect(
+        runGuard({ body: { clipId: 1, creatorWallet: 'GABC...XYZ' } }),
+      ).rejects.toThrow('Insufficient wallet balance');
+    });
+
+    it('allows minting when Horizon is unreachable (best-effort check)', async () => {
+      prismaMock.clip.findUnique.mockResolvedValue(mintableClip);
+      stellarServiceMock.getAccountBalance.mockRejectedValue(
+        new Error('Horizon timeout'),
+      );
+
+      await expect(
+        runGuard({ body: { clipId: 1, creatorWallet: 'GABC...XYZ' } }),
+      ).resolves.toBe(true);
+    });
+
+    it('skips balance check when no wallet address is provided', async () => {
+      prismaMock.clip.findUnique.mockResolvedValue(mintableClip);
+
+      await expect(runGuard({ body: { clipId: 1 } })).resolves.toBe(true);
+      expect(stellarServiceMock.getAccountBalance).not.toHaveBeenCalled();
+    });
+
+    it('skips balance check when wallet address is not a string', async () => {
+      prismaMock.clip.findUnique.mockResolvedValue(mintableClip);
+
+      await expect(
+        runGuard({ body: { clipId: 1, creatorWallet: 12345 } }),
+      ).resolves.toBe(true);
+      expect(stellarServiceMock.getAccountBalance).not.toHaveBeenCalled();
+    });
+
+    it('uses walletAddress fallback from prepare-mint DTO', async () => {
+      prismaMock.clip.findUnique.mockResolvedValue(mintableClip);
+      stellarServiceMock.getAccountBalance.mockResolvedValue(5);
+
+      await expect(
+        runGuard({ body: { clipId: 1, walletAddress: 'GDEF...UVW' } }),
+      ).resolves.toBe(true);
+
+      expect(stellarServiceMock.getAccountBalance).toHaveBeenCalledWith('GDEF...UVW');
+    });
   });
 });

--- a/src/nft/guards/nft-mint.guard.ts
+++ b/src/nft/guards/nft-mint.guard.ts
@@ -4,17 +4,25 @@ import {
   ConflictException,
   ExecutionContext,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
+import { StellarService, LOW_BALANCE_THRESHOLD_XLM } from '../../stellar/stellar.service';
 
 /**
- * Prevents minting clips that are already minted, in progress, posted, or not ready.
+ * Prevents minting clips that are already minted, in progress, posted, not ready,
+ * or when the creator wallet has insufficient XLM to cover transaction fees.
  * Apply before prepare-mint and queue enqueue endpoints.
  */
 @Injectable()
 export class NftMintGuard implements CanActivate {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(NftMintGuard.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly stellarService: StellarService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -38,6 +46,13 @@ export class NftMintGuard implements CanActivate {
     }
 
     await this.assertMintable(clip);
+
+    // Check wallet balance before minting to prevent failed on-chain transactions
+    const walletAddress = request.body?.creatorWallet ?? request.body?.walletAddress;
+    if (walletAddress && typeof walletAddress === 'string') {
+      await this.assertSufficientBalance(walletAddress, clipId);
+    }
+
     return true;
   }
 
@@ -89,6 +104,44 @@ export class NftMintGuard implements CanActivate {
     if (!clip.clipUrl) {
       throw new BadRequestException(
         'Clip is not ready for minting (missing URL)',
+      );
+    }
+  }
+
+  /**
+   * Verify the creator wallet has enough XLM to cover the Stellar network
+   * base fee plus the minimum reserve.  Rejects the mint early rather than
+   * letting it fail on-chain with a cryptic error.
+   */
+  private async assertSufficientBalance(
+    walletAddress: string,
+    clipId: number,
+  ): Promise<void> {
+    try {
+      const validation = this.stellarService.validateAddress(walletAddress);
+      if (!validation.valid) {
+        this.logger.warn(
+          `Skipping balance check for clip ${clipId}: invalid address format`,
+        );
+        return;
+      }
+
+      const balance = await this.stellarService.getAccountBalance(walletAddress);
+      if (balance < LOW_BALANCE_THRESHOLD_XLM) {
+        throw new BadRequestException(
+          `Insufficient wallet balance to cover minting fees. ` +
+          `Your wallet has ${balance.toFixed(2)} XLM but at least ${LOW_BALANCE_THRESHOLD_XLM} XLM is recommended. ` +
+          `Top up your wallet and try again.`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      // If Horizon is unreachable, log a warning but don't block the mint —
+      // the user may be on a different network or the check is best-effort.
+      this.logger.warn(
+        `Balance pre-check failed for clip ${clipId}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }


### PR DESCRIPTION
## Goal

Add a pre-mint wallet balance check to prevent failed on-chain transactions when the creator wallet doesn't have enough XLM to cover Stellar network fees.

## Changes

- src/nft/guards/nft-mint.guard.ts: Enhanced NftMintGuard with ssertSufficientBalance() � queries Stellar for the creator wallet's XLM balance before allowing mint; rejects with a clear error message when below the 2 XLM threshold (LOW_BALANCE_THRESHOLD_XLM). Best-effort: logs a warning but allows the mint if Horizon is unreachable. Reads wallet address from creatorWallet (for /nfts/mint) or walletAddress (for /nfts/prepare-mint).
- src/nft/guards/nft-mint.guard.spec.ts: 7 new tests covering sufficient balance, insufficient balance, zero balance, Horizon unreachable fallback, no wallet address provided, non-string wallet address, and walletAddress fallback for prepare-mint DTO.

## Testing
- 17 total guard tests (10 existing + 7 new) all passing
- Existing NFT tests unaffected

Closes #759