### PR TITLE
feat(#751): Add Stellar token-based subscription payments

### DIFF
--- a/src/subscriptions/subscriptions.controller.ts
+++ b/src/subscriptions/subscriptions.controller.ts
@@ -9,7 +9,6 @@ import {
   HttpStatus,
   Query,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import {
   ApiOperation,
   ApiResponse,


### PR DESCRIPTION
## Summary

Implements [#751] — allow users to pay for Pro/Agency plans using Stellar assets (XLM or custom stablecoin).

### Endpoints

| Method | Path | Description |
|---|---|---|
| `POST` | `/subscriptions/create-stellar` | Generate Stellar payment intent (amount + memo + destination) |
| `POST` | `/subscriptions/create-intent` | Alias for `create-stellar` |
| `GET` | `/subscriptions/stellar/pending` | List non-expired pending intents for authenticated user |
| `POST` | `/subscriptions/stellar/verify?paymentIntentId=&transactionHash=` | Verify Horizon tx and activate subscription |

### Acceptance criteria

| Criterion | Status |
|---|---|
| `paymentMethod: "stellar"` option in Subscription model | ✅ `Subscription.paymentMethod` column + `activateSubscription()` sets `'stellar'` |
| `POST /subscriptions/create-stellar` | ✅ Generates `StellarPaymentIntent` with amount, memo, destination, expiry |
| Generate payment intent (amount + memo) | ✅ `createPaymentIntent()` in `StellarPaymentService` |
| Verify payment via Horizon listener/webhook | ✅ `verifyPayment()` — checks memo, amount, destination, asset type against Horizon |
| Activate subscription on confirmed payment | ✅ `activateSubscription()` cancels any prior active subscription, creates new one with `status='active'` |

### Payment flow

1. Frontend calls `POST /subscriptions/create-stellar` → receives `{ id, amount, asset, destination, memo, expiresAt }`
2. User sends XLM/USDC to `destination` with exactly the `memo` included
3. Frontend calls `POST /subscriptions/stellar/verify?paymentIntentId=X&transactionHash=Y`
4. Backend fetches tx from Horizon, validates memo + amount + destination + asset
5. On match: `StellarPaymentIntent.status → 'completed'`, new `Subscription` created with `paymentMethod='stellar'`

### Assets supported

- `xlm` — native Stellar lumens
- `usdc` — USDC via Stellar asset code
- `custom` — any Stellar asset (requires `assetCode` + `assetIssuer` in body)

### This PR

Fixes a compile-breaking **duplicate `@nestjs/swagger` import block** in `subscriptions.controller.ts` that prevented the module from loading in the NestJS DI container.

Closes #751