### PR TITLE
fix(nft): add missing RedisModule import for on-chain royalty query endpoint

### DIFF
--- a/src/nft/nft.module.ts
+++ b/src/nft/nft.module.ts
@@ -22,6 +22,7 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.module';
 import { GasMetricsService } from './gas-metrics.service';
+import { RedisModule } from '../redis/redis.module';
 
 @Module({
   imports: [


### PR DESCRIPTION
## Summary

Fixes the missing `RedisModule` import in `NftModule` that prevented the on-chain royalty query endpoint from working at runtime.

## Problem

`RoyaltyQueryService` depends on `RedisService` to cache on-chain royalty responses for 5 minutes. `RedisModule` was listed in the `NftModule` `imports` array but the corresponding ES import statement at the top of the file was absent, causing a NestJS DI resolution error when the application started.

## Changes

- **`src/nft/nft.module.ts`**: Added the missing `import { RedisModule } from '../redis/redis.module';` statement.

## What already worked

The following were already fully implemented and required no changes:
- `GET /nfts/:mintAddress/royalty` endpoint in `NftController`
- `RoyaltyQueryService.getRoyaltyInfo()` — queries Soroban contract via `stellar-sdk`, caches result for 5 min using Redis
- Response shape: `{ royaltyBps: number, recipient: string }`
- 5-minute Redis cache keyed on mint address
- Circuit breaker around Soroban RPC calls

## Testing

1. Start the server — it previously crashed at boot due to the unresolved `RedisModule` reference.
2. Authenticate and call `GET /nfts/42/royalty` — returns `{ royaltyBps, recipient }` from the Soroban contract, cached for 5 minutes in Redis.

Closes #750