### PR TITLE
Add:Stellar wallet connection endpoint and service

### DIFF
--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -27,6 +27,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     }
     return {
       id: payload.sub,
+      userId: payload.sub,
       email: payload.email,
       emailVerified: payload.emailVerified,
     };

--- a/src/wallets/wallet-management.service.spec.ts
+++ b/src/wallets/wallet-management.service.spec.ts
@@ -30,6 +30,7 @@ const mockPrisma = {
 const mockWalletValidationService = {
   validateStellarAddress: jest.fn(),
   validateAddressForChain: jest.fn(),
+  verifySignatureOwnership: jest.fn(),
 };
 
 const baseWallet = {
@@ -131,6 +132,10 @@ describe('WalletManagementService.connect', () => {
     mockWalletValidationService.validateAddressForChain.mockImplementation(
       () => undefined,
     );
+    mockWalletValidationService.verifySignatureOwnership.mockImplementation(
+      () => undefined,
+    );
+    mockPrisma.wallet.findUnique.mockResolvedValue(null);
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WalletManagementService,
@@ -148,6 +153,9 @@ describe('WalletManagementService.connect', () => {
     address: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
     chain: 'stellar' as const,
     type: 'freighter',
+    publicKey: 'GC6XOTK6L6LGBKIWH3IRUZPVUY4COGEMW4J5YINOSPKO27YKTUUHTZF3',
+    signature: 'sig-base64',
+    signedMessage: 'Connect ClipCash wallet 1719266696836',
   };
 
   it('rejects unsupported chain values before touching the database', async () => {
@@ -168,6 +176,9 @@ describe('WalletManagementService.connect', () => {
     const dtoWithoutChain = {
       address: stellarDto.address,
       type: stellarDto.type,
+      publicKey: stellarDto.publicKey,
+      signature: stellarDto.signature,
+      signedMessage: stellarDto.signedMessage,
     };
     mockPrisma.wallet.upsert.mockResolvedValue({
       id: 1,
@@ -233,7 +244,6 @@ describe('WalletManagementService.connect', () => {
         },
       },
       update: expect.objectContaining({
-        userId: 42,
         type: stellarDto.type,
         deletedAt: null,
       }),
@@ -247,10 +257,83 @@ describe('WalletManagementService.connect', () => {
     expect(result.id).toBe(1);
   });
 
+  it('verifies the signature and requires publicKey to match address for stellar', async () => {
+    mockPrisma.wallet.upsert.mockResolvedValue({
+      id: 1,
+      userId: 42,
+      ...stellarDto,
+    });
+
+    await service.connect(42, stellarDto);
+
+    expect(
+      mockWalletValidationService.verifySignatureOwnership,
+    ).toHaveBeenCalledWith(
+      stellarDto.publicKey,
+      stellarDto.signature,
+      stellarDto.signedMessage,
+    );
+  });
+
+  it('rejects a stellar connect when publicKey does not match address', async () => {
+    await expect(
+      service.connect(42, { ...stellarDto, publicKey: 'GDIFFERENTKEY' }),
+    ).rejects.toThrow(BadRequestException);
+    expect(mockPrisma.wallet.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects when signature verification fails', async () => {
+    mockWalletValidationService.verifySignatureOwnership.mockImplementation(
+      () => {
+        throw new BadRequestException('Signature verification failed');
+      },
+    );
+    await expect(service.connect(42, stellarDto)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(mockPrisma.wallet.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects connecting a wallet address already owned by another user', async () => {
+    mockPrisma.wallet.findUnique.mockResolvedValue({
+      ...baseWallet,
+      address: stellarDto.address,
+      userId: 99,
+    });
+
+    await expect(service.connect(42, stellarDto)).rejects.toThrow(
+      ConflictException,
+    );
+    expect(mockPrisma.wallet.upsert).not.toHaveBeenCalled();
+  });
+
+  it('allows the same user to reconnect their own wallet', async () => {
+    mockPrisma.wallet.findUnique.mockResolvedValue({
+      ...baseWallet,
+      address: stellarDto.address,
+      userId: 42,
+    });
+    mockPrisma.wallet.upsert.mockResolvedValue({
+      id: 1,
+      userId: 42,
+      ...stellarDto,
+    });
+
+    await expect(service.connect(42, stellarDto)).resolves.toBeDefined();
+    expect(mockPrisma.wallet.upsert).toHaveBeenCalled();
+  });
+
   it.each(SUPPORTED_CHAINS)(
     'upserts a wallet for each supported chain "%s"',
     async (chain) => {
-      const dto = { address: stellarDto.address, chain, type: 'freighter' };
+      const dto = {
+        address: stellarDto.address,
+        chain,
+        type: 'freighter',
+        publicKey: stellarDto.address,
+        signature: stellarDto.signature,
+        signedMessage: stellarDto.signedMessage,
+      };
       mockPrisma.wallet.upsert.mockResolvedValue({ id: 1, userId: 42, ...dto });
 
       await service.connect(42, dto);
@@ -277,6 +360,7 @@ describe('WalletManagementService.connect', () => {
     const result = await service.connect(42, {
       ...stellarDto,
       address: fullAddress,
+      publicKey: fullAddress,
     });
 
     expect(result.address).not.toBe(fullAddress);

--- a/src/wallets/wallet-management.service.ts
+++ b/src/wallets/wallet-management.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ConnectWalletDto } from './dto/connect-wallet.dto';
@@ -100,6 +101,34 @@ export class WalletManagementService {
 
     this.walletValidationService.validateAddressForChain(dto.address, chain);
 
+    if (chain === 'stellar') {
+      if (dto.publicKey !== dto.address) {
+        throw new BadRequestException(
+          'publicKey must match the wallet address being connected',
+        );
+      }
+      this.walletValidationService.verifySignatureOwnership(
+        dto.publicKey,
+        dto.signature,
+        dto.signedMessage,
+      );
+    }
+
+    const existing = await this.prisma.wallet.findUnique({
+      where: {
+        address_chain: {
+          address: dto.address,
+          chain,
+        },
+      },
+    });
+
+    if (existing && existing.userId !== userId) {
+      throw new ConflictException(
+        'This wallet address is already connected to another account',
+      );
+    }
+
     const wallet = await this.prisma.wallet.upsert({
       where: {
         address_chain: {
@@ -108,7 +137,6 @@ export class WalletManagementService {
         },
       },
       update: {
-        userId,
         type: dto.type,
         deletedAt: null,
         updatedAt: new Date(),


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2 data-path-to-node="0" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Summary of Changes</h2><p data-path-to-node="1" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Rather than adding duplicate endpoints (since <code data-path-to-node="1" data-index-in-node="46" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">POST /wallets/connect</code> and Soroban NFT verification were already implemented in the codebase), the changes focused on fixing critical authentication and wallet security vulnerabilities, expanding unit tests, and verifying compilation.</p><h2 data-path-to-node="3" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Technical Breakdown</h2><h3 data-path-to-node="4" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">1. JWT Payload Mismatch Fix (<code data-path-to-node="4" data-index-in-node="29" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">jwt.strategy.ts</code>)</h3><ul data-path-to-node="5" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="5,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="5,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Problem:</b> The JWT strategy's <code data-path-to-node="5,0,0" data-index-in-node="28" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">validate()</code> method was returning <code data-path-to-node="5,0,0" data-index-in-node="60" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">req.user.id</code>, but multiple controllers (including <code data-path-to-node="5,0,0" data-index-in-node="109" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">WalletsController</code>) and <code data-path-to-node="5,0,0" data-index-in-node="132" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">admin.guard.ts</code> were attempting to read <code data-path-to-node="5,0,0" data-index-in-node="171" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">req.user.userId</code>, causing <code data-path-to-node="5,0,0" data-index-in-node="196" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">userId</code> to resolve as <code data-path-to-node="5,0,0" data-index-in-node="217" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">undefined</code>.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="5,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="5,1,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Fix:</b> Added <code data-path-to-node="5,1,0" data-index-in-node="11" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">userId: payload.sub</code> alongside <code data-path-to-node="5,1,0" data-index-in-node="41" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">id</code> in the returned object. This ensures both properties are populated, resolving downstream authorization failures without breaking legacy calls.</p></li></ul><h3 data-path-to-node="6" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">2. Wallet Security &amp; Hijack Prevention (<code data-path-to-node="6" data-index-in-node="40" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">wallet-management.service.ts</code>)</h3><ul data-path-to-node="7" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="7,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="7,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Problem 1 (Account Hijacking):</b> The <code data-path-to-node="7,0,0" data-index-in-node="35" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">connect()</code> method previously ran an unconditional upsert on <code data-path-to-node="7,0,0" data-index-in-node="94" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">{address, chain}</code> and reassigned <code data-path-to-node="7,0,0" data-index-in-node="126" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">userId</code>. If User B attempted to connect a wallet already linked to User A, User B would silently hijack User A's wallet.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="7,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="7,1,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Problem 2 (Unverified Claims):</b> The service never invoked <code data-path-to-node="7,1,0" data-index-in-node="57" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">verifySignatureOwnership()</code>, allowing users to register addresses without proving ownership.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="7,2,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="7,2,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Fixes Implemented:</b></p><ul data-path-to-node="7,2,1" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="7,2,1,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="7,2,1,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Ownership Verification:</b> For <code data-path-to-node="7,2,1,0,0" data-index-in-node="28" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">chain === 'stellar'</code>, required <code data-path-to-node="7,2,1,0,0" data-index-in-node="58" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">publicKey === address</code> and executed <code data-path-to-node="7,2,1,0,0" data-index-in-node="93" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">verifySignatureOwnership(publicKey, signature, signedMessage)</code> before performing database reads/writes.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="7,2,1,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="7,2,1,1,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Conflict Handling:</b> Added a pre-upsert database check. If the wallet address is already linked to another user account, the service now throws a <code data-path-to-node="7,2,1,1,0" data-index-in-node="144" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">409 ConflictException</code>.</p></li></ul></li></ul><h3 data-path-to-node="8" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">3. Test Suite Updates (<code data-path-to-node="8" data-index-in-node="23" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">wallet-management.service.spec.ts</code>)</h3><ul data-path-to-node="9" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="9,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="9,0,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Mocking &amp; Fixtures:</b> Added test fixtures for <code data-path-to-node="9,0,0" data-index-in-node="44" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">publicKey</code>, <code data-path-to-node="9,0,0" data-index-in-node="55" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">signature</code>, and <code data-path-to-node="9,0,0" data-index-in-node="70" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">signedMessage</code>, along with mocks for <code data-path-to-node="9,0,0" data-index-in-node="106" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">verifySignatureOwnership</code>.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="9,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="9,1,0" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Coverage:</b> Added new unit test scenarios specifically targeting signature mismatch failures and hijack rejection (verifying the <code data-path-to-node="9,1,0" data-index-in-node="127" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">409 ConflictException</code>).</p></li></ul><h2 data-path-to-node="11" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Verification &amp; Status</h2>
Metric | Status | Details
-- | -- | --
Touched File Tests | 35 / 35 Passed | All updated tests pass cleanly.
Module Tests | 95 / 95 Passed | Full pass across src/wallets and src/auth.
TypeScript Compilation | 0 Errors | tsc --noEmit clean on touched files.

</body></html><!--EndFragment-->
</body>
</html>

Closes #756
closes #746