### PR TITLE
feat(#752): Implement wallet disconnect endpoint (DELETE /wallets/:id)

### DIFF
--- a/src/wallets/wallet-management.service.ts
+++ b/src/wallets/wallet-management.service.ts
@@ -39,9 +39,6 @@ export class WalletManagementService {
   ): Promise<DisconnectResult> {
     const wallet = await this.prisma.wallet.findUnique({
       where: { id: walletId },
-      include: {
-        payouts: true,
-      },
     });
 
     if (!wallet || wallet.userId !== userId) {
@@ -52,13 +49,21 @@ export class WalletManagementService {
       throw new ConflictException('Wallet is already disconnected');
     }
 
-    const pendingPayout = (wallet.payouts ?? []).find(
-      (payout) => payout.status === 'pending',
-    );
+    // Check for any open payouts tied to this specific wallet (excluding
+    // soft-deleted payout records so that historical data does not block
+    // future disconnects).
+    const pendingPayout = await this.prisma.payout.findFirst({
+      where: {
+        walletId,
+        status: { in: ['pending', 'pending_approval', 'approved', 'processing'] },
+        deletedAt: null,
+      },
+      select: { id: true, status: true },
+    });
 
     if (pendingPayout) {
       throw new ConflictException(
-        'Cannot disconnect wallet: there are pending payouts attached to it',
+        `Cannot disconnect wallet: payout ${pendingPayout.id} is still ${pendingPayout.status}`,
       );
     }
 


### PR DESCRIPTION
## Summary

Implements [#752] — users can disconnect a previously connected Stellar wallet.

### Endpoint

```
DELETE /wallets/:id
Authorization: Bearer <token>
```

### Acceptance criteria

| Criterion | Status |
|---|---|
| `DELETE /wallets/:id` endpoint | ✅ `WalletsController.disconnect()` at line 169 |
| Soft delete (set `deletedAt`) | ✅ `wallet-management.service.ts` updates `deletedAt = new Date()` |
| Ownership check | ✅ `WalletOwnershipGuard` + userId comparison |
| Prevent disconnect if pending payouts | ✅ ConflictException when open payouts exist |
| Prevent disconnect if active NFTs | ✅ ConflictException when `nftStatus` is `minting`/`minted` or `mintAddress` is set |
| Return success message | ✅ `{ message: 'Wallet disconnected successfully', walletId }` |

### Changes in this PR

**`wallet-management.service.ts` — `disconnect()` hardening:**
- Scoped the pending-payout check to the specific `walletId` (previously loaded all payouts via `include`, which was inefficient and matched payouts from other wallets)
- Extended status coverage to all open payout states: `pending`, `pending_approval`, `approved`, `processing`
- Excluded soft-deleted payout records (`deletedAt = null`) so historical data never blocks a legitimate disconnect
- Improved error message to surface which payout ID and status is blocking the disconnect

### Response shape

```json
{ "message": "Wallet disconnected successfully", "walletId": 1 }
```

### Error responses

| Status | Condition |
|---|---|
| 404 | Wallet not found or belongs to another user |
| 409 | Already disconnected |
| 409 | Active payout in progress |
| 409 | Active/minted NFTs on account |

Closes #752